### PR TITLE
change default process kill time

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,9 @@ DIFY_PLUGIN_SERVERLESS_CONNECTOR_API_KEY=HeRFb6yrzAy5vUSlJWK2lUl36mpkaRycv4witbQ
 # otherwise, it should be /usr/bin/python3
 PYTHON_INTERPRETER_PATH=/Users/yeuoly/miniconda3/envs/dify-plugin-sdk/bin/python
 
+# python environment init timeout, if the python environment init process is not finished within this time, it will be killed
+PYTHON_ENV_INIT_TIMEOUT=120
+
 # pprof enabled, for debugging
 PPROF_ENABLED=false
 

--- a/internal/core/plugin_manager/launcher.go
+++ b/internal/core/plugin_manager/launcher.go
@@ -129,7 +129,7 @@ func (p *PluginManager) launchLocal(pluginUniqueIdentifier plugin_entities.Plugi
 		return nil, nil, nil, failed(err.Error())
 	}
 
-	localPluginRuntime := local_runtime.NewLocalPluginRuntime(p.pythonInterpreterPath)
+	localPluginRuntime := local_runtime.NewLocalPluginRuntime(p.pythonInterpreterPath, p.pythonEnvInitTimeout)
 	localPluginRuntime.PluginRuntime = plugin.runtime
 	localPluginRuntime.BasicChecksum = basic_runtime.BasicChecksum{
 		MediaTransport: basic_runtime.NewMediaTransport(p.mediaBucket),

--- a/internal/core/plugin_manager/local_runtime/environment_python.go
+++ b/internal/core/plugin_manager/local_runtime/environment_python.go
@@ -161,9 +161,9 @@ func (p *LocalPluginRuntime) InitPythonEnvironment() error {
 				break
 			}
 
-			if time.Since(lastActiveAt) > 180*time.Second {
+			if time.Since(lastActiveAt) > time.Duration(p.pythonEnvInitTimeout)*time.Second {
 				cmd.Process.Kill()
-				err_msg.WriteString("init process exited due to long time no activity")
+				err_msg.WriteString(fmt.Sprintf("init process exited due to no activity for %d seconds", p.pythonEnvInitTimeout))
 				break
 			}
 		}

--- a/internal/core/plugin_manager/local_runtime/environment_python.go
+++ b/internal/core/plugin_manager/local_runtime/environment_python.go
@@ -161,7 +161,7 @@ func (p *LocalPluginRuntime) InitPythonEnvironment() error {
 				break
 			}
 
-			if time.Since(lastActiveAt) > 60*time.Second {
+			if time.Since(lastActiveAt) > 180*time.Second {
 				cmd.Process.Kill()
 				err_msg.WriteString("init process exited due to long time no activity")
 				break

--- a/internal/core/plugin_manager/local_runtime/type.go
+++ b/internal/core/plugin_manager/local_runtime/type.go
@@ -17,6 +17,9 @@ type LocalPluginRuntime struct {
 	// python interpreter path, currently only support python
 	pythonInterpreterPath string
 
+	// python env init timeout
+	pythonEnvInitTimeout int
+
 	// to create a new python virtual environment, we need a default python interpreter
 	// by using its venv module
 	defaultPythonInterpreterPath string
@@ -30,8 +33,10 @@ type LocalPluginRuntime struct {
 
 func NewLocalPluginRuntime(
 	pythonInterpreterPath string,
+	pythonEnvInitTimeout int,
 ) *LocalPluginRuntime {
 	return &LocalPluginRuntime{
 		defaultPythonInterpreterPath: pythonInterpreterPath,
+		pythonEnvInitTimeout:         pythonEnvInitTimeout,
 	}
 }

--- a/internal/core/plugin_manager/manager.go
+++ b/internal/core/plugin_manager/manager.go
@@ -56,6 +56,9 @@ type PluginManager struct {
 	// python interpreter path
 	pythonInterpreterPath string
 
+	// python env init timeout
+	pythonEnvInitTimeout int
+
 	// remote plugin server
 	remotePluginServer debugging_runtime.RemotePluginServerInterface
 
@@ -91,6 +94,7 @@ func InitGlobalManager(oss oss.OSS, configuration *app.Config) *PluginManager {
 		localPluginLaunchingLock: lock.NewGranularityLock(),
 		maxLaunchingLock:         make(chan bool, 2), // by default, we allow 2 plugins launching at the same time
 		pythonInterpreterPath:    configuration.PythonInterpreterPath,
+		pythonEnvInitTimeout:     configuration.PythonEnvInitTimeout,
 		platform:                 configuration.Platform,
 	}
 

--- a/internal/types/app/config.go
+++ b/internal/types/app/config.go
@@ -82,6 +82,7 @@ type Config struct {
 	MaxAWSLambdaTransactionTimeout int   `envconfig:"MAX_AWS_LAMBDA_TRANSACTION_TIMEOUT"`
 
 	PythonInterpreterPath string `envconfig:"PYTHON_INTERPRETER_PATH"`
+	PythonEnvInitTimeout  int    `envconfig:"PYTHON_ENV_INIT_TIMEOUT" validate:"required"`
 
 	DisplayClusterLog bool `envconfig:"DISPLAY_CLUSTER_LOG"`
 

--- a/internal/types/app/default.go
+++ b/internal/types/app/default.go
@@ -28,6 +28,7 @@ func (config *Config) SetDefault() {
 	setDefaultInt(&config.PersistenceStorageMaxSize, 100*1024*1024)
 	setDefaultString(&config.PluginPackageCachePath, "plugin_packages")
 	setDefaultString(&config.PythonInterpreterPath, "/usr/bin/python3")
+	setDefaultInt(&config.PythonEnvInitTimeout, 120)
 	setDefaultBoolPtr(&config.ForceVerifyingSignature, true)
 }
 


### PR DESCRIPTION
when I install some plugin like `gemini`, `ollama`,  it always raise `init process exited due to long time no activity`.
and after I change the time, all packages installed success.

the time is always larger than 60s,  `gemini`:
![3bdf5e6f4de6cc83b8cc9e5a7f15117](https://github.com/user-attachments/assets/e4356f9b-a88a-4d51-b319-47d12fea4f97)


`siliconflow`:
![ec5791d5f5b6a077bcb3b994d41da56](https://github.com/user-attachments/assets/e8960195-dac4-44c2-ad9d-cb6f2ae9c538)
