### PR TITLE
fix unit test

### DIFF
--- a/internal/utils/cache/redis_test.go
+++ b/internal/utils/cache/redis_test.go
@@ -283,7 +283,7 @@ func TestGetRedisOptions(t *testing.T) {
 }
 
 func TestSetAndGet(t *testing.T) {
-	if err := InitRedisClient("127.0.0.1:6379", "difyai123456", false); err != nil {
+	if err := InitRedisClient("127.0.0.1:6379", "difyai123456", false, 0); err != nil {
 		t.Fatal(err)
 	}
 	defer Close()


### PR DESCRIPTION
fix cache unit test.
```
Error: internal/utils/cache/redis_test.go:286:62: not enough arguments in call to InitRedisClient
	have (string, string, bool)
	want (string, string, bool, int)
```