### PR TITLE
fix: optimize plugin last active time tracking in stdio handler

### DIFF
--- a/internal/core/plugin_manager/local_runtime/stdio_handle.go
+++ b/internal/core/plugin_manager/local_runtime/stdio_handle.go
@@ -187,8 +187,19 @@ func (s *stdioHolder) Wait() error {
 		select {
 		case <-ticker.C:
 			// check heartbeat
-			if time.Since(s.lastActiveAt) > 60*time.Second {
+			if time.Since(s.lastActiveAt) > 120*time.Second {
+				log.Error(
+					"plugin %s is not active for 120 seconds, it may be dead, killing and restarting it",
+					s.pluginUniqueIdentifier,
+				)
 				return plugin_errors.ErrPluginNotActive
+			}
+			if time.Since(s.lastActiveAt) > 60*time.Second {
+				log.Warn(
+					"plugin %s is not active for %d seconds, it may be dead",
+					s.pluginUniqueIdentifier,
+					time.Since(s.lastActiveAt).Seconds(),
+				)
 			}
 		case <-s.waitingControllerChan:
 			// closed

--- a/internal/core/plugin_manager/local_runtime/stdio_handle.go
+++ b/internal/core/plugin_manager/local_runtime/stdio_handle.go
@@ -90,6 +90,9 @@ func (s *stdioHolder) StartStdout(notify_heartbeat func()) {
 			continue
 		}
 
+		// update the last active time on each time the plugin sends data
+		s.lastActiveAt = time.Now()
+
 		plugin_entities.ParsePluginUniversalEvent(
 			data,
 			"",
@@ -106,7 +109,6 @@ func (s *stdioHolder) StartStdout(notify_heartbeat func()) {
 				}
 			},
 			func() {
-				s.lastActiveAt = time.Now()
 				// notify launched
 				notify_heartbeat()
 			},


### PR DESCRIPTION
Move last active time update to occur on each data receipt to ensure more accurate tracking of plugin activity