### PR TITLE
BUGFIX: fix AutoGetWithGetter will never hit cache issue.

### DIFF
--- a/internal/utils/cache/redis.go
+++ b/internal/utils/cache/redis.go
@@ -68,6 +68,11 @@ func serialKey(keys ...string) string {
 
 // Store the key-value pair
 func Store(key string, value any, time time.Duration, context ...redis.Cmdable) error {
+	return store(serialKey(key), value, time, context...)
+}
+
+// store the key-value pair, without serialKey
+func store(key string, value any, time time.Duration, context ...redis.Cmdable) error {
 	if client == nil {
 		return ErrDBNotInit
 	}
@@ -80,7 +85,7 @@ func Store(key string, value any, time time.Duration, context ...redis.Cmdable) 
 		}
 	}
 
-	return getCmdable(context...).Set(ctx, serialKey(key), value, time).Err()
+	return getCmdable(context...).Set(ctx, key, value, time).Err()
 }
 
 // Get the value with key

--- a/internal/utils/cache/redis_auto_type.go
+++ b/internal/utils/cache/redis_auto_type.go
@@ -59,7 +59,7 @@ func AutoGetWithGetter[T any](key string, getter func() (*T, error), context ...
 				return nil, err
 			}
 
-			if err := Store(key, value, time.Minute*30, context...); err != nil {
+			if err := store(key, value, time.Minute*30, context...); err != nil {
 				return nil, err
 			}
 			return value, nil

--- a/internal/utils/cache/redis_auto_type_test.go
+++ b/internal/utils/cache/redis_auto_type_test.go
@@ -35,7 +35,7 @@ func TestAutoType(t *testing.T) {
 }
 
 func TestAutoTypeWithGetter(t *testing.T) {
-	if err := InitRedisClient("192.168.125.241:26379", "difyai123456", false); err != nil {
+	if err := InitRedisClient("127.0.0.1:6379", "difyai123456", false); err != nil {
 		t.Fatal(err)
 	}
 	defer Close()

--- a/internal/utils/cache/redis_auto_type_test.go
+++ b/internal/utils/cache/redis_auto_type_test.go
@@ -1,6 +1,9 @@
 package cache
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
 
 type TestAutoTypeStruct struct {
 	ID string `json:"id"`
@@ -32,7 +35,7 @@ func TestAutoType(t *testing.T) {
 }
 
 func TestAutoTypeWithGetter(t *testing.T) {
-	if err := InitRedisClient("127.0.0.1:6379", "difyai123456", false); err != nil {
+	if err := InitRedisClient("192.168.125.241:26379", "difyai123456", false); err != nil {
 		t.Fatal(err)
 	}
 	defer Close()
@@ -41,6 +44,12 @@ func TestAutoTypeWithGetter(t *testing.T) {
 		return &TestAutoTypeStruct{
 			ID: "123",
 		}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err = AutoGetWithGetter("test1", func() (*TestAutoTypeStruct, error) {
+		return nil, errors.New("must hit cache")
 	})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
add a new function named `store` for internal use, without calling serialKey.

modify `TestAutoTypeWithGetter` to call twice, check if cache hit.