### PR TITLE
fix: update stdio buffer size configuration in stdioHolder

### DIFF
--- a/internal/core/plugin_manager/local_runtime/stdio.go
+++ b/internal/core/plugin_manager/local_runtime/stdio.go
@@ -138,7 +138,7 @@ func (s *stdioHolder) StartStdout(notify_heartbeat func()) {
 	scanner := bufio.NewScanner(s.reader)
 
 	// TODO: set a reasonable buffer size or use a reader, this is a temporary solution
-	scanner.Buffer(make([]byte, 1024), 5*1024*1024)
+	scanner.Buffer(make([]byte, s.stdoutBufferSize), s.stdoutMaxBufferSize)
 
 	for scanner.Scan() {
 		data := scanner.Bytes()


### PR DESCRIPTION
Fixes #254

- Adjusted the buffer size settings in the stdioHolder to utilize configurable values for stdout buffer size and maximum buffer size, enhancing flexibility in plugin output handling.