### PR TITLE
fix: make description field optional in PromptMessageTool

### DIFF
--- a/pkg/entities/model_entities/llm.go
+++ b/pkg/entities/model_entities/llm.go
@@ -176,7 +176,7 @@ func (p *PromptMessage) UnmarshalJSON(data []byte) error {
 
 type PromptMessageTool struct {
 	Name        string         `json:"name" validate:"required"`
-	Description string         `json:"description" validate:"required"`
+	Description string         `json:"description"`
 	Parameters  map[string]any `json:"parameters"`
 }
 


### PR DESCRIPTION
To resolve the Tool invoke error.

**before**

![image](https://github.com/user-attachments/assets/f36f78d2-667b-44e9-a0a3-725cd470f0e3)

**after**

<img width="1535" alt="image" src="https://github.com/user-attachments/assets/eb379944-be9f-47e4-9a19-25e43071bd30" />
