### PR TITLE
fix: Fix CROSSSLOT Error in Redis Commands

### DIFF
--- a/internal/core/plugin_manager/debugging_runtime/connection_key.go
+++ b/internal/core/plugin_manager/debugging_runtime/connection_key.go
@@ -29,8 +29,8 @@ type Key struct {
 }
 
 const (
-	CONNECTION_KEY_MANAGER_KEY2ID_PREFIX = "remote:key:manager:key2id"
-	CONNECTION_KEY_MANAGER_ID2KEY_PREFIX = "remote:key:manager:id2key"
+	CONNECTION_KEY_MANAGER_KEY2ID_PREFIX = "{remote:key:manager}:key2id"
+	CONNECTION_KEY_MANAGER_ID2KEY_PREFIX = "{remote:key:manager}:id2key"
 	CONNECTION_KEY_LOCK                  = "connection_lock"
 	CONNECTION_KEY_EXPIRE_TIME           = time.Minute * 120 // 2 hours
 )


### PR DESCRIPTION
This pull request addresses the issue of the "CROSSSLOT Keys in request don't hash to the same slot" error, which occurs when Redis commands involve keys that are not hashed to the same slot in a clustered environment.

Changes Made:

1. Updated Redis command logic to ensure that all keys involved in transactions or multi-key operations are hashed to the same slot.
2. Modified the data distribution strategy to align with Redis cluster requirements, ensuring key patterns are consistent with slot allocation.