### PR TITLE
fix: plugins are not installed when plugin-daemon is restarted and plugins are stored on s3

### DIFF
--- a/internal/core/plugin_manager/media_transport/installed_bucket.go
+++ b/internal/core/plugin_manager/media_transport/installed_bucket.go
@@ -48,15 +48,6 @@ func (b *InstalledBucket) Get(
 
 // List lists all the plugins in the installed bucket
 func (b *InstalledBucket) List() ([]plugin_entities.PluginUniqueIdentifier, error) {
-	// check if the patch exists
-	exists, err := b.oss.Exists(b.installedPath)
-	if err != nil {
-		return nil, err
-	}
-	if !exists {
-		return []plugin_entities.PluginUniqueIdentifier{}, nil
-	}
-
 	paths, err := b.oss.List(b.installedPath)
 	if err != nil {
 		return nil, err

--- a/internal/oss/local/local_storage.go
+++ b/internal/oss/local/local_storage.go
@@ -57,10 +57,18 @@ func (l *LocalStorage) State(key string) (oss.OSSState, error) {
 }
 
 func (l *LocalStorage) List(prefix string) ([]oss.OSSPath, error) {
-	prefix = filepath.Join(l.root, prefix)
 	paths := make([]oss.OSSPath, 0)
+	// check if the patch exists
+	exists, err := l.Exists(prefix)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return paths, nil
+	}
+	prefix = filepath.Join(l.root, prefix)
 
-	err := filepath.WalkDir(prefix, func(path string, d fs.DirEntry, err error) error {
+	err = filepath.WalkDir(prefix, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
closes #35 
closes https://github.com/langgenius/dify/issues/14769
closes https://github.com/langgenius/dify/issues/14534
I moved the exists operation from installedBucket.List to localStorage.List. This makes the exist function for S3 storage no longer called, fixing the issue without changing any existing behavior for localStorage.

Since some implementation of storage does not require to check the existence of a directory before list operation, I believe it makes more sense to run an exists function inside a list function of each implementation, instead of handling it from caller.