### PR TITLE
fix tool provider panel not display help message

### DIFF
--- a/pkg/entities/plugin_entities/config.go
+++ b/pkg/entities/plugin_entities/config.go
@@ -243,7 +243,7 @@ type ProviderConfig struct {
 	Scope       *string        `json:"scope" validate:"omitempty,is_scope"`
 	Required    bool           `json:"required"`
 	Default     any            `json:"default" validate:"omitempty,is_basic_type"`
-	Options     []ConfigOption `json:"optioSns" validate:"omitempty,lt=128,dive"`
+	Options     []ConfigOption `json:"options" validate:"omitempty,lt=128,dive"`
 	Label       I18nObject     `json:"label" validate:"required"`
 	Help        *I18nObject    `json:"help" validate:"omitempty"`
 	URL         *string        `json:"url" validate:"omitempty"`

--- a/pkg/entities/plugin_entities/config.go
+++ b/pkg/entities/plugin_entities/config.go
@@ -243,9 +243,9 @@ type ProviderConfig struct {
 	Scope       *string        `json:"scope" validate:"omitempty,is_scope"`
 	Required    bool           `json:"required"`
 	Default     any            `json:"default" validate:"omitempty,is_basic_type"`
-	Options     []ConfigOption `json:"options" validate:"omitempty,lt=128,dive"`
+	Options     []ConfigOption `json:"optioSns" validate:"omitempty,lt=128,dive"`
 	Label       I18nObject     `json:"label" validate:"required"`
-	Helper      *I18nObject    `json:"helper" validate:"omitempty"`
+	Help        *I18nObject    `json:"help" validate:"omitempty"`
 	URL         *string        `json:"url" validate:"omitempty"`
 	Placeholder *I18nObject    `json:"placeholder" validate:"omitempty"`
 }

--- a/pkg/entities/plugin_entities/tool_declaration_test.go
+++ b/pkg/entities/plugin_entities/tool_declaration_test.go
@@ -40,7 +40,7 @@ func TestFullFunctionToolProvider_Validate(t *testing.T) {
 				"zh_Hans": "API 密钥",
 				"pt_BR": "Chave da API"
 			},
-			"helper": {
+			"help": {
 				"en_US": "API Key",
 				"zh_Hans": "API 密钥",
 				"pt_BR": "Chave da API"
@@ -130,7 +130,7 @@ credentials_schema:
       en_US: API Key
       zh_Hans: API 密钥
       pt_BR: Chave da API
-    helper:
+    help:
       en_US: API Key
       zh_Hans: API 密钥
       pt_BR: Chave da API
@@ -230,7 +230,7 @@ func TestToolProviderWithMapCredentials_Validate(t *testing.T) {
 				"zh_Hans": "API 密钥",
 				"pt_BR": "Chave da API"
 			},
-			"helper": {
+			"help": {
 				"en_US": "API Key",
 				"zh_Hans": "API 密钥",
 				"pt_BR": "Chave da API"
@@ -320,7 +320,7 @@ credentials_schema:
       en_US: API Key
       zh_Hans: API 密钥
       pt_BR: Chave da API
-    helper:
+    help:
       en_US: API Key
       zh_Hans: API 密钥
       pt_BR: Chave da API
@@ -430,7 +430,7 @@ func TestWithoutAuthorToolProvider_Validate(t *testing.T) {
 				"zh_Hans": "API 密钥",
 				"pt_BR": "Chave da API"
 			},
-			"helper": {
+			"help": {
 				"en_US": "API Key",
 				"zh_Hans": "API 密钥",
 				"pt_BR": "Chave da API"
@@ -490,7 +490,7 @@ func TestWithoutNameToolProvider_Validate(t *testing.T) {
 				"zh_Hans": "API 密钥",
 				"pt_BR": "Chave da API"
 			},
-			"helper": {
+			"help": {
 				"en_US": "API Key",
 				"zh_Hans": "API 密钥",
 				"pt_BR": "Chave da API"
@@ -544,7 +544,7 @@ func TestWithoutDescriptionToolProvider_Validate(t *testing.T) {
 				"zh_Hans": "API 密钥",
 				"pt_BR": "Chave da API"
 			},
-			"helper": {
+			"help": {
 				"en_US": "API Key",
 				"zh_Hans": "API 密钥",
 				"pt_BR": "Chave da API"
@@ -603,7 +603,7 @@ func TestWrongCredentialTypeToolProvider_Validate(t *testing.T) {
 				"zh_Hans": "API 密钥",
 				"pt_BR": "Chave da API"
 			},
-			"helper": {
+			"help": {
 				"en_US": "API Key",
 				"zh_Hans": "API 密钥",
 				"pt_BR": "Chave da API"
@@ -662,7 +662,7 @@ func TestWrongIdentityTagsToolProvider_Validate(t *testing.T) {
 				"zh_Hans": "API 密钥",
 				"pt_BR": "Chave da API"
 			},
-			"helper": {
+			"help": {
 				"en_US": "API Key",
 				"zh_Hans": "API 密钥",
 				"pt_BR": "Chave da API"
@@ -979,7 +979,7 @@ func TestWrongAppSelectorScopeToolProvider_Validate(t *testing.T) {
 				"zh_Hans": "app-selector",
 				"pt_BR": "app-selector"
 			},
-			"helper": {
+			"help": {
 				"en_US": "app-selector",
 				"zh_Hans": "app-selector",
 				"pt_BR": "app-selector"
@@ -1086,7 +1086,7 @@ func TestAppSelectorScopeToolProvider_Validate(t *testing.T) {
 				"zh_Hans": "app-selector",
 				"pt_BR": "app-selector"
 			},
-			"helper": {
+			"help": {
 				"en_US": "app-selector",
 				"zh_Hans": "app-selector",
 				"pt_BR": "app-selector"


### PR DESCRIPTION
The correct definition in `dify` and `dify-plugin-sdk` is `help`, not `helper`. 

After the fix, the help message will display correctly.
 
![CleanShot 2025-03-04 at 13 57 50](https://github.com/user-attachments/assets/605c4488-ea7b-42e3-a135-43292241d6dd)
