### PR TITLE
feat(invocation): add FetchApp method to backwards invocations

### DIFF
--- a/internal/core/dify_invocation/invcation.go
+++ b/internal/core/dify_invocation/invcation.go
@@ -33,4 +33,6 @@ type BackwardsInvocation interface {
 	InvokeSummary(payload *InvokeSummaryRequest) (*InvokeSummaryResponse, error)
 	// UploadFile
 	UploadFile(payload *UploadFileRequest) (*UploadFileResponse, error)
+	// FetchApp
+	FetchApp(payload *FetchAppRequest) (map[string]any, error)
 }

--- a/internal/core/dify_invocation/real/http_request.go
+++ b/internal/core/dify_invocation/real/http_request.go
@@ -169,3 +169,20 @@ func (i *RealBackwardsInvocation) InvokeSummary(payload *dify_invocation.InvokeS
 func (i *RealBackwardsInvocation) UploadFile(payload *dify_invocation.UploadFileRequest) (*dify_invocation.UploadFileResponse, error) {
 	return Request[dify_invocation.UploadFileResponse](i, "POST", "upload/file/request", http_requests.HttpPayloadJson(payload))
 }
+
+func (i *RealBackwardsInvocation) FetchApp(payload *dify_invocation.FetchAppRequest) (map[string]any, error) {
+	type resp struct {
+		Data map[string]any `json:"data,omitempty"`
+	}
+
+	data, err := Request[resp](i, "POST", "fetch/app/info", http_requests.HttpPayloadJson(payload))
+	if err != nil {
+		return nil, err
+	}
+
+	if data.Data == nil {
+		return nil, fmt.Errorf("data is nil")
+	}
+
+	return data.Data, nil
+}

--- a/internal/core/dify_invocation/tester/mock.go
+++ b/internal/core/dify_invocation/tester/mock.go
@@ -320,3 +320,9 @@ func (m *MockedDifyInvocation) UploadFile(payload *dify_invocation.UploadFileReq
 		URL: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
 	}, nil
 }
+
+func (m *MockedDifyInvocation) FetchApp(payload *dify_invocation.FetchAppRequest) (map[string]any, error) {
+	return map[string]any{
+		"name": "test",
+	}, nil
+}

--- a/internal/core/dify_invocation/types.go
+++ b/internal/core/dify_invocation/types.go
@@ -31,6 +31,7 @@ const (
 	INVOKE_TYPE_ENCRYPT                  InvokeType = "encrypt"
 	INVOKE_TYPE_SYSTEM_SUMMARY           InvokeType = "system_summary"
 	INVOKE_TYPE_UPLOAD_FILE              InvokeType = "upload_file"
+	INVOKE_TYPE_FETCH_APP                InvokeType = "fetch_app"
 )
 
 type InvokeLLMSchema struct {
@@ -256,4 +257,9 @@ type UploadFileRequest struct {
 
 type UploadFileResponse struct {
 	URL string `json:"url"`
+}
+
+type FetchAppRequest struct {
+	BaseInvokeDifyRequest
+	AppId string `json:"app_id" validate:"required"`
 }

--- a/internal/core/plugin_daemon/backwards_invocation/task.go
+++ b/internal/core/plugin_daemon/backwards_invocation/task.go
@@ -148,6 +148,12 @@ var (
 			},
 			"error": "permission denied, you need to enable storage access in plugin manifest",
 		},
+		dify_invocation.INVOKE_TYPE_FETCH_APP: {
+			"func": func(declaration *plugin_entities.PluginDeclaration) bool {
+				return declaration.Resource.Permission.AllowInvokeApp()
+			},
+			"error": "permission denied, you need to enable app access in plugin manifest",
+		},
 	}
 )
 
@@ -240,6 +246,9 @@ var (
 		},
 		dify_invocation.INVOKE_TYPE_UPLOAD_FILE: func(handle *BackwardsInvocation) {
 			genericDispatchTask(handle, executeDifyInvocationUploadFileTask)
+		},
+		dify_invocation.INVOKE_TYPE_FETCH_APP: func(handle *BackwardsInvocation) {
+			genericDispatchTask(handle, executeDifyInvocationFetchAppTask)
 		},
 	}
 )
@@ -576,6 +585,19 @@ func executeDifyInvocationUploadFileTask(
 	response, err := handle.backwardsInvocation.UploadFile(request)
 	if err != nil {
 		handle.WriteError(fmt.Errorf("upload file failed: %s", err.Error()))
+		return
+	}
+
+	handle.WriteResponse("struct", response)
+}
+
+func executeDifyInvocationFetchAppTask(
+	handle *BackwardsInvocation,
+	request *dify_invocation.FetchAppRequest,
+) {
+	response, err := handle.backwardsInvocation.FetchApp(request)
+	if err != nil {
+		handle.WriteError(fmt.Errorf("fetch app failed: %s", err.Error()))
 		return
 	}
 


### PR DESCRIPTION
- Introduced FetchApp method in BackwardsInvocation interface to retrieve application data.
- Implemented FetchAppRequest type for request payload with required AppId field.
- Updated RealBackwardsInvocation to handle FetchApp requests and return application data.
- Added mock implementation for FetchApp in the testing suite.
- Enhanced task handling in plugin daemon to support FetchApp invocation.