### PR TITLE
deduplicate codes in benchmark testing

### DIFF
--- a/internal/core/plugin_manager/local_runtime_benchmark_fake_openai_test.go
+++ b/internal/core/plugin_manager/local_runtime_benchmark_fake_openai_test.go
@@ -1,4 +1,4 @@
-package plugin_manager
+package plugin_manager_test
 
 import (
 	"context"


### PR DESCRIPTION
- Introduced a new test file to implement a fake OpenAI server that streams responses for benchmarking purposes.
- Updated the existing benchmark test to utilize the new fake server, enhancing the testing environment for local plugin runtime invocations.
- Refactored the package name in the benchmark test file for clarity and consistency.