### PR TITLE
feat: add backward compatibility for LLMResultChunk and new test case

### DIFF
--- a/pkg/entities/model_entities/llm.go
+++ b/pkg/entities/model_entities/llm.go
@@ -188,6 +188,22 @@ type LLMResultChunk struct {
 	Delta             LLMResultChunkDelta `json:"delta" validate:"required"`
 }
 
+/*
+This is a compatibility layer for the old LLMResultChunk format.
+The old one has the `PromptMessages` field, we need to ensure the new one is backward compatible.
+*/
+func (l LLMResultChunk) MarshalJSON() ([]byte, error) {
+	type Alias LLMResultChunk
+	type LLMResultChunk struct {
+		Alias
+		PromptMessages []any `json:"prompt_messages"`
+	}
+	return json.Marshal(LLMResultChunk{
+		Alias:          (Alias)(l),
+		PromptMessages: []any{},
+	})
+}
+
 type LLMUsage struct {
 	PromptTokens        *int            `json:"prompt_tokens" validate:"required"`
 	PromptUnitPrice     decimal.Decimal `json:"prompt_unit_price" validate:"required"`

--- a/pkg/entities/model_entities/llm_test.go
+++ b/pkg/entities/model_entities/llm_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/langgenius/dify-plugin-daemon/internal/utils/parser"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFullFunctionPromptMessage(t *testing.T) {
@@ -297,4 +298,17 @@ func TestImagePromptMessage(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+}
+
+func TestLLMResultChunkCompatibility(t *testing.T) {
+	llmResultChunk := LLMResultChunk{
+		Model: "gpt-3.5-turbo",
+	}
+
+	result := parser.MarshalJson(llmResultChunk)
+	assert.Contains(t, string(result), `"prompt_messages":[]`)
+
+	llmResultChunkPointer := &llmResultChunk
+	result = parser.MarshalJson(llmResultChunkPointer)
+	assert.Contains(t, string(result), `"prompt_messages":[]`)
 }


### PR DESCRIPTION
- Implemented a compatibility layer in LLMResultChunk to ensure backward compatibility with the old format by adding a `PromptMessages` field.
- Added a new test case `TestLLMResultChunkCompatibility` to verify the JSON marshaling behavior of the updated LLMResultChunk structure.