### PR TITLE
fix: update moderation model docstring to reflect plugin name correctly

### DIFF
--- a/cmd/commandline/plugin/templates/python/moderation.py
+++ b/cmd/commandline/plugin/templates/python/moderation.py
@@ -5,7 +5,7 @@ from dify_plugin import ModerationModel
 
 class {{ .PluginName | SnakeToCamel }}ModerationModel(ModerationModel):
     """
-    Model class for {{ .PluginName | CamelToTitle }} text moderation model.
+    Model class for {{ .PluginName }} text moderation model.
     """
 
     def _invoke(self, model: str, credentials: dict,


### PR DESCRIPTION
- Modified the docstring in the moderation model to use the correct format for the plugin name, enhancing clarity and consistency in the documentation.