### PR TITLE
feat(plugin-manager): add support for additional Python compileall arguments

### DIFF
--- a/internal/core/plugin_manager/launcher.go
+++ b/internal/core/plugin_manager/launcher.go
@@ -130,13 +130,14 @@ func (p *PluginManager) launchLocal(pluginUniqueIdentifier plugin_entities.Plugi
 	}
 
 	localPluginRuntime := local_runtime.NewLocalPluginRuntime(local_runtime.LocalPluginRuntimeConfig{
-		PythonInterpreterPath: p.pythonInterpreterPath,
-		PythonEnvInitTimeout:  p.pythonEnvInitTimeout,
-		HttpProxy:             p.HttpProxy,
-		HttpsProxy:            p.HttpsProxy,
-		PipMirrorUrl:          p.pipMirrorUrl,
-		PipPreferBinary:       p.pipPreferBinary,
-		PipExtraArgs:          p.pipExtraArgs,
+		PythonInterpreterPath:     p.pythonInterpreterPath,
+		PythonEnvInitTimeout:      p.pythonEnvInitTimeout,
+		PythonCompileAllExtraArgs: p.pythonCompileAllExtraArgs,
+		HttpProxy:                 p.HttpProxy,
+		HttpsProxy:                p.HttpsProxy,
+		PipMirrorUrl:              p.pipMirrorUrl,
+		PipPreferBinary:           p.pipPreferBinary,
+		PipExtraArgs:              p.pipExtraArgs,
 	})
 	localPluginRuntime.PluginRuntime = plugin.runtime
 	localPluginRuntime.BasicChecksum = basic_runtime.BasicChecksum{

--- a/internal/core/plugin_manager/local_runtime/environment_python.go
+++ b/internal/core/plugin_manager/local_runtime/environment_python.go
@@ -220,8 +220,14 @@ func (p *LocalPluginRuntime) InitPythonEnvironment() error {
 		return fmt.Errorf("failed to install dependencies: %s, output: %s", err, errMsg.String())
 	}
 
+	compileArgs := []string{"-m", "compileall"}
+	if p.pythonCompileAllExtraArgs != "" {
+		compileArgs = append(compileArgs, strings.Split(p.pythonCompileAllExtraArgs, " ")...)
+	}
+	compileArgs = append(compileArgs, ".")
+
 	// pre-compile the plugin to avoid costly compilation on first invocation
-	compileCmd := exec.CommandContext(ctx, pythonPath, "-m", "compileall", ".")
+	compileCmd := exec.CommandContext(ctx, pythonPath, compileArgs...)
 	compileCmd.Dir = p.State.WorkingPath
 
 	// get stdout and stderr

--- a/internal/core/plugin_manager/local_runtime/type.go
+++ b/internal/core/plugin_manager/local_runtime/type.go
@@ -20,6 +20,9 @@ type LocalPluginRuntime struct {
 	// python env init timeout
 	pythonEnvInitTimeout int
 
+	// python compileall extra args
+	pythonCompileAllExtraArgs string
+
 	// to create a new python virtual environment, we need a default python interpreter
 	// by using its venv module
 	defaultPythonInterpreterPath string
@@ -41,20 +44,22 @@ type LocalPluginRuntime struct {
 }
 
 type LocalPluginRuntimeConfig struct {
-	PythonInterpreterPath string
-	PythonEnvInitTimeout  int
-	HttpProxy             string
-	HttpsProxy            string
-	PipMirrorUrl          string
-	PipPreferBinary       bool
-	PipVerbose            bool
-	PipExtraArgs          string
+	PythonInterpreterPath     string
+	PythonEnvInitTimeout      int
+	PythonCompileAllExtraArgs string
+	HttpProxy                 string
+	HttpsProxy                string
+	PipMirrorUrl              string
+	PipPreferBinary           bool
+	PipVerbose                bool
+	PipExtraArgs              string
 }
 
 func NewLocalPluginRuntime(config LocalPluginRuntimeConfig) *LocalPluginRuntime {
 	return &LocalPluginRuntime{
 		defaultPythonInterpreterPath: config.PythonInterpreterPath,
 		pythonEnvInitTimeout:         config.PythonEnvInitTimeout,
+		pythonCompileAllExtraArgs:    config.PythonCompileAllExtraArgs,
 		HttpProxy:                    config.HttpProxy,
 		HttpsProxy:                   config.HttpsProxy,
 		pipMirrorUrl:                 config.PipMirrorUrl,

--- a/internal/core/plugin_manager/manager.go
+++ b/internal/core/plugin_manager/manager.go
@@ -75,6 +75,9 @@ type PluginManager struct {
 	// pip extra args
 	pipExtraArgs string
 
+	// python compileall extra args
+	pythonCompileAllExtraArgs string
+
 	// remote plugin server
 	remotePluginServer debugging_runtime.RemotePluginServerInterface
 
@@ -107,17 +110,18 @@ func InitGlobalManager(oss oss.OSS, configuration *app.Config) *PluginManager {
 			oss,
 			configuration.PluginInstalledPath,
 		),
-		localPluginLaunchingLock: lock.NewGranularityLock(),
-		maxLaunchingLock:         make(chan bool, 2), // by default, we allow 2 plugins launching at the same time
-		pythonInterpreterPath:    configuration.PythonInterpreterPath,
-		pythonEnvInitTimeout:     configuration.PythonEnvInitTimeout,
-		platform:                 configuration.Platform,
-		HttpProxy:                configuration.HttpProxy,
-		HttpsProxy:               configuration.HttpsProxy,
-		pipMirrorUrl:             configuration.PipMirrorUrl,
-		pipPreferBinary:          *configuration.PipPreferBinary,
-		pipVerbose:               *configuration.PipVerbose,
-		pipExtraArgs:             configuration.PipExtraArgs,
+		localPluginLaunchingLock:  lock.NewGranularityLock(),
+		maxLaunchingLock:          make(chan bool, 2), // by default, we allow 2 plugins launching at the same time
+		pythonInterpreterPath:     configuration.PythonInterpreterPath,
+		pythonEnvInitTimeout:      configuration.PythonEnvInitTimeout,
+		pythonCompileAllExtraArgs: configuration.PythonCompileAllExtraArgs,
+		platform:                  configuration.Platform,
+		HttpProxy:                 configuration.HttpProxy,
+		HttpsProxy:                configuration.HttpsProxy,
+		pipMirrorUrl:              configuration.PipMirrorUrl,
+		pipPreferBinary:           *configuration.PipPreferBinary,
+		pipVerbose:                *configuration.PipVerbose,
+		pipExtraArgs:              configuration.PipExtraArgs,
 	}
 
 	return manager

--- a/internal/types/app/config.go
+++ b/internal/types/app/config.go
@@ -89,12 +89,13 @@ type Config struct {
 	MaxBundlePackageSize            int64 `envconfig:"MAX_BUNDLE_PACKAGE_SIZE" validate:"required"`
 	MaxServerlessTransactionTimeout int   `envconfig:"MAX_SERVERLESS_TRANSACTION_TIMEOUT"`
 
-	PythonInterpreterPath string `envconfig:"PYTHON_INTERPRETER_PATH"`
-	PythonEnvInitTimeout  int    `envconfig:"PYTHON_ENV_INIT_TIMEOUT" validate:"required"`
-	PipMirrorUrl          string `envconfig:"PIP_MIRROR_URL"`
-	PipPreferBinary       *bool  `envconfig:"PIP_PREFER_BINARY"`
-	PipVerbose            *bool  `envconfig:"PIP_VERBOSE"`
-	PipExtraArgs          string `envconfig:"PIP_EXTRA_ARGS"`
+	PythonInterpreterPath      string `envconfig:"PYTHON_INTERPRETER_PATH"`
+	PythonEnvInitTimeout  	   int    `envconfig:"PYTHON_ENV_INIT_TIMEOUT" validate:"required"`
+	PythonCompileAllExtraArgs  string `envconfig:"PYTHON_COMPILE_ALL_EXTRA_ARGS"`
+	PipMirrorUrl               string `envconfig:"PIP_MIRROR_URL"`
+	PipPreferBinary            *bool  `envconfig:"PIP_PREFER_BINARY"`
+	PipVerbose                 *bool  `envconfig:"PIP_VERBOSE"`
+	PipExtraArgs               string `envconfig:"PIP_EXTRA_ARGS"`
 
 	DisplayClusterLog bool `envconfig:"DISPLAY_CLUSTER_LOG"`
 


### PR DESCRIPTION
Introduce `pythonCompileAllExtraArgs` to allow users to pass extra arguments to the Python `compileall` command. This enhancement enables more flexible compilation options for plugins by extending the configuration in the plugin manager and local runtime components.

- Updated `launcher.go` to include `PythonCompileAllExtraArgs` in the runtime configuration.
- Modified `environment_python.go` to handle the additional compile arguments.
- Added new configuration fields in `type.go` and `config.go`.
- Adjusted initialization in `manager.go` to accept the new configuration parameter.