### PR TITLE
enhancement(llm): remove non-required PromptMessages field from LLMResultChunk

### DIFF
--- a/internal/core/dify_invocation/tester/mock.go
+++ b/internal/core/dify_invocation/tester/mock.go
@@ -21,7 +21,6 @@ func (m *MockedDifyInvocation) InvokeLLM(payload *dify_invocation.InvokeLLMReque
 	routine.Submit(nil, func() {
 		stream.Write(model_entities.LLMResultChunk{
 			Model:             model_entities.LLMModel(payload.Model),
-			PromptMessages:    payload.PromptMessages,
 			SystemFingerprint: "test",
 			Delta: model_entities.LLMResultChunkDelta{
 				Index: &[]int{1}[0],
@@ -35,7 +34,6 @@ func (m *MockedDifyInvocation) InvokeLLM(payload *dify_invocation.InvokeLLMReque
 		time.Sleep(100 * time.Millisecond)
 		stream.Write(model_entities.LLMResultChunk{
 			Model:             model_entities.LLMModel(payload.Model),
-			PromptMessages:    payload.PromptMessages,
 			SystemFingerprint: "test",
 			Delta: model_entities.LLMResultChunkDelta{
 				Index: &[]int{1}[0],
@@ -49,7 +47,6 @@ func (m *MockedDifyInvocation) InvokeLLM(payload *dify_invocation.InvokeLLMReque
 		time.Sleep(100 * time.Millisecond)
 		stream.Write(model_entities.LLMResultChunk{
 			Model:             model_entities.LLMModel(payload.Model),
-			PromptMessages:    payload.PromptMessages,
 			SystemFingerprint: "test",
 			Delta: model_entities.LLMResultChunkDelta{
 				Index: &[]int{2}[0],
@@ -63,7 +60,6 @@ func (m *MockedDifyInvocation) InvokeLLM(payload *dify_invocation.InvokeLLMReque
 		time.Sleep(100 * time.Millisecond)
 		stream.Write(model_entities.LLMResultChunk{
 			Model:             model_entities.LLMModel(payload.Model),
-			PromptMessages:    payload.PromptMessages,
 			SystemFingerprint: "test",
 			Delta: model_entities.LLMResultChunkDelta{
 				Index: &[]int{3}[0],
@@ -77,7 +73,6 @@ func (m *MockedDifyInvocation) InvokeLLM(payload *dify_invocation.InvokeLLMReque
 		time.Sleep(100 * time.Millisecond)
 		stream.Write(model_entities.LLMResultChunk{
 			Model:             model_entities.LLMModel(payload.Model),
-			PromptMessages:    payload.PromptMessages,
 			SystemFingerprint: "test",
 			Delta: model_entities.LLMResultChunkDelta{
 				Index: &[]int{3}[0],

--- a/pkg/entities/model_entities/llm.go
+++ b/pkg/entities/model_entities/llm.go
@@ -105,7 +105,7 @@ type PromptMessageContent struct {
 	EncodeFormat string                   `json:"encode_format"`
 	Format       string                   `json:"format"`
 	MimeType     string                   `json:"mime_type"`
-	Detail       string                   `json:"detail"`      // for multi-modal data
+	Detail       string                   `json:"detail"` // for multi-modal data
 }
 
 type PromptMessageToolCall struct {
@@ -184,7 +184,6 @@ type PromptMessageTool struct {
 
 type LLMResultChunk struct {
 	Model             LLMModel            `json:"model" validate:"required"`
-	PromptMessages    []PromptMessage     `json:"prompt_messages" validate:"required,dive"`
 	SystemFingerprint string              `json:"system_fingerprint" validate:"omitempty"`
 	Delta             LLMResultChunkDelta `json:"delta" validate:"required"`
 }


### PR DESCRIPTION
Solves high CPU usage of dify-api container caused by LLMResultChunk decoding

Related: 
- https://github.com/langgenius/dify/issues/17799
- https://github.com/langgenius/dify-official-plugins/issues/648
