### PR TITLE
fix(plugin-manager): log pre-compilation python errors instead of raises it outside to avoid plugins to broken

### DIFF
--- a/internal/core/plugin_manager/local_runtime/environment_python.go
+++ b/internal/core/plugin_manager/local_runtime/environment_python.go
@@ -314,7 +314,7 @@ func (p *LocalPluginRuntime) InitPythonEnvironment() error {
 		// ISSUE: for some weird reasons, plugins may reference to a broken sdk but it works well itself
 		// we need to skip it but log the messages
 		// https://github.com/langgenius/dify/issues/16292
-		log.Error("failed to pre-compile the plugin: %s", compileErrMsg.String())
+		log.Warn("failed to pre-compile the plugin: %s", compileErrMsg.String())
 	}
 
 	log.Info("pre-loaded the plugin %s", p.Config.Identity())

--- a/internal/core/plugin_manager/local_runtime/environment_python.go
+++ b/internal/core/plugin_manager/local_runtime/environment_python.go
@@ -310,10 +310,14 @@ func (p *LocalPluginRuntime) InitPythonEnvironment() error {
 
 	compileWg.Wait()
 	if err := compileCmd.Wait(); err != nil {
-		return fmt.Errorf("failed to pre-compile the plugin: %s", compileErrMsg.String())
+		// skip the error if the plugin is not compiled
+		// ISSUE: for some weird reasons, plugins may reference to a broken sdk but it works well itself
+		// we need to skip it but log the messages
+		// https://github.com/langgenius/dify/issues/16292
+		log.Error("failed to pre-compile the plugin: %s", compileErrMsg.String())
 	}
 
-	log.Info("pre-loading the plugin %s", p.Config.Identity())
+	log.Info("pre-loaded the plugin %s", p.Config.Identity())
 
 	// import dify_plugin to speedup the first launching
 	// ISSUE: it takes too long to setup all the deps, that's why we choose to preload it


### PR DESCRIPTION
Updated the error handling in the InitPythonEnvironment function to log pre-compilation errors instead of returning them. This change addresses issues with plugins referencing broken SDKs while still functioning correctly. Additionally, corrected the log message for pre-loading plugins to reflect the accurate state.

Fixes: https://github.com/langgenius/dify/issues/16292