### PR TITLE
feat: Add max execution time parameter to endpoint handling

### DIFF
--- a/internal/server/endpoint_test.go
+++ b/internal/server/endpoint_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/langgenius/dify-plugin-daemon/internal/types/app"
@@ -21,7 +22,7 @@ func TestEndpointParams(t *testing.T) {
 	globalHookId := ""
 	globalHookPath := ""
 
-	handler := func(ctx *gin.Context, hook_id string, path string) {
+	handler := func(ctx *gin.Context, hook_id string, maxExecutionTime time.Duration, path string) {
 		globalHookId = hook_id
 		globalHookPath = path
 	}

--- a/internal/server/http_server.go
+++ b/internal/server/http_server.go
@@ -104,12 +104,12 @@ func (app *App) remoteDebuggingGroup(group *gin.RouterGroup, config *app.Config)
 
 func (app *App) endpointGroup(group *gin.RouterGroup, config *app.Config) {
 	if config.PluginEndpointEnabled != nil && *config.PluginEndpointEnabled {
-		group.HEAD("/:hook_id/*path", app.Endpoint())
-		group.POST("/:hook_id/*path", app.Endpoint())
-		group.GET("/:hook_id/*path", app.Endpoint())
-		group.PUT("/:hook_id/*path", app.Endpoint())
-		group.DELETE("/:hook_id/*path", app.Endpoint())
-		group.OPTIONS("/:hook_id/*path", app.Endpoint())
+		group.HEAD("/:hook_id/*path", app.Endpoint(config))
+		group.POST("/:hook_id/*path", app.Endpoint(config))
+		group.GET("/:hook_id/*path", app.Endpoint(config))
+		group.PUT("/:hook_id/*path", app.Endpoint(config))
+		group.DELETE("/:hook_id/*path", app.Endpoint(config))
+		group.OPTIONS("/:hook_id/*path", app.Endpoint(config))
 	}
 }
 

--- a/internal/service/endpoint.go
+++ b/internal/service/endpoint.go
@@ -31,6 +31,7 @@ func Endpoint(
 	ctx *gin.Context,
 	endpoint *models.Endpoint,
 	pluginInstallation *models.PluginInstallation,
+	maxExecutionTime time.Duration,
 	path string,
 ) {
 	if !endpoint.Enabled {
@@ -195,7 +196,7 @@ func Endpoint(
 	select {
 	case <-ctx.Writer.CloseNotify():
 	case <-done:
-	case <-time.After(240 * time.Second):
+	case <-time.After(maxExecutionTime):
 		ctx.JSON(500, exception.InternalServerError(errors.New("killed by timeout")).ToResponse())
 	}
 }


### PR DESCRIPTION
Modify endpoint-related functions to support configurable maximum execution time:
- Update EndpointHandler signature to include maxExecutionTime
- Pass max execution timeout from config to endpoint service
- Modify timeout mechanism to use configurable duration instead of hardcoded 240 seconds