### PR TITLE
feat:Add python3-pip to Dockerfile Dependencies

### DIFF
--- a/docker/local.dockerfile
+++ b/docker/local.dockerfile
@@ -33,7 +33,7 @@ WORKDIR /app
 ARG PLATFORM=local
 
 # Install python3.12 if PLATFORM is local
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y python3.12 python3.12-venv python3.12-dev ffmpeg \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y python3.12 python3.12-venv python3.12-dev python3-pip ffmpeg \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1;


### PR DESCRIPTION
This PR adds python3-pip to the list of packages installed in the Docker image. The change addresses scenarios where the environment operates in an air-gapped/offline network (no external internet access) and requires manual installation of Python libraries during development or deployment.

Context:
When introducing new model APIs that depend on third-party Python libraries(dify_plugin), teams in restricted environments must manually install dependencies within the container. Without pip, users cannot use pip install to add libraries from pre-downloaded source distributions or internal package repositories. Adding python3-pip ensures compatibility with offline workflows.

Impact:
By including pip, users gain flexibility to:

Install libraries from local .whl or .tar.gz files during container runtime.
Integrate with internal artifact repositories or mirrored PyPI sources.
Avoid reliance on external PyPI servers during deployment.