### PR TITLE
add `exist` for self.session.storage

### DIFF
--- a/internal/core/dify_invocation/types.go
+++ b/internal/core/dify_invocation/types.go
@@ -96,14 +96,15 @@ type InvokeAppSchema struct {
 type StorageOpt string
 
 const (
-	STORAGE_OPT_GET StorageOpt = "get"
-	STORAGE_OPT_SET StorageOpt = "set"
-	STORAGE_OPT_DEL StorageOpt = "del"
+	STORAGE_OPT_GET   StorageOpt = "get"
+	STORAGE_OPT_SET   StorageOpt = "set"
+	STORAGE_OPT_DEL   StorageOpt = "del"
+	STORAGE_OPT_EXIST StorageOpt = "exist"
 )
 
 func isStorageOpt(fl validator.FieldLevel) bool {
 	opt := StorageOpt(fl.Field().String())
-	return opt == STORAGE_OPT_GET || opt == STORAGE_OPT_SET || opt == STORAGE_OPT_DEL
+	return opt == STORAGE_OPT_GET || opt == STORAGE_OPT_SET || opt == STORAGE_OPT_DEL || opt == STORAGE_OPT_EXIST
 }
 
 func init() {

--- a/internal/core/persistence/persistence.go
+++ b/internal/core/persistence/persistence.go
@@ -137,3 +137,22 @@ func (c *Persistence) Delete(tenantId string, pluginId string, key string) (int6
 
 	return deletedNum, nil
 }
+
+func (c *Persistence) Exist(tenantId string, pluginId string, key string) (int64, error) {
+	existNum, err := cache.Exist(c.getCacheKey(tenantId, pluginId, key))
+	if err != nil {
+		return 0, err
+	}
+	if existNum > 0 {
+		return existNum, nil
+	}
+	
+	isExist, err := c.storage.Exists(tenantId, pluginId, key)
+	if err != nil {
+		return 0, err
+	}
+	if isExist {
+		return 1, nil
+	}
+	return 0, nil
+}

--- a/internal/core/persistence/type.go
+++ b/internal/core/persistence/type.go
@@ -5,4 +5,5 @@ type PersistenceStorage interface {
 	Load(tenant_id string, plugin_checksum string, key string) ([]byte, error)
 	Delete(tenant_id string, plugin_checksum string, key string) error
 	StateSize(tenant_id string, plugin_checksum string, key string) (int64, error)
+	Exists(tenant_id string, plugin_checksum string, key string) (bool, error)
 }

--- a/internal/core/persistence/wrapper.go
+++ b/internal/core/persistence/wrapper.go
@@ -23,15 +23,18 @@ func (s *wrapper) getFilePath(tenant_id string, plugin_checksum string, key stri
 }
 
 func (s *wrapper) Save(tenant_id string, plugin_checksum string, key string, data []byte) error {
-	// save to s3
 	filePath := s.getFilePath(tenant_id, plugin_checksum, key)
 	return s.oss.Save(filePath, data)
 }
 
 func (s *wrapper) Load(tenant_id string, plugin_checksum string, key string) ([]byte, error) {
-	// load from s3
 	filePath := s.getFilePath(tenant_id, plugin_checksum, key)
 	return s.oss.Load(filePath)
+}
+
+func (s *wrapper) Exists(tenant_id string, plugin_checksum string, key string) (bool, error) {
+	filePath := s.getFilePath(tenant_id, plugin_checksum, key)
+	return s.oss.Exists(filePath)
 }
 
 func (s *wrapper) Delete(tenant_id string, plugin_checksum string, key string) error {

--- a/internal/core/plugin_daemon/backwards_invocation/task.go
+++ b/internal/core/plugin_daemon/backwards_invocation/task.go
@@ -541,6 +541,18 @@ func executeDifyInvocationStorageTask(
 			"data":        "ok",
 			"deleted_num": deletedNum,
 		})
+	} else if request.Opt == dify_invocation.STORAGE_OPT_EXIST {
+		existNum, err := persistence.Exist(tenantId, pluginId.PluginID(), request.Key)
+		if err != nil {
+			handle.WriteError(fmt.Errorf("exist data failed: %s", err.Error()))
+			return
+		}
+		isExist := existNum > 0
+
+		handle.WriteResponse("struct", map[string]any{
+			"data":      isExist,
+			"exist_num": existNum,
+		})
 	}
 }
 


### PR DESCRIPTION
Currently,  get or delete a non-existent key will raises an exception, although this is a common operation. 

On the other hand, we can use the storage as a pipeline, frequently retrieving data from it. This results in numerous error logs on the daemon. Using 'exists' can significantly reduce these error logs.