### PR TITLE
fix:fix gorm id specified twice when use mysql,make field.HasDefaultV…

### DIFF
--- a/internal/db/mysql/dialector.go
+++ b/internal/db/mysql/dialector.go
@@ -35,7 +35,8 @@ func (migrator myMigrator) FullDataTypeOf(field *schema.Field) clause.Expr {
 	if field.DataType == "uuid" {
 		field.DataType = "char(36)"
 		if field.HasDefaultValue && field.DefaultValue == "uuid_generate_v4()" {
-			field.HasDefaultValue = false
+			// issue: https://github.com/go-gorm/gorm/issues/5893
+			// field.HasDefaultValue = false
 			field.DefaultValue = ""
 			var fieldsWithDefault []*schema.Field
 			for _, fieldWithDefault := range field.Schema.FieldsWithDefaultDBValue {


### PR DESCRIPTION
When use mysql,Column 'id' specified twice when generate the sql

Failed to insert into MySQL, referred to this Gorm issue `https://github.com/go-gorm/gorm/issues/5893` and fix the error.
![image](https://github.com/user-attachments/assets/05c3ec25-1c72-407f-88cc-1db7ad9a48f0)
