### PR TITLE
feat: add repository URL support for plugin manifest

### DIFF
--- a/cmd/commandline/plugin.go
+++ b/cmd/commandline/plugin.go
@@ -11,6 +11,7 @@ import (
 var (
 	author                   string
 	name                     string
+	repo                     string
 	description              string
 	allowRegisterEndpoint    bool
 	allowInvokeTool          bool
@@ -38,6 +39,7 @@ If no parameters are provided, an interactive mode will be started.`,
 		Run: func(c *cobra.Command, args []string) {
 			author, _ := c.Flags().GetString("author")
 			name, _ := c.Flags().GetString("name")
+			repo, _ := c.Flags().GetString("repo")
 			description, _ := c.Flags().GetString("description")
 			allowRegisterEndpoint, _ := c.Flags().GetBool("allow-register-endpoint")
 			allowInvokeTool, _ := c.Flags().GetBool("allow-invoke-tool")
@@ -60,6 +62,7 @@ If no parameters are provided, an interactive mode will be started.`,
 			plugin.InitPluginWithFlags(
 				author,
 				name,
+				repo,
 				description,
 				allowRegisterEndpoint,
 				allowInvokeTool,
@@ -234,6 +237,7 @@ func init() {
 	pluginInitCommand.Flags().StringVar(&author, "author", "", "Author name (1-64 characters, lowercase letters, numbers, dashes and underscores only)")
 	pluginInitCommand.Flags().StringVar(&name, "name", "", "Plugin name (1-128 characters, lowercase letters, numbers, dashes and underscores only)")
 	pluginInitCommand.Flags().StringVar(&description, "description", "", "Plugin description (cannot be empty)")
+	pluginInitCommand.Flags().StringVar(&repo, "repo", "", "Plugin repository URL (optional)")
 	pluginInitCommand.Flags().BoolVar(&allowRegisterEndpoint, "allow-endpoint", false, "Allow the plugin to register endpoints")
 	pluginInitCommand.Flags().BoolVar(&allowInvokeTool, "allow-tool", false, "Allow the plugin to invoke tools")
 	pluginInitCommand.Flags().BoolVar(&allowInvokeModel, "allow-model", false, "Allow the plugin to invoke models")

--- a/cmd/commandline/plugin/init.go
+++ b/cmd/commandline/plugin/init.go
@@ -39,6 +39,7 @@ func InitPlugin() {
 func InitPluginWithFlags(
 	author string,
 	name string,
+	repo string,
 	description string,
 	allowRegisterEndpoint bool,
 	allowInvokeTool bool,
@@ -345,7 +346,10 @@ func (m model) createPlugin() {
 		},
 	}
 
-	fmt.Println(m.subMenus[SUB_MENU_KEY_VERSION_REQUIRE].(versionRequire).MinimalDifyVersion())
+	repo := m.subMenus[SUB_MENU_KEY_PROFILE].(profile).Repo()
+	if repo != "" {
+		manifest.Repo = parser.ToPtr(repo)
+	}
 
 	categoryString := m.subMenus[SUB_MENU_KEY_CATEGORY].(category).Category()
 	if categoryString == "tool" {

--- a/cmd/commandline/plugin/init_test.go
+++ b/cmd/commandline/plugin/init_test.go
@@ -25,6 +25,7 @@ func TestInitPluginWithFlags(t *testing.T) {
 		testName    string
 		author      string
 		pluginName  string
+		repo        string
 		description string
 		quick       bool
 		permissions struct {
@@ -47,6 +48,7 @@ func TestInitPluginWithFlags(t *testing.T) {
 			testName:    "Quick mode with minimal permissions",
 			author:      "test-author",
 			pluginName:  "test-plugin",
+			repo:        "https://github.com/langgenius/dify-official-plugins",
 			description: "Test plugin description",
 			quick:       true,
 			permissions: struct {
@@ -80,6 +82,7 @@ func TestInitPluginWithFlags(t *testing.T) {
 			testName:    "Quick mode with all permissions",
 			author:      "test-author",
 			pluginName:  "test-plugin-full",
+			repo:        "https://github.com/langgenius/dify-official-plugins",
 			description: "Test plugin with all permissions",
 			quick:       true,
 			permissions: struct {
@@ -122,6 +125,7 @@ func TestInitPluginWithFlags(t *testing.T) {
 			testName:    "Non-quick mode with tool permissions",
 			author:      "test-author",
 			pluginName:  "test-plugin-tool",
+			repo:        "https://github.com/langgenius/dify-official-plugins",
 			description: "Test plugin with tool permissions",
 			quick:       false,
 			permissions: struct {
@@ -157,6 +161,7 @@ func TestInitPluginWithFlags(t *testing.T) {
 			InitPluginWithFlags(
 				tt.author,
 				tt.pluginName,
+				tt.repo,
 				tt.description,
 				tt.permissions.endpoint,
 				tt.permissions.tool,
@@ -261,6 +266,7 @@ func TestInitPluginWithFlagsValidation(t *testing.T) {
 		name        string
 		author      string
 		pluginName  string
+		repo        string
 		description string
 		expectError bool
 	}{
@@ -268,6 +274,7 @@ func TestInitPluginWithFlagsValidation(t *testing.T) {
 			name:        "Valid inputs",
 			author:      "test-author",
 			pluginName:  "test-plugin",
+			repo:        "https://github.com/langgenius/dify-official-plugins",
 			description: "Test description",
 			expectError: false,
 		},
@@ -275,6 +282,7 @@ func TestInitPluginWithFlagsValidation(t *testing.T) {
 			name:        "Invalid author (uppercase)",
 			author:      "Test-Author",
 			pluginName:  "test-plugin",
+			repo:        "https://github.com/langgenius/dify-official-plugins",
 			description: "Test description",
 			expectError: true,
 		},
@@ -282,6 +290,7 @@ func TestInitPluginWithFlagsValidation(t *testing.T) {
 			name:        "Invalid plugin name (uppercase)",
 			author:      "test-author",
 			pluginName:  "Test-Plugin",
+			repo:        "https://github.com/langgenius/dify-official-plugins",
 			description: "Test description",
 			expectError: true,
 		},
@@ -289,6 +298,7 @@ func TestInitPluginWithFlagsValidation(t *testing.T) {
 			name:        "Empty description",
 			author:      "test-author",
 			pluginName:  "test-plugin",
+			repo:        "https://github.com/langgenius/dify-official-plugins",
 			description: "",
 			expectError: true,
 		},
@@ -312,6 +322,7 @@ func TestInitPluginWithFlagsValidation(t *testing.T) {
 			InitPluginWithFlags(
 				tt.author,
 				tt.pluginName,
+				tt.repo,
 				tt.description,
 				false, // allowRegisterEndpoint
 				false, // allowInvokeTool

--- a/cmd/commandline/plugin/profile.go
+++ b/cmd/commandline/plugin/profile.go
@@ -67,7 +67,7 @@ func (p profile) View() string {
 }
 
 func (p *profile) checkRule() bool {
-	if p.inputs[p.cursor].Value() == "" {
+	if p.cursor >= 0 && p.cursor <= 2 && p.inputs[p.cursor].Value() == "" {
 		p.warning = "Name, author and description cannot be empty"
 		return false
 	} else if p.cursor == 0 && !plugin_entities.PluginNameRegex.MatchString(p.inputs[p.cursor].Value()) {

--- a/cmd/commandline/plugin/profile.go
+++ b/cmd/commandline/plugin/profile.go
@@ -32,8 +32,13 @@ func newProfile() profile {
 	description.CharLimit = 1024
 	description.Prompt = "Description (press Enter to next step): "
 
+	repo := ti.New()
+	repo.Placeholder = "Repository URL (Optional)"
+	repo.CharLimit = 128
+	repo.Prompt = "Repository URL (Optional) (press Enter to next step): "
+
 	return profile{
-		inputs: []ti.Model{name, author, description},
+		inputs: []ti.Model{name, author, description, repo},
 	}
 }
 
@@ -49,8 +54,12 @@ func (p profile) Description() string {
 	return p.inputs[2].Value()
 }
 
+func (p profile) Repo() string {
+	return p.inputs[3].Value()
+}
+
 func (p profile) View() string {
-	s := fmt.Sprintf("Edit profile of the plugin\n%s\n%s\n%s\n", p.inputs[0].View(), p.inputs[1].View(), p.inputs[2].View())
+	s := fmt.Sprintf("Edit profile of the plugin\n%s\n%s\n%s\n%s\n", p.inputs[0].View(), p.inputs[1].View(), p.inputs[2].View(), p.inputs[3].View())
 	if p.warning != "" {
 		s += fmt.Sprintf("\033[31m%s\033[0m\n", p.warning)
 	}

--- a/pkg/entities/plugin_entities/plugin_declaration.go
+++ b/pkg/entities/plugin_entities/plugin_declaration.go
@@ -153,6 +153,7 @@ type PluginDeclarationWithoutAdvancedFields struct {
 	Tags        []manifest_entities.PluginTag      `json:"tags" yaml:"tags,omitempty" validate:"omitempty,dive,plugin_tag,max=128"`
 	CreatedAt   time.Time                          `json:"created_at" yaml:"created_at,omitempty" validate:"required"`
 	Privacy     *string                            `json:"privacy,omitempty" yaml:"privacy,omitempty" validate:"omitempty"`
+	Repo        *string                            `json:"repo,omitempty" yaml:"repo,omitempty" validate:"omitempty,url"`
 }
 
 func (p *PluginDeclarationWithoutAdvancedFields) UnmarshalJSON(data []byte) error {


### PR DESCRIPTION
Related PR:
- https://github.com/langgenius/dify-plugin-sdks/pull/134
- https://github.com/langgenius/dify/pull/19337

feat: add repository URL support for plugin manifest
    
- Introduced a new optional flag for specifying the plugin repository URL during initialization.
- Updated the InitPluginWithFlags function to handle the new repository parameter.
- Enhanced profile management to include repository input.
- Modified related tests to validate the new repository functionality.