### PR TITLE
feat: allow skipping Python plugin precompilation

### DIFF
--- a/internal/core/plugin_manager/launcher.go
+++ b/internal/core/plugin_manager/launcher.go
@@ -142,6 +142,7 @@ func (p *PluginManager) launchLocal(pluginUniqueIdentifier plugin_entities.Plugi
 		PipExtraArgs:              p.pipExtraArgs,
 		StdoutBufferSize:          p.pluginStdioBufferSize,
 		StdoutMaxBufferSize:       p.pluginStdioMaxBufferSize,
+		SkipPrecompilation:        p.skipPrecompilation,
 	})
 	localPluginRuntime.PluginRuntime = plugin.runtime
 	localPluginRuntime.BasicChecksum = basic_runtime.BasicChecksum{

--- a/internal/core/plugin_manager/local_runtime/environment_python.go
+++ b/internal/core/plugin_manager/local_runtime/environment_python.go
@@ -266,6 +266,9 @@ func (p *LocalPluginRuntime) InitPythonEnvironment() error {
 }
 
 func precompilePlugin(p *LocalPluginRuntime, ctx context.Context, pythonPath string) error {
+	if p.skipPrecompilation {
+		return nil
+	}
 	compileArgs := []string{"-m", "compileall"}
 	if p.pythonCompileAllExtraArgs != "" {
 		compileArgs = append(compileArgs, strings.Split(p.pythonCompileAllExtraArgs, " ")...)

--- a/internal/core/plugin_manager/local_runtime/type.go
+++ b/internal/core/plugin_manager/local_runtime/type.go
@@ -47,6 +47,8 @@ type LocalPluginRuntime struct {
 	isNotFirstStart bool
 
 	stdioHolder *stdioHolder
+
+	skipPrecompilation bool
 }
 
 type LocalPluginRuntimeConfig struct {
@@ -63,6 +65,7 @@ type LocalPluginRuntimeConfig struct {
 	PipExtraArgs              string
 	StdoutBufferSize          int
 	StdoutMaxBufferSize       int
+	SkipPrecompilation        bool
 }
 
 func NewLocalPluginRuntime(config LocalPluginRuntimeConfig) *LocalPluginRuntime {
@@ -80,5 +83,6 @@ func NewLocalPluginRuntime(config LocalPluginRuntimeConfig) *LocalPluginRuntime 
 		pipExtraArgs:                 config.PipExtraArgs,
 		stdoutBufferSize:             config.StdoutBufferSize,
 		stdoutMaxBufferSize:          config.StdoutMaxBufferSize,
+		skipPrecompilation:           config.SkipPrecompilation,
 	}
 }

--- a/internal/core/plugin_manager/manager.go
+++ b/internal/core/plugin_manager/manager.go
@@ -97,6 +97,9 @@ type PluginManager struct {
 	// plugin stdio buffer size
 	pluginStdioBufferSize    int
 	pluginStdioMaxBufferSize int
+
+	// skip plugin pre-compilation
+	skipPrecompilation bool
 }
 
 var (
@@ -138,6 +141,7 @@ func InitGlobalManager(oss oss.OSS, configuration *app.Config) *PluginManager {
 		serverlessConnectorLaunchTimeout: configuration.DifyPluginServerlessConnectorLaunchTimeout,
 		pluginStdioBufferSize:            configuration.PluginStdioBufferSize,
 		pluginStdioMaxBufferSize:         configuration.PluginStdioMaxBufferSize,
+		skipPrecompilation:               *configuration.SkipPrecompilation,
 	}
 
 	return manager

--- a/internal/types/app/config.go
+++ b/internal/types/app/config.go
@@ -155,6 +155,9 @@ type Config struct {
 	DifyInvocationWriteTimeout int64 `envconfig:"DIFY_BACKWARDS_INVOCATION_WRITE_TIMEOUT" default:"5000"`
 	// dify invocation read timeout in milliseconds
 	DifyInvocationReadTimeout int64 `envconfig:"DIFY_BACKWARDS_INVOCATION_READ_TIMEOUT" default:"240000"`
+
+	// skip plugin precompilation
+	SkipPrecompilation *bool `envconfig:"SKIP_PRECOMPILATION" default:"false"`
 }
 
 func (c *Config) Validate() error {


### PR DESCRIPTION
- add `SkipPrecompilation` config to allow skip Python plugin precompilation, which is handy to speed-up local plugin launching to skip overhead time cost in pre-compiling all the Python scripts and its dependency in each plugin