### PR TITLE
docs: bump minimal python version to 3.11 to follow changes on dify-plugin-sdks

### DIFF
--- a/cmd/commandline/plugin/templates/python/GUIDE.md
+++ b/cmd/commandline/plugin/templates/python/GUIDE.md
@@ -69,7 +69,7 @@ Now you can edit the `manifest.yaml` file to describe your Plugin, here is the b
 
 ### Install Dependencies
 
-- First of all, you need a Python 3.10+ environment, as our SDK requires that.
+- First of all, you need a Python 3.11+ environment, as our SDK requires that.
 - Then, install the dependencies:
     ```bash
     pip install -r requirements.txt


### PR DESCRIPTION
The Python SDK has changed the minimum Python version to 3.11 since version [0.0.1b45](https://pypi.org/project/dify_plugin/0.0.1b45/).
If we on the Python 3.10, we can only install versions prior to 0.0.1b44 with pip.

This PR updates the documentation accordingly.