### PR TITLE
feat: add pip configuration options for plugin environment setup

### DIFF
--- a/internal/core/plugin_manager/launcher.go
+++ b/internal/core/plugin_manager/launcher.go
@@ -135,6 +135,8 @@ func (p *PluginManager) launchLocal(pluginUniqueIdentifier plugin_entities.Plugi
 		HttpProxy:             p.HttpProxy,
 		HttpsProxy:            p.HttpsProxy,
 		PipMirrorUrl:          p.pipMirrorUrl,
+		PipPreferBinary:       p.pipPreferBinary,
+		PipExtraArgs:          p.pipExtraArgs,
 	})
 	localPluginRuntime.PluginRuntime = plugin.runtime
 	localPluginRuntime.BasicChecksum = basic_runtime.BasicChecksum{

--- a/internal/core/plugin_manager/local_runtime/environment_python.go
+++ b/internal/core/plugin_manager/local_runtime/environment_python.go
@@ -102,7 +102,7 @@ func (p *LocalPluginRuntime) InitPythonEnvironment() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
-	args := []string{"install"}
+	args := []string{"install", "--disable-pip-version-check"} // FIX: pip version check takes too long
 
 	if p.HttpProxy != "" {
 		args = append(args, "--proxy", p.HttpProxy)
@@ -115,6 +115,18 @@ func (p *LocalPluginRuntime) InitPythonEnvironment() error {
 	}
 
 	args = append(args, "-r", "requirements.txt")
+
+	if p.pipPreferBinary {
+		args = append(args, "--prefer-binary")
+	}
+
+	if p.pipVerbose {
+		args = append(args, "-vvv")
+	}
+
+	if p.pipExtraArgs != "" {
+		args = append(args, strings.Split(p.pipExtraArgs, " ")...)
+	}
 
 	cmd = exec.CommandContext(ctx, pipPath, args...)
 	cmd.Dir = p.State.WorkingPath

--- a/internal/core/plugin_manager/local_runtime/type.go
+++ b/internal/core/plugin_manager/local_runtime/type.go
@@ -24,7 +24,10 @@ type LocalPluginRuntime struct {
 	// by using its venv module
 	defaultPythonInterpreterPath string
 
-	pipMirrorUrl string
+	pipMirrorUrl    string
+	pipPreferBinary bool
+	pipVerbose      bool
+	pipExtraArgs    string
 
 	// proxy settings
 	HttpProxy  string
@@ -43,6 +46,9 @@ type LocalPluginRuntimeConfig struct {
 	HttpProxy             string
 	HttpsProxy            string
 	PipMirrorUrl          string
+	PipPreferBinary       bool
+	PipVerbose            bool
+	PipExtraArgs          string
 }
 
 func NewLocalPluginRuntime(config LocalPluginRuntimeConfig) *LocalPluginRuntime {
@@ -52,5 +58,8 @@ func NewLocalPluginRuntime(config LocalPluginRuntimeConfig) *LocalPluginRuntime 
 		HttpProxy:                    config.HttpProxy,
 		HttpsProxy:                   config.HttpsProxy,
 		pipMirrorUrl:                 config.PipMirrorUrl,
+		pipPreferBinary:              config.PipPreferBinary,
+		pipVerbose:                   config.PipVerbose,
+		pipExtraArgs:                 config.PipExtraArgs,
 	}
 }

--- a/internal/core/plugin_manager/manager.go
+++ b/internal/core/plugin_manager/manager.go
@@ -66,6 +66,15 @@ type PluginManager struct {
 	// pip mirror url
 	pipMirrorUrl string
 
+	// pip prefer binary
+	pipPreferBinary bool
+
+	// pip verbose
+	pipVerbose bool
+
+	// pip extra args
+	pipExtraArgs string
+
 	// remote plugin server
 	remotePluginServer debugging_runtime.RemotePluginServerInterface
 
@@ -106,6 +115,9 @@ func InitGlobalManager(oss oss.OSS, configuration *app.Config) *PluginManager {
 		HttpProxy:                configuration.HttpProxy,
 		HttpsProxy:               configuration.HttpsProxy,
 		pipMirrorUrl:             configuration.PipMirrorUrl,
+		pipPreferBinary:          *configuration.PipPreferBinary,
+		pipVerbose:               *configuration.PipVerbose,
+		pipExtraArgs:             configuration.PipExtraArgs,
 	}
 
 	return manager

--- a/internal/core/plugin_manager/serverless.go
+++ b/internal/core/plugin_manager/serverless.go
@@ -33,6 +33,9 @@ func (p *PluginManager) getServerlessPluginRuntime(
 
 	// FIXME: get declaration
 	declaration, err := helper.CombinedGetPluginDeclaration(identity, plugin_entities.PLUGIN_RUNTIME_TYPE_SERVERLESS)
+	if err != nil {
+		return nil, err
+	}
 
 	// init runtime entity
 	runtimeEntity := plugin_entities.PluginRuntime{

--- a/internal/core/plugin_manager/watcher_test.go
+++ b/internal/core/plugin_manager/watcher_test.go
@@ -111,7 +111,7 @@ func TestRemotePluginWatcherPluginStoredToManager(t *testing.T) {
 	config.SetDefault()
 	routine.InitPool(1024)
 	oss := local.NewLocalStorage("./storage")
-	pm := InitGlobalManager(oss, &app.Config{})
+	pm := InitGlobalManager(oss, config)
 	pm.remotePluginServer = &fakeRemotePluginServer{}
 	pm.startRemoteWatcher(config)
 

--- a/internal/types/app/config.go
+++ b/internal/types/app/config.go
@@ -91,6 +91,9 @@ type Config struct {
 	PythonInterpreterPath string `envconfig:"PYTHON_INTERPRETER_PATH"`
 	PythonEnvInitTimeout  int    `envconfig:"PYTHON_ENV_INIT_TIMEOUT" validate:"required"`
 	PipMirrorUrl          string `envconfig:"PIP_MIRROR_URL"`
+	PipPreferBinary       *bool  `envconfig:"PIP_PREFER_BINARY"`
+	PipVerbose            *bool  `envconfig:"PIP_VERBOSE"`
+	PipExtraArgs          string `envconfig:"PIP_EXTRA_ARGS"`
 
 	DisplayClusterLog bool `envconfig:"DISPLAY_CLUSTER_LOG"`
 

--- a/internal/types/app/default.go
+++ b/internal/types/app/default.go
@@ -31,6 +31,8 @@ func (config *Config) SetDefault() {
 	setDefaultString(&config.PythonInterpreterPath, "/usr/bin/python3")
 	setDefaultInt(&config.PythonEnvInitTimeout, 120)
 	setDefaultBoolPtr(&config.ForceVerifyingSignature, true)
+	setDefaultBoolPtr(&config.PipPreferBinary, true)
+	setDefaultBoolPtr(&config.PipVerbose, true)
 }
 
 func setDefaultInt[T constraints.Integer](value *T, defaultValue T) {


### PR DESCRIPTION
Enhance Python plugin environment initialization with new configuration options:
- Add support for pip prefer binary flag
- Add pip verbose mode
- Add extra pip arguments configuration
- Set default values for new pip-related configuration options