### PR TITLE
Ensure thread safety by adding locking when processing listeners.

### DIFF
--- a/internal/core/plugin_manager/local_runtime/stdio_handle.go
+++ b/internal/core/plugin_manager/local_runtime/stdio_handle.go
@@ -97,9 +97,12 @@ func (s *stdioHolder) StartStdout(notify_heartbeat func()) {
 			data,
 			"",
 			func(session_id string, data []byte) {
+				l.Lock()
 				for _, listener := range listeners {
 					listener(s.id, data)
 				}
+				l.Unlock()
+				
 				// FIX: avoid deadlock to plugin invoke
 				s.l.Lock()
 				tasks := []func(){}


### PR DESCRIPTION
Fix:  fatal error: concurrent map iteration and map write


error info:
```
"/plugin/3ce9ade6-4593-4d7d-8171-e3eaee7f6a66/dispatch/model/schema"
plugin_daemon-1  | fatal error: concurrent map iteration and map write
plugin_daemon-1  | 
plugin_daemon-1  | goroutine 54 [running]:
plugin_daemon-1  | github.com/langgenius/dify-plugin-daemon/internal/core/plugin_manager/local_runtime.(*stdioHolder).StartStdout.func1({0xc00020a8d0, 0x24}, {0xc001b34558, 0x18, 0x18})
plugin_daemon-1  |      /app/internal/core/plugin_manager/local_runtime/stdio_handle.go:100 +0x105
plugin_daemon-1  | github.com/langgenius/dify-plugin-daemon/pkg/entities/plugin_entities.ParsePluginUniversalEvent({0xc000636919, 0x67, 0x0?}, {0x0, 0x0}, 0xc0011a9d38, 0xc0011a9d20, 0xc0011a9d10, 0xc0011a9d00)
```