### PR TITLE
feat(redis): Add support for Redis Sentinel mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,6 +62,18 @@ REDIS_PORT=6379
 REDIS_PASSWORD=difyai123456
 REDIS_DB=0
 
+# Whether to use Redis Sentinel mode.
+# If set to true, the application will automatically discover and connect to the master node through Sentinel.
+REDIS_USE_SENTINEL=false
+
+# List of Redis Sentinel nodes. If Sentinel mode is enabled, provide at least one Sentinel IP and port.
+# Format: `<sentinel1_ip>:<sentinel1_port>,<sentinel2_ip>:<sentinel2_port>,<sentinel3_ip>:<sentinel3_port>`
+REDIS_SENTINELS=
+REDIS_SENTINEL_SERVICE_NAME=
+REDIS_SENTINEL_USERNAME=
+REDIS_SENTINEL_PASSWORD=
+REDIS_SENTINEL_SOCKET_TIMEOUT=0.1
+
 DB_USERNAME=postgres
 DB_PASSWORD=difyai123456
 DB_HOST=localhost

--- a/internal/core/plugin_manager/manager.go
+++ b/internal/core/plugin_manager/manager.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/langgenius/dify-plugin-daemon/internal/core/dify_invocation"
 	"github.com/langgenius/dify-plugin-daemon/internal/core/dify_invocation/real"
@@ -175,14 +176,31 @@ func (p *PluginManager) Launch(configuration *app.Config) {
 	log.Info("start plugin manager daemon...")
 
 	// init redis client
-	if err := cache.InitRedisClient(
-		fmt.Sprintf("%s:%d", configuration.RedisHost, configuration.RedisPort),
-		configuration.RedisUser,
-		configuration.RedisPass,
-		configuration.RedisUseSsl,
-		configuration.RedisDB,
-	); err != nil {
-		log.Panic("init redis client failed: %s", err.Error())
+	if configuration.RedisUseSentinel {
+		// use Redis Sentinel
+		sentinels := strings.Split(configuration.RedisSentinels, ",")
+		if err := cache.InitRedisSentinelClient(
+			sentinels,
+			configuration.RedisSentinelServiceName,
+			configuration.RedisPass,
+			configuration.RedisSentinelUsername,
+			configuration.RedisSentinelPassword,
+			configuration.RedisUseSsl,
+			configuration.RedisDB,
+			configuration.RedisSentinelSocketTimeout,
+		); err != nil {
+			log.Panic("init redis sentinel client failed: %s", err.Error())
+		}
+	} else {
+		if err := cache.InitRedisClient(
+			fmt.Sprintf("%s:%d", configuration.RedisHost, configuration.RedisPort),
+			configuration.RedisUser,
+			configuration.RedisPass,
+			configuration.RedisUseSsl,
+			configuration.RedisDB,
+		); err != nil {
+			log.Panic("init redis client failed: %s", err.Error())
+		}
 	}
 
 	invocation, err := real.NewDifyInvocationDaemon(

--- a/internal/core/plugin_manager/manager.go
+++ b/internal/core/plugin_manager/manager.go
@@ -182,6 +182,7 @@ func (p *PluginManager) Launch(configuration *app.Config) {
 		if err := cache.InitRedisSentinelClient(
 			sentinels,
 			configuration.RedisSentinelServiceName,
+			configuration.RedisUser,
 			configuration.RedisPass,
 			configuration.RedisSentinelUsername,
 			configuration.RedisSentinelPassword,

--- a/internal/types/app/config.go
+++ b/internal/types/app/config.go
@@ -79,6 +79,14 @@ type Config struct {
 	RedisUseSsl bool   `envconfig:"REDIS_USE_SSL"`
 	RedisDB     int    `envconfig:"REDIS_DB"`
 
+	// redis sentinel
+	RedisUseSentinel           bool    `envconfig:"REDIS_USE_SENTINEL"`
+	RedisSentinels             string  `envconfig:"REDIS_SENTINELS"`
+	RedisSentinelServiceName   string  `envconfig:"REDIS_SENTINEL_SERVICE_NAME"`
+	RedisSentinelUsername      string  `envconfig:"REDIS_SENTINEL_USERNAME"`
+	RedisSentinelPassword      string  `envconfig:"REDIS_SENTINEL_PASSWORD"`
+	RedisSentinelSocketTimeout float64 `envconfig:"REDIS_SENTINEL_SOCKET_TIMEOUT"`
+
 	// database
 	DBType            string `envconfig:"DB_TYPE" default:"postgresql"`
 	DBUsername        string `envconfig:"DB_USERNAME" validate:"required"`

--- a/internal/utils/cache/redis.go
+++ b/internal/utils/cache/redis.go
@@ -44,10 +44,11 @@ func InitRedisClient(addr, username, password string, useSsl bool, db int) error
 	return nil
 }
 
-func InitRedisSentinelClient(sentinels []string, masterName, password, sentinelUsername, sentinelPassword string, useSsl bool, db int, socketTimeout float64) error {
+func InitRedisSentinelClient(sentinels []string, masterName, username, password, sentinelUsername, sentinelPassword string, useSsl bool, db int, socketTimeout float64) error {
 	opts := &redis.FailoverOptions{
 		MasterName:       masterName,
 		SentinelAddrs:    sentinels,
+		Username:         username,
 		Password:         password,
 		DB:               db,
 		SentinelUsername: sentinelUsername,

--- a/internal/utils/cache/redis.go
+++ b/internal/utils/cache/redis.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	client *redis.Client
+	client redis.UniversalClient
 	ctx    = context.Background()
 
 	ErrDBNotInit = errors.New("redis client not init")
@@ -36,6 +36,33 @@ func getRedisOptions(addr, username, password string, useSsl bool, db int) *redi
 func InitRedisClient(addr, username, password string, useSsl bool, db int) error {
 	opts := getRedisOptions(addr, username, password, useSsl, db)
 	client = redis.NewClient(opts)
+
+	if _, err := client.Ping(ctx).Result(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func InitRedisSentinelClient(sentinels []string, masterName, password, sentinelUsername, sentinelPassword string, useSsl bool, db int, socketTimeout float64) error {
+	opts := &redis.FailoverOptions{
+		MasterName:       masterName,
+		SentinelAddrs:    sentinels,
+		Password:         password,
+		DB:               db,
+		SentinelUsername: sentinelUsername,
+		SentinelPassword: sentinelPassword,
+	}
+
+	if useSsl {
+		opts.TLSConfig = &tls.Config{}
+	}
+
+	if socketTimeout > 0 {
+		opts.DialTimeout = time.Duration(socketTimeout * float64(time.Second))
+	}
+
+	client = redis.NewFailoverClient(opts)
 
 	if _, err := client.Ping(ctx).Result(); err != nil {
 		return err


### PR DESCRIPTION
Added support for Redis Sentinel mode to the Redis client, enabling automatic discovery and connection to the primary node through Sentinel. Updated relevant configuration files and initialization logic to support Sentinel mode configuration and connection.

refs: https://github.com/langgenius/dify-plugin-daemon/issues/274