### PR TITLE
Add missing `url` field of PromptMessageContent

### DIFF
--- a/pkg/entities/model_entities/llm.go
+++ b/pkg/entities/model_entities/llm.go
@@ -100,6 +100,7 @@ func isPromptMessageContentType(fl validator.FieldLevel) bool {
 type PromptMessageContent struct {
 	Type         PromptMessageContentType `json:"type" validate:"required,prompt_message_content_type"`
 	Base64Data   string                   `json:"base64_data"` // for multi-modal data
+        URL          string 	              `json:"url"`         // for multi-modal data
 	Data         string                   `json:"data"`        // for text only
 	EncodeFormat string                   `json:"encode_format"`
 	Format       string                   `json:"format"`


### PR DESCRIPTION
MultiModal content supports both base64 and url format, but lost in dify-plugin-daemon server