### PR TITLE
fix: add error logging for connection handshake failure

### DIFF
--- a/internal/core/plugin_manager/debugging_runtime/hooks.go
+++ b/internal/core/plugin_manager/debugging_runtime/hooks.go
@@ -226,6 +226,7 @@ func (s *DifyServer) onMessage(runtime *RemotePluginRuntime, message []byte) {
 				return
 			} else if err != nil {
 				// close connection if handshake failed
+				log.Error("failed to get connection info: %v", err)
 				closeConn([]byte("internal error\n"))
 				return
 			}


### PR DESCRIPTION
Add error logging when connection handshake fails in the plugin runtime to improve debugging and error traceability