### PR TITLE
feat: support NO_PROXY for initialization process

### DIFF
--- a/internal/core/plugin_manager/launcher.go
+++ b/internal/core/plugin_manager/launcher.go
@@ -136,6 +136,7 @@ func (p *PluginManager) launchLocal(pluginUniqueIdentifier plugin_entities.Plugi
 		PythonCompileAllExtraArgs: p.pythonCompileAllExtraArgs,
 		HttpProxy:                 p.HttpProxy,
 		HttpsProxy:                p.HttpsProxy,
+		NoProxy:                   p.NoProxy,
 		PipMirrorUrl:              p.pipMirrorUrl,
 		PipPreferBinary:           p.pipPreferBinary,
 		PipExtraArgs:              p.pipExtraArgs,

--- a/internal/core/plugin_manager/local_runtime/environment_python.go
+++ b/internal/core/plugin_manager/local_runtime/environment_python.go
@@ -133,6 +133,9 @@ func (p *LocalPluginRuntime) InitPythonEnvironment() error {
 	if p.HttpsProxy != "" {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("HTTPS_PROXY=%s", p.HttpsProxy))
 	}
+	if p.NoProxy != "" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("NO_PROXY=%s", p.NoProxy))
+	}
 	cmd.Dir = p.State.WorkingPath
 
 	// get stdout and stderr

--- a/internal/core/plugin_manager/local_runtime/run.go
+++ b/internal/core/plugin_manager/local_runtime/run.go
@@ -39,6 +39,9 @@ func (r *LocalPluginRuntime) getCmd() (*exec.Cmd, error) {
 		if r.HttpProxy != "" {
 			cmd.Env = append(cmd.Env, fmt.Sprintf("HTTP_PROXY=%s", r.HttpProxy))
 		}
+		if r.NoProxy != "" {
+			cmd.Env = append(cmd.Env, fmt.Sprintf("NO_PROXY=%s", r.NoProxy))
+		}
 		return cmd, nil
 	}
 

--- a/internal/core/plugin_manager/local_runtime/type.go
+++ b/internal/core/plugin_manager/local_runtime/type.go
@@ -35,6 +35,7 @@ type LocalPluginRuntime struct {
 	// proxy settings
 	HttpProxy  string
 	HttpsProxy string
+	NoProxy    string
 
 	waitChanLock    sync.Mutex
 	waitStartedChan []chan bool
@@ -52,6 +53,7 @@ type LocalPluginRuntimeConfig struct {
 	PythonCompileAllExtraArgs string
 	HttpProxy                 string
 	HttpsProxy                string
+	NoProxy                   string
 	PipMirrorUrl              string
 	PipPreferBinary           bool
 	PipVerbose                bool
@@ -66,6 +68,7 @@ func NewLocalPluginRuntime(config LocalPluginRuntimeConfig) *LocalPluginRuntime 
 		pythonCompileAllExtraArgs:    config.PythonCompileAllExtraArgs,
 		HttpProxy:                    config.HttpProxy,
 		HttpsProxy:                   config.HttpsProxy,
+		NoProxy:                      config.NoProxy,
 		pipMirrorUrl:                 config.PipMirrorUrl,
 		pipPreferBinary:              config.PipPreferBinary,
 		pipVerbose:                   config.PipVerbose,

--- a/internal/core/plugin_manager/manager.go
+++ b/internal/core/plugin_manager/manager.go
@@ -65,6 +65,7 @@ type PluginManager struct {
 	// proxy settings
 	HttpProxy  string
 	HttpsProxy string
+	NoProxy    string
 
 	// pip mirror url
 	pipMirrorUrl string
@@ -125,6 +126,7 @@ func InitGlobalManager(oss oss.OSS, configuration *app.Config) *PluginManager {
 		platform:                         configuration.Platform,
 		HttpProxy:                        configuration.HttpProxy,
 		HttpsProxy:                       configuration.HttpsProxy,
+		NoProxy:                          configuration.NoProxy,
 		pipMirrorUrl:                     configuration.PipMirrorUrl,
 		pipPreferBinary:                  *configuration.PipPreferBinary,
 		pipVerbose:                       *configuration.PipVerbose,

--- a/internal/types/app/config.go
+++ b/internal/types/app/config.go
@@ -130,6 +130,7 @@ type Config struct {
 	// proxy settings
 	HttpProxy  string `envconfig:"HTTP_PROXY"`
 	HttpsProxy string `envconfig:"HTTPS_PROXY"`
+	NoProxy string `envconfig:"NO_PROXY"`
 
 	// log settings
 	HealthApiLogEnabled *bool `envconfig:"HEALTH_API_LOG_ENABLED"`


### PR DESCRIPTION
## Description

This PR adds support for `NO_PROXY` environment variable for initialization process.

Closes #168

## Test

Pass the following environment variables and try to install any plugin.

```yaml
    environment:
      HTTP_PROXY: http://proxy.example.com:8080/
      HTTPS_PROXY: http://proxy.example.com:8080/
      NO_PROXY: pypi.org,pythonhosted.org
```

Note that `http://proxy.example.com:8080/` is a non-existing proxy, so all traffic which is routed through the proxy, it will always fail.
However, if `NO_PROXY` works, the installation should succeed.

### Before

Even though `pypi.org` is in `NO_PROXY`, it is routed through a proxy, which causes installation to fail.

```bash
2025-04-12 23:42:40 2025/04/12 14:42:40 runtime_lifetime.go:80: [INFO]init environment for plugin langgenius/openai:0.0.16
2025-04-12 23:42:45 2025/04/12 14:42:45 runtime_lifetime.go:86: [ERROR]init environment failed: failed to install dependencies: exit status 2, output: error: Failed to fetch: `https://pypi.org/simple/dify-plugin/`
2025-04-12 23:42:45   Caused by: Could not connect, are you offline?
2025-04-12 23:42:45   Caused by: Request failed after 3 retries
2025-04-12 23:42:45   Caused by: error sending request for url (https://pypi.org/simple/dify-plugin/)
2025-04-12 23:42:45   Caused by: client error (Connect)
2025-04-12 23:42:45   Caused by: dns error: failed to lookup address information: Name or service not known
2025-04-12 23:42:45   Caused by: failed to lookup address information: Name or service not known
2025-04-12 23:42:45 , retry in 30s
```

### After

Installation success without any errors.

```bash
2025-04-12 23:45:48 2025/04/12 14:45:48 runtime_lifetime.go:80: [INFO]init environment for plugin langgenius/openai:0.0.16
2025-04-12 23:45:51 2025/04/12 14:45:51 environment_python.go:294: [INFO]pre-compiling langgenius/openai:0.0.16 - Listing '.'......
2025-04-12 23:45:51 2025/04/12 14:45:51 environment_python.go:294: [INFO]pre-compiling langgenius/openai:0.0.16 - Compiling './.venv/lib/python3.12/site-packages/dify_plugin/config/config.py'......
2025-04-12 23:45:51 2025/04/12 14:45:51 environment_python.go:294: [INFO]pre-compiling langgenius/openai:0.0.16 - Compiling './.venv/lib/python3.12/site-packages/dify_plugin/interfaces/model/speech2text_model.py'......
2025-04-12 23:45:51 2025/04/12 14:45:51 environment_python.go:294: [INFO]pre-compiling langgenius/openai:0.0.16 - Compiling './.venv/lib/python3.12/site-packages/dpkt/stp.py'......
2025-04-12 23:45:51 2025/04/12 14:45:51 environment_python.go:294: [INFO]pre-compiling langgenius/openai:0.0.16 - Compiling './.venv/lib/python3.12/site-packages/gevent/resolver/thread.py'......
2025-04-12 23:45:51 2025/04/12 14:45:51 environment_python.go:294: [INFO]pre-compiling langgenius/openai:0.0.16 - Compiling './.venv/lib/python3.12/site-packages/gevent/tests/test__greenlet.py'......
2025-04-12 23:45:51 2025/04/12 14:45:51 environment_python.go:294: [INFO]pre-compiling langgenius/openai:0.0.16 - Compiling './.venv/lib/python3.12/site-packages/gevent/win32util.py'......
2025-04-12 23:45:52 2025/04/12 14:45:52 environment_python.go:294: [INFO]pre-compiling langgenius/openai:0.0.16 - Compiling './.venv/lib/python3.12/site-packages/httpx/_multipart.py'......
2025-04-12 23:45:52 2025/04/12 14:45:52 environment_python.go:294: [INFO]pre-compiling langgenius/openai:0.0.16 - Compiling './.venv/lib/python3.12/site-packages/numpy/_utils/_pep440.py'......
2025-04-12 23:45:52 2025/04/12 14:45:52 environment_python.go:294: [INFO]pre-compiling langgenius/openai:0.0.16 - Compiling './.venv/lib/python3.12/site-packages/numpy/core/tests/test_dlpack.py'......
2025-04-12 23:45:53 2025/04/12 14:45:53 environment_python.go:294: [INFO]pre-compiling langgenius/openai:0.0.16 - Listing './.venv/lib/python3.12/site-packages/numpy/f2py/tests/src/return_complex'......
2025-04-12 23:45:53 2025/04/12 14:45:53 environment_python.go:294: [INFO]pre-compiling langgenius/openai:0.0.16 - Compiling './.venv/lib/python3.12/site-packages/numpy/lib/ufunclike.py'......
2025-04-12 23:45:53 2025/04/12 14:45:53 environment_python.go:294: [INFO]pre-compiling langgenius/openai:0.0.16 - Compiling './.venv/lib/python3.12/site-packages/numpy/testing/setup.py'......
2025-04-12 23:45:53 2025/04/12 14:45:53 environment_python.go:294: [INFO]pre-compiling langgenius/openai:0.0.16 - Compiling './.venv/lib/python3.12/site-packages/openai/cli/_api/__init__.py'......
2025-04-12 23:45:53 2025/04/12 14:45:53 environment_python.go:294: [INFO]pre-compiling langgenius/openai:0.0.16 - Compiling './.venv/lib/python3.12/site-packages/openai/resources/uploads/uploads.py'......
2025-04-12 23:45:53 2025/04/12 14:45:53 environment_python.go:294: [INFO]pre-compiling langgenius/openai:0.0.16 - Compiling './.venv/lib/python3.12/site-packages/openai/types/beta/realtime/input_audio_buffer_committed_event.py'......
2025-04-12 23:45:53 2025/04/12 14:45:53 environment_python.go:294: [INFO]pre-compiling langgenius/openai:0.0.16 - Compiling './.venv/lib/python3.12/site-packages/openai/types/beta/threads/run.py'......
2025-04-12 23:45:53 2025/04/12 14:45:53 environment_python.go:294: [INFO]pre-compiling langgenius/openai:0.0.16 - Compiling './.venv/lib/python3.12/site-packages/openai/types/chat/chat_completion_user_message_param.py'......
2025-04-12 23:45:53 2025/04/12 14:45:53 environment_python.go:294: [INFO]pre-compiling langgenius/openai:0.0.16 - Listing './.venv/lib/python3.12/site-packages/pkg_resources/tests/data/my-test-package_unpacked-egg/my_test_package-1.0-py3.7.egg'......
2025-04-12 23:45:54 2025/04/12 14:45:54 environment_python.go:294: [INFO]pre-compiling langgenius/openai:0.0.16 - Compiling './.venv/lib/python3.12/site-packages/pydantic/v1/class_validators.py'......
2025-04-12 23:45:54 2025/04/12 14:45:54 environment_python.go:294: [INFO]pre-compiling langgenius/openai:0.0.16 - Compiling './.venv/lib/python3.12/site-packages/setuptools/_distutils/command/build_scripts.py'......
2025-04-12 23:45:54 2025/04/12 14:45:54 environment_python.go:294: [INFO]pre-compiling langgenius/openai:0.0.16 - Compiling './.venv/lib/python3.12/site-packages/setuptools/_distutils/versionpredicate.py'......
2025-04-12 23:45:54 2025/04/12 14:45:54 environment_python.go:294: [INFO]pre-compiling langgenius/openai:0.0.16 - Compiling './.venv/lib/python3.12/site-packages/setuptools/_vendor/packaging/utils.py'......
2025-04-12 23:45:54 2025/04/12 14:45:54 environment_python.go:294: [INFO]pre-compiling langgenius/openai:0.0.16 - Compiling './.venv/lib/python3.12/site-packages/setuptools/command/build_ext.py'......
2025-04-12 23:45:54 2025/04/12 14:45:54 environment_python.go:294: [INFO]pre-compiling langgenius/openai:0.0.16 - Compiling './.venv/lib/python3.12/site-packages/setuptools/tests/test_distutils_adoption.py'......
2025-04-12 23:45:54 2025/04/12 14:45:54 environment_python.go:294: [INFO]pre-compiling langgenius/openai:0.0.16 - Compiling './.venv/lib/python3.12/site-packages/urllib3/_request_methods.py'......
2025-04-12 23:45:55 2025/04/12 14:45:55 environment_python.go:294: [INFO]pre-compiling langgenius/openai:0.0.16 - Compiling './.venv/lib/python3.12/site-packages/yaml/emitter.py'......
2025-04-12 23:45:55 2025/04/12 14:45:55 environment_python.go:327: [INFO]pre-loaded the plugin langgenius/openai:0.0.16
2025-04-12 23:45:55 2025/04/12 14:45:55 run.go:144: [INFO]plugin langgenius/openai:0.0.16 started
2025-04-12 23:45:56 2025/04/12 14:45:56 stdio.go:160: [INFO]plugin langgenius/openai:0.0.16: Installed model: openai
```