### PR TITLE
fix: Remove redundant proxy handling in Python environment setup

### DIFF
--- a/internal/core/plugin_manager/local_runtime/environment_python.go
+++ b/internal/core/plugin_manager/local_runtime/environment_python.go
@@ -104,12 +104,6 @@ func (p *LocalPluginRuntime) InitPythonEnvironment() error {
 
 	args := []string{"install"}
 
-	if p.HttpProxy != "" {
-		args = append(args, "--proxy", p.HttpProxy)
-	} else if p.HttpsProxy != "" {
-		args = append(args, "--proxy", p.HttpsProxy)
-	}
-
 	if p.pipMirrorUrl != "" {
 		args = append(args, "-i", p.pipMirrorUrl)
 	}


### PR DESCRIPTION
Remove duplicate proxy configuration logic when installing Python packages, keeping only the mirror URL configuration