### PR TITLE
Increase NODE_DISCONNECTED_TIMEOUT

### DIFF
--- a/internal/cluster/cluster_lifetime.go
+++ b/internal/cluster/cluster_lifetime.go
@@ -27,7 +27,7 @@ const (
 	// each node will also update its own status to remain active. If a node becomes inactive, it will be removed from the cluster.
 	NODE_VOTE_INTERVAL          = time.Second * 30 // interval to vote the ips of the nodes
 	UPDATE_NODE_STATUS_INTERVAL = time.Second * 5  // interval to update the status of the node
-	NODE_DISCONNECTED_TIMEOUT   = time.Second * 60 // once a node is no longer active, it will be removed from the cluster
+	NODE_DISCONNECTED_TIMEOUT   = time.Second * 25 // once a node is no longer active, it will be removed from the cluster
 
 	// plugin scheduler
 	// each node will schedule its plugins every $PLUGIN_SCHEDULER_INTERVAL time

--- a/internal/cluster/vote.go
+++ b/internal/cluster/vote.go
@@ -51,7 +51,7 @@ func (c *Cluster) voteAddresses() error {
 				}
 			}
 
-			ipsVoting[addr.fullAddress()] = c.voteAddress(addr) == nil
+			ipsVoting[addr.fullAddress()] = time.Since(time.Unix(nodeStatus.LastPingAt, 0)) < c.nodeDisconnectedTimeout
 		}
 
 		// lock the node status


### PR DESCRIPTION
The current value of NODE_DISCONNECTED_TIMEOUT is too small. When deleting and creating a new pod, tasks like tickerLockMaster and tickerUpdateNodeStatus may block the tickerUpdateNodeStatus task, causing the health node to be marked as not available, which results in all plugin states being removed.

![efc5b9e351d22be82ed84328a19e76c](https://github.com/user-attachments/assets/afdeaeef-72e8-470e-b310-c1d35ab6bb20)
