### PR TITLE
chore: align go version in GHA to 1.23

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,9 +16,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v5
+      - name: Setup Go
+        uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: '1.23'
 
       # setup uv and get uv path to env
       - name: Install uv

--- a/.github/workflows/publish-cli.yaml
+++ b/.github/workflows/publish-cli.yaml
@@ -26,10 +26,10 @@ jobs:
           GOARCH=$(echo "${{ matrix.platform }}" | cut -d '/' -f 2)
           echo "GOARCH=$GOARCH" >> $GITHUB_ENV
 
-      - name: Set up Go
+      - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.22.x
+          go-version: '1.23'
 
       - name: Build CLI
         run: |

--- a/.github/workflows/publish-cli.yaml
+++ b/.github/workflows/publish-cli.yaml
@@ -27,7 +27,7 @@ jobs:
           echo "GOARCH=$GOARCH" >> $GITHUB_ENV
 
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: '1.23'
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,10 +49,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup Golang 1.21.6
+      - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21.6'
+          go-version: '1.23'
 
       - name: Setup License
         run: go run cmd/license/generate/main.go


### PR DESCRIPTION
- As Go 1.23 is required in go.mod since #158, all the Go version in Github actions should be updated to 1.23 as well for testing and publishing.