### PR TITLE
Add get/delete implement, for internal use.

### DIFF
--- a/internal/utils/cache/redis.go
+++ b/internal/utils/cache/redis.go
@@ -90,11 +90,15 @@ func store(key string, value any, time time.Duration, context ...redis.Cmdable) 
 
 // Get the value with key
 func Get[T any](key string, context ...redis.Cmdable) (*T, error) {
+	return get[T](serialKey(key), context...)
+}
+
+func get[T any](key string, context ...redis.Cmdable) (*T, error) {
 	if client == nil {
 		return nil, ErrDBNotInit
 	}
 
-	val, err := getCmdable(context...).Get(ctx, serialKey(key)).Bytes()
+	val, err := getCmdable(context...).Get(ctx, key).Bytes()
 	if err != nil {
 		if err == redis.Nil {
 			return nil, ErrNotFound
@@ -128,11 +132,15 @@ func GetString(key string, context ...redis.Cmdable) (string, error) {
 
 // Del the key
 func Del(key string, context ...redis.Cmdable) error {
+	return del(serialKey(key), context...)
+}
+
+func del(key string, context ...redis.Cmdable) error {
 	if client == nil {
 		return ErrDBNotInit
 	}
 
-	_, err := getCmdable(context...).Del(ctx, serialKey(key)).Result()
+	_, err := getCmdable(context...).Del(ctx, key).Result()
 	if err != nil {
 		if err == redis.Nil {
 			return ErrNotFound

--- a/internal/utils/cache/redis_auto_type.go
+++ b/internal/utils/cache/redis_auto_type.go
@@ -5,7 +5,6 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/langgenius/dify-plugin-daemon/internal/utils/parser"
 	"github.com/redis/go-redis/v9"
 )
 
@@ -21,12 +20,7 @@ func AutoSet[T any](key string, value T, context ...redis.Cmdable) error {
 	fullTypeName := pkgPath + "." + typeName
 
 	key = serialKey("auto_type", fullTypeName, key)
-	cborValue, err := parser.MarshalCBOR(value)
-	if err != nil {
-		return err
-	}
-
-	return getCmdable(context...).Set(ctx, key, cborValue, time.Minute*30).Err()
+	return store(key, value, time.Minute*30, context...)
 }
 
 // Get the value with key
@@ -51,24 +45,23 @@ func AutoGetWithGetter[T any](key string, getter func() (*T, error), context ...
 	fullTypeName := pkgPath + "." + typeName
 
 	key = serialKey("auto_type", fullTypeName, key)
-	val, err := getCmdable(context...).Get(ctx, key).Bytes()
+	result, err := get[T](key, context...)
 	if err != nil {
-		if err == redis.Nil {
-			value, err := getter()
+		if err == ErrNotFound {
+			result, err = getter()
 			if err != nil {
 				return nil, err
 			}
 
-			if err := store(key, value, time.Minute*30, context...); err != nil {
+			if err := store(key, result, time.Minute*30, context...); err != nil {
 				return nil, err
 			}
-			return value, nil
+			return result, nil
 		}
 		return nil, err
 	}
 
-	result, err := parser.UnmarshalCBOR[T](val)
-	return &result, err
+	return result, err
 }
 
 // Delete the value with key
@@ -85,5 +78,5 @@ func AutoDelete[T any](key string, context ...redis.Cmdable) error {
 	fullTypeName := pkgPath + "." + typeName
 
 	key = serialKey("auto_type", fullTypeName, key)
-	return getCmdable(context...).Del(ctx, key).Err()
+	return del(key, context...)
 }

--- a/internal/utils/cache/redis_test.go
+++ b/internal/utils/cache/redis_test.go
@@ -281,3 +281,35 @@ func TestGetRedisOptions(t *testing.T) {
 		return
 	}
 }
+
+func TestSetAndGet(t *testing.T) {
+	if err := InitRedisClient("127.0.0.1:6379", "difyai123456", false); err != nil {
+		t.Fatal(err)
+	}
+	defer Close()
+
+	m := map[string]string{
+		"key": "hello",
+	}
+
+	err := Store(strings.Join([]string{TEST_PREFIX, "get-test"}, ":"), m, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	val, err := Get[map[string]string](strings.Join([]string{TEST_PREFIX, "get-test"}, ":"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if (*val)["key"] != "hello" {
+		t.Fatalf("Get[\"key\"] should be \"hello\"")
+	}
+	err = Del(strings.Join([]string{TEST_PREFIX, "get-test"}, ":"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	val, err = Get[map[string]string](strings.Join([]string{TEST_PREFIX, "get-test"}, ":"))
+	if err != ErrNotFound {
+		t.Fatalf("Get[\"key\"] should be ErrNotFound")
+	}
+}


### PR DESCRIPTION
Add get/delete implement, without `serialKey`, for internal use, as metioned in #128 