### PR TITLE
fix: respect resolution settings for vision sent from api

### DIFF
--- a/pkg/entities/model_entities/llm.go
+++ b/pkg/entities/model_entities/llm.go
@@ -100,11 +100,12 @@ func isPromptMessageContentType(fl validator.FieldLevel) bool {
 type PromptMessageContent struct {
 	Type         PromptMessageContentType `json:"type" validate:"required,prompt_message_content_type"`
 	Base64Data   string                   `json:"base64_data"` // for multi-modal data
-        URL          string 	              `json:"url"`         // for multi-modal data
+	URL          string                   `json:"url"`         // for multi-modal data
 	Data         string                   `json:"data"`        // for text only
 	EncodeFormat string                   `json:"encode_format"`
 	Format       string                   `json:"format"`
 	MimeType     string                   `json:"mime_type"`
+	Detail       string                   `json:"detail"`      // for multi-modal data
 }
 
 type PromptMessageToolCall struct {


### PR DESCRIPTION
This PR changes the `PromptMessageContent` structure to allow having the `Detail` (`detail` in JSON) key.

By this change, the "Resolution" configuration for the vision requests that are sent from the API side will be handled and passed to LLM model correctly.

Closes #109 