### PR TITLE
chore: dockerfile improvements

### DIFF
--- a/docker/local.dockerfile
+++ b/docker/local.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-alpine as builder
+FROM golang:1.23-alpine AS builder
 
 ARG VERSION=unknown
 
@@ -24,9 +24,6 @@ RUN chmod +x /app/entrypoint.sh
 
 FROM ubuntu:24.04
 
-COPY --from=builder /app/main /app/main
-COPY --from=builder /app/entrypoint.sh /app/entrypoint.sh
-
 WORKDIR /app
 
 # check build args
@@ -51,6 +48,8 @@ RUN mv /usr/lib/python3.12/EXTERNALLY-MANAGED /usr/lib/python3.12/EXTERNALLY-MAN
 ENV UV_PATH=/usr/local/bin/uv
 ENV PLATFORM=$PLATFORM
 ENV GIN_MODE=release
+
+COPY --from=builder /app/main /app/entrypoint.sh /app/
 
 # run the server, using sh as the entrypoint to avoid process being the root process
 # and using bash to recycle resources

--- a/docker/serverless.dockerfile
+++ b/docker/serverless.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-alpine as builder
+FROM golang:1.23-alpine AS builder
 
 ARG VERSION=unknown
 
@@ -20,8 +20,6 @@ RUN CGO_ENABLED=0 go build \
 
 FROM alpine:latest
 
-COPY --from=builder /app/main /app/main
-
 WORKDIR /app
 
 # check build args
@@ -29,6 +27,8 @@ ARG PLATFORM=serverless
 
 ENV PLATFORM=$PLATFORM
 ENV GIN_MODE=release
+
+COPY --from=builder /app/main /app/main
 
 # run the server
 CMD ["./main"]


### PR DESCRIPTION
- dockerfile improvements
  - correct `FROM ... as` to `FROM ... AS` for setting base image, eliminating the warning message in docker image build `WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)`
  - move the copying action of `main` to latter steps , to reuse the previous built layer as many as possible especially for repeated builds and also help to extraction layer compressions earlier for image pulling
  - squeeze the file copying into single command to reduce image layers