### PR TITLE
feat: add plugin reinstallation functionality and admin API support

### DIFF
--- a/internal/core/plugin_manager/serverless.go
+++ b/internal/core/plugin_manager/serverless.go
@@ -93,3 +93,10 @@ func (p *PluginManager) getServerlessPluginRuntimeModel(
 
 	return runtime, nil
 }
+
+func (p *PluginManager) clearServerlessRuntimeCache(
+	identity plugin_entities.PluginUniqueIdentifier,
+) error {
+	_, err := cache.Del(p.getServerlessRuntimeCacheKey(identity))
+	return err
+}

--- a/internal/server/constants/constants.go
+++ b/internal/server/constants/constants.go
@@ -1,8 +1,9 @@
 package constants
 
 const (
-	X_PLUGIN_ID = "X-Plugin-ID"
-	X_API_KEY   = "X-Api-Key"
+	X_PLUGIN_ID     = "X-Plugin-ID"
+	X_API_KEY       = "X-Api-Key"
+	X_ADMIN_API_KEY = "X-Admin-Api-Key"
 
 	CONTEXT_KEY_PLUGIN_INSTALLATION      = "plugin_installation"
 	CONTEXT_KEY_PLUGIN_UNIQUE_IDENTIFIER = "plugin_unique_identifier"

--- a/internal/server/controllers/plugins.go
+++ b/internal/server/controllers/plugins.go
@@ -35,12 +35,12 @@ func UploadPlugin(app *app.Config) gin.HandlerFunc {
 
 		tenantId := c.Param("tenant_id")
 		if tenantId == "" {
-			c.JSON(http.StatusOK, exception.BadRequestError(errors.New("Tenant ID is required")).ToResponse())
+			c.JSON(http.StatusOK, exception.BadRequestError(errors.New("tenant ID is required")).ToResponse())
 			return
 		}
 
 		if difyPkgFileHeader.Size > app.MaxPluginPackageSize {
-			c.JSON(http.StatusOK, exception.BadRequestError(errors.New("File size exceeds the maximum limit")).ToResponse())
+			c.JSON(http.StatusOK, exception.BadRequestError(errors.New("file size exceeds the maximum limit")).ToResponse())
 			return
 		}
 
@@ -67,12 +67,12 @@ func UploadBundle(app *app.Config) gin.HandlerFunc {
 
 		tenantId := c.Param("tenant_id")
 		if tenantId == "" {
-			c.JSON(http.StatusOK, exception.BadRequestError(errors.New("Tenant ID is required")).ToResponse())
+			c.JSON(http.StatusOK, exception.BadRequestError(errors.New("tenant ID is required")).ToResponse())
 			return
 		}
 
 		if difyBundleFileHeader.Size > app.MaxBundlePackageSize {
-			c.JSON(http.StatusOK, exception.BadRequestError(errors.New("File size exceeds the maximum limit")).ToResponse())
+			c.JSON(http.StatusOK, exception.BadRequestError(errors.New("file size exceeds the maximum limit")).ToResponse())
 			return
 		}
 
@@ -136,6 +136,16 @@ func InstallPluginFromIdentifiers(app *app.Config) gin.HandlerFunc {
 			c.JSON(http.StatusOK, service.InstallPluginFromIdentifiers(
 				app, request.TenantID, request.PluginUniqueIdentifiers, request.Source, request.Metas,
 			))
+		})
+	}
+}
+
+func ReinstallPluginFromIdentifier(app *app.Config) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		BindRequest(c, func(request struct {
+			PluginUniqueIdentifier plugin_entities.PluginUniqueIdentifier `json:"plugin_unique_identifier" validate:"required,plugin_unique_identifier"`
+		}) {
+			service.ReinstallPluginFromIdentifier(c, app, request.PluginUniqueIdentifier)
 		})
 	}
 }

--- a/internal/server/http_server.go
+++ b/internal/server/http_server.go
@@ -181,7 +181,7 @@ func (app *App) pluginManagementGroup(group *gin.RouterGroup, config *app.Config
 }
 
 func (app *App) adminGroup(group *gin.RouterGroup, config *app.Config) {
-	group.POST("/plugins/reinstall", controllers.ReinstallPluginFromIdentifier(config))
+	group.POST("/plugin/serverless/reinstall", controllers.ReinstallPluginFromIdentifier(config))
 }
 
 func (app *App) pluginAssetGroup(group *gin.RouterGroup) {

--- a/internal/server/http_server.go
+++ b/internal/server/http_server.go
@@ -34,6 +34,17 @@ func (app *App) server(config *app.Config) func() {
 	pluginGroup := engine.Group("/plugin/:tenant_id")
 	pprofGroup := engine.Group("/debug/pprof")
 
+	if config.AdminApiEnabled {
+		if len(config.AdminApiKey) < 10 {
+			log.Panic("length of admin api key must be greater than 10")
+		}
+
+		adminGroup := engine.Group("/admin")
+		adminGroup.Use(app.AdminAPIKey(config.AdminApiKey))
+
+		app.adminGroup(adminGroup, config)
+	}
+
 	if config.SentryEnabled {
 		// setup sentry for all groups
 		sentryGroup := []*gin.RouterGroup{
@@ -167,6 +178,10 @@ func (app *App) pluginManagementGroup(group *gin.RouterGroup, config *app.Config
 	group.POST("/tools/check_existence", controllers.CheckToolExistence)
 	group.GET("/agent_strategies", controllers.ListAgentStrategies)
 	group.GET("/agent_strategy", controllers.GetAgentStrategy)
+}
+
+func (app *App) adminGroup(group *gin.RouterGroup, config *app.Config) {
+	group.POST("/plugins/reinstall", controllers.ReinstallPluginFromIdentifier(config))
 }
 
 func (app *App) pluginAssetGroup(group *gin.RouterGroup) {

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -170,3 +170,14 @@ func (app *App) InitClusterID() gin.HandlerFunc {
 		ctx.Next()
 	}
 }
+
+func (app *App) AdminAPIKey(key string) gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		if ctx.GetHeader(constants.X_ADMIN_API_KEY) != key {
+			ctx.AbortWithStatusJSON(401, exception.UnauthorizedError().ToResponse())
+			return
+		}
+
+		ctx.Next()
+	}
+}

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -174,7 +174,7 @@ func (app *App) InitClusterID() gin.HandlerFunc {
 func (app *App) AdminAPIKey(key string) gin.HandlerFunc {
 	return func(ctx *gin.Context) {
 		if ctx.GetHeader(constants.X_ADMIN_API_KEY) != key {
-			ctx.AbortWithStatusJSON(401, exception.UnauthorizedError().ToResponse())
+			ctx.AbortWithStatusJSON(401, gin.H{"message": "unauthorized"})
 			return
 		}
 

--- a/internal/types/app/config.go
+++ b/internal/types/app/config.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fmt"
+
 	"github.com/langgenius/dify-plugin-daemon/internal/oss"
 
 	"github.com/go-playground/validator/v10"
@@ -11,6 +12,10 @@ type Config struct {
 	// server
 	ServerPort uint16 `envconfig:"SERVER_PORT" validate:"required"`
 	ServerKey  string `envconfig:"SERVER_KEY" validate:"required"`
+
+	// admin api enable
+	AdminApiEnabled bool   `envconfig:"ADMIN_API_ENABLED" default:"false"`
+	AdminApiKey     string `envconfig:"ADMIN_API_KEY"`
 
 	// dify inner api
 	DifyInnerApiURL string `envconfig:"DIFY_INNER_API_URL" validate:"required"`


### PR DESCRIPTION
- Implemented ReinstallToAWSFromPkg method to allow reinstallation of plugins on AWS Lambda, updating function URL and name.
- Added clearServerlessRuntimeCache method to manage serverless runtime cache.
- Enhanced LaunchPlugin to support an ignoreIdempotent flag for forced reinstallation.
- Introduced admin API endpoints for plugin reinstallation, secured with an API key validation middleware.
- Updated configuration to include AdminApiEnabled and AdminApiKey settings.