### PR TITLE
fix(lock): Add concurrency test for Redis lock functionality

### DIFF
--- a/internal/utils/cache/redis.go
+++ b/internal/utils/cache/redis.go
@@ -449,7 +449,9 @@ func Lock(key string, expire time.Duration, tryLockTimeout time.Duration, contex
 	defer ticker.Stop()
 
 	for range ticker.C {
-		if _, err := getCmdable(context...).SetNX(ctx, serialKey(key), "1", expire).Result(); err == nil {
+		if success, err := getCmdable(context...).SetNX(ctx, serialKey(key), "1", expire).Result(); err != nil {
+			return err
+		} else if success {
 			return nil
 		}
 


### PR DESCRIPTION
- Introduced a new test case `TestLock` to validate the behavior of the Redis locking mechanism under concurrent access.
- Enhanced the `Lock` function to improve error handling and ensure proper locking behavior.
- Utilized `sync.WaitGroup` and atomic operations to measure wait times during lock acquisition, ensuring the lock behaves as expected under high concurrency.