### PR TITLE
feat: add windows compatibility (#133)

### DIFF
--- a/internal/core/plugin_manager/local_runtime/environment_python.go
+++ b/internal/core/plugin_manager/local_runtime/environment_python.go
@@ -10,6 +10,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -32,7 +33,11 @@ func (p *LocalPluginRuntime) InitPythonEnvironment() error {
 			os.RemoveAll(path.Join(p.State.WorkingPath, ".venv"))
 		} else {
 			// setup python interpreter path
-			pythonPath, err := filepath.Abs(path.Join(p.State.WorkingPath, ".venv/bin/python"))
+			pythonExec := ".venv/bin/python"
+			if runtime.GOOS == "windows" {
+				pythonExec = ".venv/Scripts/python.exe"
+			}
+			pythonPath, err := filepath.Abs(path.Join(p.State.WorkingPath, pythonExec))
 			if err != nil {
 				return fmt.Errorf("failed to find python: %s", err)
 			}
@@ -85,7 +90,11 @@ func (p *LocalPluginRuntime) InitPythonEnvironment() error {
 		}
 	}()
 
-	pythonPath, err := filepath.Abs(path.Join(p.State.WorkingPath, ".venv/bin/python"))
+	pythonExec := ".venv/bin/python"
+	if runtime.GOOS == "windows" {
+		pythonExec = ".venv/Scripts/python.exe"
+	}
+	pythonPath, err := filepath.Abs(path.Join(p.State.WorkingPath, pythonExec))
 	if err != nil {
 		return fmt.Errorf("failed to find python: %s", err)
 	}

--- a/internal/core/plugin_manager/local_runtime/run.go
+++ b/internal/core/plugin_manager/local_runtime/run.go
@@ -33,6 +33,7 @@ func (r *LocalPluginRuntime) getCmd() (*exec.Cmd, error) {
 		cmd := exec.Command(r.pythonInterpreterPath, "-m", r.Config.Meta.Runner.Entrypoint)
 		cmd.Dir = r.State.WorkingPath
 		cmd.Env = cmd.Environ()
+		cmd.Env = append(cmd.Env, "PYTHONIOENCODING=utf-8") // for windows
 		if r.HttpsProxy != "" {
 			cmd.Env = append(cmd.Env, fmt.Sprintf("HTTPS_PROXY=%s", r.HttpsProxy))
 		}

--- a/internal/core/plugin_manager/media_transport/installed_bucket.go
+++ b/internal/core/plugin_manager/media_transport/installed_bucket.go
@@ -2,6 +2,7 @@ package media_transport
 
 import (
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/langgenius/dify-plugin-daemon/internal/oss"
@@ -22,28 +23,44 @@ func (b *InstalledBucket) Save(
 	plugin_unique_identifier plugin_entities.PluginUniqueIdentifier,
 	file []byte,
 ) error {
-	return b.oss.Save(filepath.Join(b.installedPath, plugin_unique_identifier.String()), file)
+	compat_plugin_unique_identifier := plugin_unique_identifier.String()
+	if runtime.GOOS == "windows" {
+		compat_plugin_unique_identifier = strings.ReplaceAll(plugin_unique_identifier.String(), ":", "$")
+	}
+	return b.oss.Save(filepath.Join(b.installedPath, compat_plugin_unique_identifier), file)
 }
 
 // Exists checks if the plugin exists in the installed bucket
 func (b *InstalledBucket) Exists(
 	plugin_unique_identifier plugin_entities.PluginUniqueIdentifier,
 ) (bool, error) {
-	return b.oss.Exists(filepath.Join(b.installedPath, plugin_unique_identifier.String()))
+	compat_plugin_unique_identifier := plugin_unique_identifier.String()
+	if runtime.GOOS == "windows" {
+		compat_plugin_unique_identifier = strings.ReplaceAll(plugin_unique_identifier.String(), ":", "$")
+	}
+	return b.oss.Exists(filepath.Join(b.installedPath, compat_plugin_unique_identifier))
 }
 
 // Delete deletes the plugin from the installed bucket
 func (b *InstalledBucket) Delete(
 	plugin_unique_identifier plugin_entities.PluginUniqueIdentifier,
 ) error {
-	return b.oss.Delete(filepath.Join(b.installedPath, plugin_unique_identifier.String()))
+	compat_plugin_unique_identifier := plugin_unique_identifier.String()
+	if runtime.GOOS == "windows" {
+		compat_plugin_unique_identifier = strings.ReplaceAll(plugin_unique_identifier.String(), ":", "$")
+	}
+	return b.oss.Delete(filepath.Join(b.installedPath, compat_plugin_unique_identifier))
 }
 
 // Get gets the plugin from the installed bucket
 func (b *InstalledBucket) Get(
 	plugin_unique_identifier plugin_entities.PluginUniqueIdentifier,
 ) ([]byte, error) {
-	return b.oss.Load(filepath.Join(b.installedPath, plugin_unique_identifier.String()))
+	compat_plugin_unique_identifier := plugin_unique_identifier.String()
+	if runtime.GOOS == "windows" {
+		compat_plugin_unique_identifier = strings.ReplaceAll(plugin_unique_identifier.String(), ":", "$")
+	}
+	return b.oss.Load(filepath.Join(b.installedPath, compat_plugin_unique_identifier))
 }
 
 // List lists all the plugins in the installed bucket

--- a/internal/core/plugin_manager/media_transport/package_bucket.go
+++ b/internal/core/plugin_manager/media_transport/package_bucket.go
@@ -2,6 +2,8 @@ package media_transport
 
 import (
 	"path"
+	"runtime"
+	"strings"
 
 	"github.com/langgenius/dify-plugin-daemon/internal/oss"
 )
@@ -17,16 +19,27 @@ func NewPackageBucket(oss oss.OSS, package_path string) *PackageBucket {
 
 // Save saves a file to the package bucket
 func (m *PackageBucket) Save(name string, file []byte) error {
+	if runtime.GOOS == "windows" {
+		name = strings.ReplaceAll(name, ":", "$")
+	}
 	filePath := path.Join(m.packagePath, name)
 
 	return m.oss.Save(filePath, file)
 }
 
 func (m *PackageBucket) Get(name string) ([]byte, error) {
-	return m.oss.Load(path.Join(m.packagePath, name))
+	if runtime.GOOS == "windows" {
+		name = strings.ReplaceAll(name, ":", "$")
+	}
+	filePath := path.Join(m.packagePath, name)
+	return m.oss.Load(filePath)
 }
 
 func (m *PackageBucket) Delete(name string) error {
 	// delete from storage
-	return m.oss.Delete(path.Join(m.packagePath, name))
+	if runtime.GOOS == "windows" {
+		name = strings.ReplaceAll(name, ":", "$")
+	}
+	filePath := path.Join(m.packagePath, name)
+	return m.oss.Delete(filePath)
 }

--- a/internal/oss/local/local_storage.go
+++ b/internal/oss/local/local_storage.go
@@ -66,13 +66,14 @@ func (l *LocalStorage) List(prefix string) ([]oss.OSSPath, error) {
 	if !exists {
 		return paths, nil
 	}
-	prefix = filepath.Join(l.root, prefix)
+	prefix = filepath.ToSlash(filepath.Join(l.root, prefix))
 
 	err = filepath.WalkDir(prefix, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 		// remove prefix
+		path = filepath.ToSlash(path)
 		path = strings.TrimPrefix(path, prefix)
 		if path == "" {
 			return nil

--- a/pkg/entities/plugin_entities/identity.go
+++ b/pkg/entities/plugin_entities/identity.go
@@ -25,6 +25,8 @@ var (
 )
 
 func NewPluginUniqueIdentifier(identifier string) (PluginUniqueIdentifier, error) {
+	identifier = strings.ReplaceAll(identifier, "$", ":") // for windows
+
 	if !pluginUniqueIdentifierRegexp.MatchString(identifier) {
 		return "", errors.New("plugin_unique_identifier is not valid: " + identifier)
 	}

--- a/pkg/plugin_packager/decoder/zip.go
+++ b/pkg/plugin_packager/decoder/zip.go
@@ -248,18 +248,18 @@ func (z *ZipPluginDecoder) UniqueIdentity() (plugin_entities.PluginUniqueIdentif
 func (z *ZipPluginDecoder) ExtractTo(dst string) error {
 	// copy to working directory
 	if err := z.Walk(func(filename, dir string) error {
-		workingPath := path.Join(dst, dir)
+		workingPath := filepath.ToSlash(path.Join(dst, dir))
 		// check if directory exists
 		if err := os.MkdirAll(workingPath, 0755); err != nil {
 			return err
 		}
 
-		bytes, err := z.ReadFile(filepath.Join(dir, filename))
+		bytes, err := z.ReadFile(filepath.ToSlash(filepath.Join(dir, filename)))
 		if err != nil {
 			return err
 		}
 
-		filename = filepath.Join(workingPath, filename)
+		filename = filepath.ToSlash(filepath.Join(workingPath, filename))
 
 		// copy file
 		if err := os.WriteFile(filename, bytes, 0644); err != nil {


### PR DESCRIPTION
add windows compatibility (#133)

1. Use the filepath.ToSlash() function to ensure slash normalization.
2. Temporarily replace (:) with ($) symbols in Win.
3. Force utf8 in Win to avoid garbage string.
4. Compatible paths for python executable programs in Win.