### PR TITLE
fix(persistence): correct path traversal checks in tests and implementation

### DIFF
--- a/internal/core/persistence/persistence.go
+++ b/internal/core/persistence/persistence.go
@@ -3,6 +3,7 @@ package persistence
 import (
 	"encoding/hex"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/langgenius/dify-plugin-daemon/internal/db"
@@ -24,7 +25,18 @@ func (c *Persistence) getCacheKey(tenantId string, pluginId string, key string) 
 	return fmt.Sprintf("%s:%s:%s:%s", CACHE_KEY_PREFIX, tenantId, pluginId, key)
 }
 
+func (c *Persistence) checkPathTraversal(key string) error {
+	if strings.Contains(key, "..") || strings.Contains(key, "//") || strings.Contains(key, "\\") {
+		return fmt.Errorf("invalid key: path traversal attempt detected")
+	}
+	return nil
+}
+
 func (c *Persistence) Save(tenantId string, pluginId string, maxSize int64, key string, data []byte) error {
+	if err := c.checkPathTraversal(key); err != nil {
+		return err
+	}
+
 	if len(key) > 256 {
 		return fmt.Errorf("key length must be less than 256 characters")
 	}
@@ -85,6 +97,10 @@ func (c *Persistence) Save(tenantId string, pluginId string, maxSize int64, key 
 
 // TODO: raises specific error to avoid confusion
 func (c *Persistence) Load(tenantId string, pluginId string, key string) ([]byte, error) {
+	if err := c.checkPathTraversal(key); err != nil {
+		return nil, err
+	}
+
 	// check if the key exists in cache
 	h, err := cache.GetString(c.getCacheKey(tenantId, pluginId, key))
 	if err != nil && err != cache.ErrNotFound {
@@ -146,7 +162,7 @@ func (c *Persistence) Exist(tenantId string, pluginId string, key string) (int64
 	if existNum > 0 {
 		return existNum, nil
 	}
-	
+
 	isExist, err := c.storage.Exists(tenantId, pluginId, key)
 	if err != nil {
 		return 0, err

--- a/internal/core/persistence/persistence.go
+++ b/internal/core/persistence/persistence.go
@@ -3,6 +3,7 @@ package persistence
 import (
 	"encoding/hex"
 	"fmt"
+	"path"
 	"strings"
 	"time"
 
@@ -26,6 +27,7 @@ func (c *Persistence) getCacheKey(tenantId string, pluginId string, key string) 
 }
 
 func (c *Persistence) checkPathTraversal(key string) error {
+	key = path.Clean(key)
 	if strings.Contains(key, "..") || strings.Contains(key, "//") || strings.Contains(key, "\\") {
 		return fmt.Errorf("invalid key: path traversal attempt detected")
 	}

--- a/internal/core/persistence/persistence_test.go
+++ b/internal/core/persistence/persistence_test.go
@@ -198,7 +198,7 @@ func TestPersistencePathTraversal(t *testing.T) {
 		{
 			name:    "double slash",
 			key:     "test//test.txt",
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name:    "backslash",
@@ -208,7 +208,7 @@ func TestPersistencePathTraversal(t *testing.T) {
 		{
 			name:    "mixed traversal",
 			key:     "test/../test.txt",
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name:    "absolute path",
@@ -232,7 +232,7 @@ func TestPersistencePathTraversal(t *testing.T) {
 			}
 
 			// Test Delete
-			err = persistence.Delete("tenant_id", "plugin_checksum", tc.key)
+			_, err = persistence.Delete("tenant_id", "plugin_checksum", tc.key)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("Delete() error = %v, wantErr %v", err, tc.wantErr)
 			}

--- a/internal/core/persistence/persistence_test.go
+++ b/internal/core/persistence/persistence_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/langgenius/dify-plugin-daemon/internal/types/app"
 	"github.com/langgenius/dify-plugin-daemon/internal/utils/cache"
 	"github.com/langgenius/dify-plugin-daemon/internal/utils/strings"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestPersistenceStoreAndLoad(t *testing.T) {
@@ -39,18 +40,11 @@ func TestPersistenceStoreAndLoad(t *testing.T) {
 
 	key := strings.RandomString(10)
 
-	if err := persistence.Save("tenant_id", "plugin_checksum", -1, key, []byte("data")); err != nil {
-		t.Fatalf("Failed to save data: %v", err)
-	}
+	assert.Nil(t, persistence.Save("tenant_id", "plugin_checksum", -1, key, []byte("data")))
 
 	data, err := persistence.Load("tenant_id", "plugin_checksum", key)
-	if err != nil {
-		t.Fatalf("Failed to load data: %v", err)
-	}
-
-	if string(data) != "data" {
-		t.Fatalf("Data mismatch: %s", data)
-	}
+	assert.Nil(t, err)
+	assert.Equal(t, string(data), "data")
 
 	// check if the file exists
 	if _, err := oss.Load("./persistence_storage/tenant_id/plugin_checksum/" + key); err != nil {
@@ -59,25 +53,16 @@ func TestPersistenceStoreAndLoad(t *testing.T) {
 
 	// check if cache is updated
 	cacheData, err := cache.GetString("persistence:cache:tenant_id:plugin_checksum:" + key)
-	if err != nil {
-		t.Fatalf("Failed to get cache data: %v", err)
-	}
+	assert.Nil(t, err)
 
 	cacheDataBytes, err := hex.DecodeString(cacheData)
-	if err != nil {
-		t.Fatalf("Failed to decode cache data: %v", err)
-	}
-
-	if string(cacheDataBytes) != "data" {
-		t.Fatalf("Cache data mismatch: %s", cacheData)
-	}
+	assert.Nil(t, err)
+	assert.Equal(t, string(cacheDataBytes), "data")
 }
 
 func TestPersistenceSaveAndLoadWithLongKey(t *testing.T) {
 	err := cache.InitRedisClient("localhost:6379", "difyai123456", false, 0)
-	if err != nil {
-		t.Fatalf("Failed to init redis client: %v", err)
-	}
+	assert.Nil(t, err)
 	defer cache.Close()
 	db.Init(&app.Config{
 		DBType:     "postgresql",
@@ -104,9 +89,7 @@ func TestPersistenceSaveAndLoadWithLongKey(t *testing.T) {
 
 func TestPersistenceDelete(t *testing.T) {
 	err := cache.InitRedisClient("localhost:6379", "difyai123456", false, 0)
-	if err != nil {
-		t.Fatalf("Failed to init redis client: %v", err)
-	}
+	assert.Nil(t, err)
 	defer cache.Close()
 	db.Init(&app.Config{
 		DBType:     "postgresql",
@@ -143,9 +126,7 @@ func TestPersistenceDelete(t *testing.T) {
 
 	// check if cache is updated
 	_, err = cache.GetString("persistence:cache:tenant_id:plugin_checksum:" + key)
-	if err != cache.ErrNotFound {
-		t.Fatalf("Cache data not deleted: %v", err)
-	}
+	assert.Equal(t, err, cache.ErrNotFound)
 }
 
 func TestPersistencePathTraversal(t *testing.T) {
@@ -221,21 +202,15 @@ func TestPersistencePathTraversal(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Test Save
 			err := persistence.Save("tenant_id", "plugin_checksum", -1, tc.key, []byte("data"))
-			if err != nil && !tc.wantErr {
-				t.Errorf("Save() error = %v, wantErr %v", err, tc.wantErr)
-			}
+			assert.Equal(t, err != nil, tc.wantErr)
 
 			// Test Load
 			_, err = persistence.Load("tenant_id", "plugin_checksum", tc.key)
-			if (err != nil) != tc.wantErr {
-				t.Errorf("Load() error = %v, wantErr %v", err, tc.wantErr)
-			}
+			assert.Equal(t, err != nil, tc.wantErr)
 
 			// Test Delete
 			_, err = persistence.Delete("tenant_id", "plugin_checksum", tc.key)
-			if (err != nil) != tc.wantErr {
-				t.Errorf("Delete() error = %v, wantErr %v", err, tc.wantErr)
-			}
+			assert.Equal(t, err != nil, tc.wantErr)
 		})
 	}
 }

--- a/internal/core/persistence/wrapper.go
+++ b/internal/core/persistence/wrapper.go
@@ -1,9 +1,7 @@
 package persistence
 
 import (
-	"fmt"
 	"path"
-	"strings"
 
 	"github.com/langgenius/dify-plugin-daemon/internal/oss"
 )
@@ -21,31 +19,17 @@ func NewWrapper(oss oss.OSS, persistenceStoragePath string) *wrapper {
 }
 
 func (s *wrapper) getFilePath(tenant_id string, plugin_checksum string, key string) string {
-	// Check for path traversal attempts
-	if strings.Contains(key, "..") || strings.Contains(key, "//") || strings.Contains(key, "\\") {
-		return ""
-	}
-
-	// Clean the key to remove any potential path traversal attempts
 	key = path.Clean(key)
-
-	// Join the paths
 	return path.Join(s.persistenceStoragePath, tenant_id, plugin_checksum, key)
 }
 
 func (s *wrapper) Save(tenant_id string, plugin_checksum string, key string, data []byte) error {
 	filePath := s.getFilePath(tenant_id, plugin_checksum, key)
-	if filePath == "" {
-		return fmt.Errorf("invalid key: path traversal attempt detected")
-	}
 	return s.oss.Save(filePath, data)
 }
 
 func (s *wrapper) Load(tenant_id string, plugin_checksum string, key string) ([]byte, error) {
 	filePath := s.getFilePath(tenant_id, plugin_checksum, key)
-	if filePath == "" {
-		return nil, fmt.Errorf("invalid key: path traversal attempt detected")
-	}
 	return s.oss.Load(filePath)
 }
 
@@ -56,17 +40,11 @@ func (s *wrapper) Exists(tenant_id string, plugin_checksum string, key string) (
 
 func (s *wrapper) Delete(tenant_id string, plugin_checksum string, key string) error {
 	filePath := s.getFilePath(tenant_id, plugin_checksum, key)
-	if filePath == "" {
-		return fmt.Errorf("invalid key: path traversal attempt detected")
-	}
 	return s.oss.Delete(filePath)
 }
 
 func (s *wrapper) StateSize(tenant_id string, plugin_checksum string, key string) (int64, error) {
 	filePath := s.getFilePath(tenant_id, plugin_checksum, key)
-	if filePath == "" {
-		return 0, fmt.Errorf("invalid key: path traversal attempt detected")
-	}
 	state, err := s.oss.State(filePath)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
fix(persistence): correct path traversal checks in tests and implementation
    
    - Updated test cases to expect no errors for valid paths with double slashes and mixed traversal.
    - Enhanced the `checkPathTraversal` method to clean the key using `path.Clean` to prevent path traversal vulnerabilities.
    - Removed redundant checks in the `getFilePath`, `Save`, `Load`, and `Delete` methods, simplifying the code while maintaining security.