### PR TITLE
change hint of input uppercase letter in plugin name

### DIFF
--- a/cmd/commandline/bundle/profile.go
+++ b/cmd/commandline/bundle/profile.go
@@ -62,10 +62,10 @@ func (p *profile) checkRule() bool {
 		p.warning = "Name, author and description cannot be empty"
 		return false
 	} else if p.cursor == 0 && !plugin_entities.PluginNameRegex.MatchString(p.inputs[p.cursor].Value()) {
-		p.warning = "Bundle name must be 1-128 characters long, and can only contain letters, numbers, dashes and underscores"
+		p.warning = "Bundle name must be 1-128 characters long, and can only contain lowercase letters, numbers, dashes and underscores"
 		return false
 	} else if p.cursor == 1 && !plugin_entities.AuthorRegex.MatchString(p.inputs[p.cursor].Value()) {
-		p.warning = "Author name must be 1-64 characters long, and can only contain letters, numbers, dashes and underscores"
+		p.warning = "Author name must be 1-64 characters long, and can only contain lowercase letters, numbers, dashes and underscores"
 		return false
 	} else {
 		p.warning = ""

--- a/cmd/commandline/plugin/profile.go
+++ b/cmd/commandline/plugin/profile.go
@@ -62,10 +62,10 @@ func (p *profile) checkRule() bool {
 		p.warning = "Name, author and description cannot be empty"
 		return false
 	} else if p.cursor == 0 && !plugin_entities.PluginNameRegex.MatchString(p.inputs[p.cursor].Value()) {
-		p.warning = "Plugin name must be 1-128 characters long, and can only contain letters, numbers, dashes and underscores"
+		p.warning = "Plugin name must be 1-128 characters long, and can only contain lowercase letters, numbers, dashes and underscores"
 		return false
 	} else if p.cursor == 1 && !plugin_entities.AuthorRegex.MatchString(p.inputs[p.cursor].Value()) {
-		p.warning = "Author name must be 1-64 characters long, and can only contain letters, numbers, dashes and underscores"
+		p.warning = "Author name must be 1-64 characters long, and can only contain lowercase letters, numbers, dashes and underscores"
 		return false
 	} else {
 		p.warning = ""

--- a/pkg/entities/plugin_entities/plugin_declaration.go
+++ b/pkg/entities/plugin_entities/plugin_declaration.go
@@ -233,8 +233,8 @@ func (p *PluginDeclaration) MarshalJSON() ([]byte, error) {
 }
 
 var (
-	PluginNameRegex = regexp.MustCompile(`^[a-z0-9_-]{1,128}$`)
-	AuthorRegex     = regexp.MustCompile(`^[a-z0-9_-]{1,64}$`)
+	PluginNameRegex = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,128}$`)
+	AuthorRegex     = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,64}$`)
 )
 
 func isPluginName(fl validator.FieldLevel) bool {

--- a/pkg/entities/plugin_entities/plugin_declaration.go
+++ b/pkg/entities/plugin_entities/plugin_declaration.go
@@ -233,8 +233,8 @@ func (p *PluginDeclaration) MarshalJSON() ([]byte, error) {
 }
 
 var (
-	PluginNameRegex = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,128}$`)
-	AuthorRegex     = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,64}$`)
+	PluginNameRegex = regexp.MustCompile(`^[a-z0-9_-]{1,128}$`)
+	AuthorRegex     = regexp.MustCompile(`^[a-z0-9_-]{1,64}$`)
 )
 
 func isPluginName(fl validator.FieldLevel) bool {


### PR DESCRIPTION
The hint state:
```
Bundle name must be 1-128 characters long, and can only contain letters, numbers, dashes and underscores
```

However, uppercase letters are currently not allowed.