### PR TITLE
 Add optional Redis username authentication

### DIFF
--- a/internal/cluster/clutser_test.go
+++ b/internal/cluster/clutser_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func createSimulationCluster(nums int) ([]*Cluster, error) {
-	err := cache.InitRedisClient("0.0.0.0:6379", "difyai123456", false, 0)
+	err := cache.InitRedisClient("0.0.0.0:6379", "", "difyai123456", false, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/core/persistence/persistence_test.go
+++ b/internal/core/persistence/persistence_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestPersistenceStoreAndLoad(t *testing.T) {
-	err := cache.InitRedisClient("localhost:6379", "difyai123456", false, 0)
+	err := cache.InitRedisClient("localhost:6379", "", "difyai123456", false, 0)
 	if err != nil {
 		t.Fatalf("Failed to init redis client: %v", err)
 	}
@@ -61,7 +61,7 @@ func TestPersistenceStoreAndLoad(t *testing.T) {
 }
 
 func TestPersistenceSaveAndLoadWithLongKey(t *testing.T) {
-	err := cache.InitRedisClient("localhost:6379", "difyai123456", false, 0)
+	err := cache.InitRedisClient("localhost:6379", "", "difyai123456", false, 0)
 	assert.Nil(t, err)
 	defer cache.Close()
 	db.Init(&app.Config{
@@ -88,7 +88,7 @@ func TestPersistenceSaveAndLoadWithLongKey(t *testing.T) {
 }
 
 func TestPersistenceDelete(t *testing.T) {
-	err := cache.InitRedisClient("localhost:6379", "difyai123456", false, 0)
+	err := cache.InitRedisClient("localhost:6379", "", "difyai123456", false, 0)
 	assert.Nil(t, err)
 	defer cache.Close()
 	db.Init(&app.Config{
@@ -130,7 +130,7 @@ func TestPersistenceDelete(t *testing.T) {
 }
 
 func TestPersistencePathTraversal(t *testing.T) {
-	err := cache.InitRedisClient("localhost:6379", "difyai123456", false, 0)
+	err := cache.InitRedisClient("localhost:6379", "", "difyai123456", false, 0)
 	if err != nil {
 		t.Fatalf("Failed to init redis client: %v", err)
 	}

--- a/internal/core/plugin_manager/debugging_runtime/connection_key_test.go
+++ b/internal/core/plugin_manager/debugging_runtime/connection_key_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestConnectionKey(t *testing.T) {
-	err := cache.InitRedisClient("0.0.0.0:6379", "difyai123456", false, 0)
+	err := cache.InitRedisClient("0.0.0.0:6379", "", "difyai123456", false, 0)
 	if err != nil {
 		t.Errorf("init redis client failed: %v", err)
 		return

--- a/internal/core/plugin_manager/debugging_runtime/server_test.go
+++ b/internal/core/plugin_manager/debugging_runtime/server_test.go
@@ -112,7 +112,7 @@ func TestLaunchAndClosePluginServer(t *testing.T) {
 
 // TestAcceptConnection tests the acceptance of the connection
 func TestAcceptConnection(t *testing.T) {
-	if cache.InitRedisClient("0.0.0.0:6379", "difyai123456", false, 0) != nil {
+	if cache.InitRedisClient("0.0.0.0:6379", "", "difyai123456", false, 0) != nil {
 		t.Errorf("failed to init redis client")
 		return
 	}
@@ -348,7 +348,7 @@ func TestNoHandleShakeIn10Seconds(t *testing.T) {
 }
 
 func TestIncorrectHandshake(t *testing.T) {
-	if cache.InitRedisClient("0.0.0.0:6379", "difyai123456", false, 0) != nil {
+	if cache.InitRedisClient("0.0.0.0:6379", "", "difyai123456", false, 0) != nil {
 		t.Errorf("failed to init redis client")
 		return
 	}

--- a/internal/core/plugin_manager/manager.go
+++ b/internal/core/plugin_manager/manager.go
@@ -171,6 +171,7 @@ func (p *PluginManager) Launch(configuration *app.Config) {
 	// init redis client
 	if err := cache.InitRedisClient(
 		fmt.Sprintf("%s:%d", configuration.RedisHost, configuration.RedisPort),
+		configuration.RedisUser,
 		configuration.RedisPass,
 		configuration.RedisUseSsl,
 		configuration.RedisDB,

--- a/internal/types/app/config.go
+++ b/internal/types/app/config.go
@@ -67,6 +67,7 @@ type Config struct {
 	RedisHost   string `envconfig:"REDIS_HOST" validate:"required"`
 	RedisPort   uint16 `envconfig:"REDIS_PORT" validate:"required"`
 	RedisPass   string `envconfig:"REDIS_PASSWORD"`
+	RedisUser   string `envconfig:"REDIS_USERNAME"`
 	RedisUseSsl bool   `envconfig:"REDIS_USE_SSL"`
 	RedisDB     int    `envconfig:"REDIS_DB"`
 

--- a/internal/utils/cache/redis.go
+++ b/internal/utils/cache/redis.go
@@ -20,9 +20,10 @@ var (
 	ErrNotFound  = errors.New("key not found")
 )
 
-func getRedisOptions(addr, password string, useSsl bool, db int) *redis.Options {
+func getRedisOptions(addr, username, password string, useSsl bool, db int) *redis.Options {
 	opts := &redis.Options{
 		Addr:     addr,
+		Username: username,
 		Password: password,
 		DB:       db,
 	}
@@ -32,8 +33,8 @@ func getRedisOptions(addr, password string, useSsl bool, db int) *redis.Options 
 	return opts
 }
 
-func InitRedisClient(addr, password string, useSsl bool, db int) error {
-	opts := getRedisOptions(addr, password, useSsl, db)
+func InitRedisClient(addr, username, password string, useSsl bool, db int) error {
+	opts := getRedisOptions(addr, username, password, useSsl, db)
 	client = redis.NewClient(opts)
 
 	if _, err := client.Ping(ctx).Result(); err != nil {

--- a/internal/utils/cache/redis_auto_type_test.go
+++ b/internal/utils/cache/redis_auto_type_test.go
@@ -10,7 +10,7 @@ type TestAutoTypeStruct struct {
 }
 
 func TestAutoType(t *testing.T) {
-	if err := InitRedisClient("127.0.0.1:6379", "difyai123456", false, 0); err != nil {
+	if err := InitRedisClient("127.0.0.1:6379", "", "difyai123456", false, 0); err != nil {
 		t.Fatal(err)
 	}
 	defer Close()
@@ -35,7 +35,7 @@ func TestAutoType(t *testing.T) {
 }
 
 func TestAutoTypeWithGetter(t *testing.T) {
-	if err := InitRedisClient("127.0.0.1:6379", "difyai123456", false, 0); err != nil {
+	if err := InitRedisClient("127.0.0.1:6379", "", "difyai123456", false, 0); err != nil {
 		t.Fatal(err)
 	}
 	defer Close()

--- a/internal/utils/cache/redis_test.go
+++ b/internal/utils/cache/redis_test.go
@@ -15,7 +15,7 @@ const (
 )
 
 func getRedisConnection() error {
-	return InitRedisClient("0.0.0.0:6379", "difyai123456", false, 0)
+	return InitRedisClient("0.0.0.0:6379", "", "difyai123456", false, 0)
 }
 
 func TestRedisConnection(t *testing.T) {
@@ -269,13 +269,13 @@ func TestRedisP2ARedis(t *testing.T) {
 }
 
 func TestGetRedisOptions(t *testing.T) {
-	opts := getRedisOptions("dummy:6379", "password", false, 0)
+	opts := getRedisOptions("dummy:6379", "", "password", false, 0)
 	if opts.TLSConfig != nil {
 		t.Errorf("TLSConfig should not be set")
 		return
 	}
 
-	opts = getRedisOptions("dummy:6379", "password", true, 0)
+	opts = getRedisOptions("dummy:6379", "", "password", true, 0)
 	if opts.TLSConfig == nil {
 		t.Errorf("TLSConfig should be set")
 		return
@@ -283,7 +283,7 @@ func TestGetRedisOptions(t *testing.T) {
 }
 
 func TestSetAndGet(t *testing.T) {
-	if err := InitRedisClient("127.0.0.1:6379", "difyai123456", false, 0); err != nil {
+	if err := InitRedisClient("127.0.0.1:6379", "", "difyai123456", false, 0); err != nil {
 		t.Fatal(err)
 	}
 	defer Close()


### PR DESCRIPTION
issue #144 related

This pull request introduces support for authenticating Redis connections using both a username and a password. This enhances compatibility with Redis hosting providers like AWS ElastiCache that require username-based authentication in addition to a password.
Motivation:
Modern Redis deployments, particularly managed services like ElastiCache (with RBAC enabled), often mandate the use of a username for authentication alongside the password. The previous implementation only supported password authentication, preventing connections to these types of Redis instances.
Changes:
Configuration: Added a new optional configuration field RedisUser to internal/types/app/config.go, loaded from the REDIS_USERNAME environment variable.
Redis Client: Modified getRedisOptions and InitRedisClient in internal/utils/cache/redis.go to accept and utilize the Username parameter when creating the redis.Options.
Initialization: Updated the Launch function in internal/core/plugin_manager/manager.go to pass the configuration.RedisUser value during Redis client initialization.
Impact:
This change is backward compatible. If the REDIS_USERNAME environment variable is not set or is empty, the client will continue to authenticate using only the password (via the AUTH <password> command).
If REDIS_USERNAME is set, the client will attempt authentication using AUTH <username> <password>.
Introduces the new environment variable REDIS_USERNAME.
How to Test:
Configure the application to connect to a Redis instance requiring username/password auth. Set the REDIS_HOST, REDIS_PORT, REDIS_PASSWORD, and the new REDIS_USERNAME environment variables. Verify the application starts and connects successfully.
Configure the application to connect to a Redis instance requiring only password auth. Set REDIS_HOST, REDIS_PORT, and REDIS_PASSWORD, but do not set REDIS_USERNAME. Verify the application starts and connects successfully. 