### PR TITLE
fix: pass HTTP_PROXY and HTTPS_PROXY to uv process

### DIFF
--- a/internal/core/plugin_manager/local_runtime/environment_python.go
+++ b/internal/core/plugin_manager/local_runtime/environment_python.go
@@ -123,6 +123,12 @@ func (p *LocalPluginRuntime) InitPythonEnvironment() error {
 	virtualEnvPath := path.Join(p.State.WorkingPath, ".venv")
 	cmd = exec.CommandContext(ctx, uvPath, args...)
 	cmd.Env = append(cmd.Env, "VIRTUAL_ENV="+virtualEnvPath, "PATH="+os.Getenv("PATH"))
+	if p.HttpProxy != "" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("HTTP_PROXY=%s", p.HttpProxy))
+	}
+	if p.HttpsProxy != "" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("HTTPS_PROXY=%s", p.HttpsProxy))
+	}
 	cmd.Dir = p.State.WorkingPath
 
 	// get stdout and stderr


### PR DESCRIPTION
This PR changes `uv` command to use proxy if it is specified by `HTTP_PROXY` and/or `HTTPS_PROXY`.

This is follow-up for #99 for #102, also closes #118