### PR TITLE
feat: bump python version for container image for local platform to 3.12

### DIFF
--- a/docker/local/Dockerfile
+++ b/docker/local/Dockerfile
@@ -12,16 +12,17 @@ WORKDIR /app
 # build
 RUN go build -o /app/main cmd/server/main.go
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 COPY --from=builder /app/main /app/main
 
 WORKDIR /app
 
-# Install python3.10
-RUN apt-get update && apt-get install -y python3.10 python3.10-venv python3.10-dev \
+# Install python3.12
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y python3.12 python3.12-venv python3.12-dev \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1
 
 ENV PLATFORM=local
 ENV GIN_MODE=release


### PR DESCRIPTION
In a Docker-based self-hosted environment (Of course I know it's not supported yet :D ), the Python version in the plugin daemon's container is 3.10.

Since version [`0.0.1b45` of the Python SDK](https://pypi.org/project/dify_plugin/0.0.1b45/), the requirement for Python has been changed to version **3.11** or later.

As a result, if version `0.0.1b45` or later is specified in the new plugin's `requirements.txt` (e.g. [Google plugin](https://github.com/langgenius/dify-official-plugins/blob/main/tools/google/requirements.txt)), the daemon will not be able to install that plugin.

```bash
2025-01-04 22:48:48 2025/01/04 13:48:48 launcher.go:181: [INFO]init environment for plugin langgenius/google:0.0.6
2025-01-04 22:48:51 2025/01/04 13:48:51 launcher.go:181: [ERROR]init environment failed: failed to install dependencies: exit status 1, output: ERROR: Could not find a version that satisfies the requirement dify_plugin~=0.0.1b48 (from versions: 0.0.1b2, 0.0.1b3, 0.0.1b4, 0.0.1b5, 0.0.1b6, 0.0.1b7, 0.0.1b8, 0.0.1b9, 0.0.1b10, 0.0.1b11, 0.0.1b12, 0.0.1b14, 0.0.1b15, 0.0.1b16, 0.0.1b17, 0.0.1b18, 0.0.1b19, 0.0.1b20, 0.0.1b21, 0.0.1b22, 0.0.1b23, 0.0.1b24, 0.0.1b26, 0.0.1b27, 0.0.1b28, 0.0.1b29, 0.0.1b31, 0.0.1b32, 0.0.1b33, 0.0.1b34, 0.0.1b35, 0.0.1b36, 0.0.1b37, 0.0.1b38, 0.0.1b39, 0.0.1b40, 0.0.1b42, 0.0.1b43, 0.0.1b44)
2025-01-04 22:48:51 ERROR: No matching distribution found for dify_plugin~=0.0.1b48
2025-01-04 22:48:51 , retry in 30s
```

This PR modifies the Dockerfile to upgrade the Python version to **3.12**.

- **Base image change**
  - Changed from 22.04 to the latest LTS version, **24.04**
  - Note, Python 3.12 is not available on 22.04
- **Python version change**
  - Adjusted to match the **3.12** version [used in the image for Lambda](https://github.com/langgenius/dify-plugin-daemon/blob/3d6ad98913e6630207d2016a7f620b299e96e075/internal/core/plugin_manager/aws_manager/dockerfile/python312.dockerfile).
- Additional changes
  - I specified `DEBIAN_FRONTEND=noninteractive` to the `apt-get install` command to accept the default settings when installing dependencies such as `tzdata`.
  - I added `update-alternatives` so that `/usr/bin/python3.12` can be used as `/usr/bin/python3`.
  
I was able to install and verify the behavior of several plugins with the image which was built with this PR.