### PR TITLE
fix: some time uv venv wrong python version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ subprocesses
 working
 cwd/
 bin/
+.venv/

--- a/internal/core/plugin_manager/local_runtime/environment_python.go
+++ b/internal/core/plugin_manager/local_runtime/environment_python.go
@@ -61,7 +61,7 @@ func (p *LocalPluginRuntime) InitPythonEnvironment() error {
 
 	uvPath := strings.TrimSpace(string(output))
 
-	cmd = exec.Command(uvPath, "venv", ".venv")
+	cmd = exec.Command(uvPath, "venv", ".venv", "--python", "3.12")
 	cmd.Dir = p.State.WorkingPath
 	b := bytes.NewBuffer(nil)
 	cmd.Stdout = b


### PR DESCRIPTION
The plugin is developed for Python 3.12. However, when the system Python version differs (e.g., 3.13), the plugin may fail to run correctly.

To ensure compatibility, we'll configure uv to default to Python 3.12, matching the manifest specification.