### PR TITLE
fix: add missing import for llm template

### DIFF
--- a/cmd/commandline/plugin/templates/python/llm.py
+++ b/cmd/commandline/plugin/templates/python/llm.py
@@ -2,6 +2,7 @@ import logging
 from collections.abc import Generator
 from typing import Optional, Union
 
+from dify_plugin import LargeLanguageModel
 from dify_plugin.entities import I18nObject
 from dify_plugin.errors.model import (
     CredentialsValidateFailedError,


### PR DESCRIPTION
`LargeLanguageModel` is used but has not been imported.

```py
class {{ .PluginName | SnakeToCamel }}LargeLanguageModel(LargeLanguageModel):
```