### PR TITLE
support AWS credentials from IAM role

### DIFF
--- a/internal/oss/s3/s3_storage.go
+++ b/internal/oss/s3/s3_storage.go
@@ -21,20 +21,30 @@ type AWSS3Storage struct {
 }
 
 func NewAWSS3Storage(ak string, sk string, region string, bucket string) (oss.OSS, error) {
-	c, err := config.LoadDefaultConfig(
-		context.TODO(),
-		config.WithRegion(region),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			ak,
-			sk,
-			"",
-		)),
-	)
+	var cfg aws.Config
+	var err error
+
+	if ak == "" && sk == "" {
+		cfg, err = config.LoadDefaultConfig(
+			context.TODO(),
+			config.WithRegion(region),
+		)
+	} else {
+		cfg, err = config.LoadDefaultConfig(
+			context.TODO(),
+			config.WithRegion(region),
+			config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
+				ak,
+				sk,
+				"",
+			)),
+		)
+	}
 	if err != nil {
 		return nil, err
 	}
 
-	client := s3.NewFromConfig(c)
+	client := s3.NewFromConfig(cfg)
 
 	// check bucket
 	_, err = client.HeadBucket(context.TODO(), &s3.HeadBucketInput{

--- a/internal/types/app/config.go
+++ b/internal/types/app/config.go
@@ -152,6 +152,10 @@ func (c *Config) Validate() error {
 		if c.PluginStorageOSSBucket == "" {
 			return fmt.Errorf("plugin storage bucket is empty")
 		}
+
+		if c.AWSRegion == "" {
+			return fmt.Errorf("aws region is empty")
+		}
 	}
 
 	return nil

--- a/internal/types/app/config.go
+++ b/internal/types/app/config.go
@@ -151,10 +151,6 @@ func (c *Config) Validate() error {
 		if c.PluginStorageOSSBucket == "" {
 			return fmt.Errorf("plugin storage bucket is empty")
 		}
-
-		if c.AWSAccessKey == "" || c.AWSSecretKey == "" || c.AWSRegion == "" {
-			return fmt.Errorf("aws access key, secret key or region is empty")
-		}
 	}
 
 	return nil


### PR DESCRIPTION
Currently only static IAM credentials are supported to access S3 buckets. It would be great if we could use IAM role credentials when running Dify on AWS, just [like Dify itself](https://github.com/langgenius/dify/blob/56e15d09a9e94de963dd5fc38c7455a7aaee99f3/api/extensions/storage/aws_s3_storage.py#L18-L36). This PR enables it.

I found adding unit test for this difficult but let me know if you think it is required 🙏  At least I E2E-tested on my AWS environment.