### PR TITLE
fix(signature): signature dose not work as expected, if upload new pkg to old dify

### DIFF
--- a/internal/service/plugin_decoder.go
+++ b/internal/service/plugin_decoder.go
@@ -61,11 +61,9 @@ func UploadPluginPkg(
 		}
 	}
 
-	verification, _ := decoderInstance.Verification(false)
+	verification, _ := decoderInstance.Verification()
 	if verification == nil && decoderInstance.Verified() {
-		verification = &decoder.Verification{
-			AuthorizedCategory: decoder.AUTHORIZED_CATEGORY_LANGGENIUS,
-		}
+		verification = decoder.DefaultVerification()
 	}
 
 	return entities.NewSuccessResponse(map[string]any{

--- a/pkg/plugin_packager/consts/verification.go
+++ b/pkg/plugin_packager/consts/verification.go
@@ -1,0 +1,5 @@
+package consts
+
+const (
+	VERIFICATION_FILE = ".verification.dify.json"
+)

--- a/pkg/plugin_packager/decoder/decoder.go
+++ b/pkg/plugin_packager/decoder/decoder.go
@@ -45,7 +45,7 @@ type PluginDecoder interface {
 
 	// Verification returns the verification of the plugin, if available
 	// Error will only returns if the plugin is not verified
-	Verification(ignoreVerifySignature bool) (*Verification, error)
+	Verification() (*Verification, error)
 
 	// CreateTime returns the creation time of the plugin as a Unix timestamp
 	CreateTime() (int64, error)

--- a/pkg/plugin_packager/decoder/entities.go
+++ b/pkg/plugin_packager/decoder/entities.go
@@ -11,3 +11,9 @@ const (
 type Verification struct {
 	AuthorizedCategory AuthorizedCategory `json:"authorized_category"`
 }
+
+func DefaultVerification() *Verification {
+	return &Verification{
+		AuthorizedCategory: AUTHORIZED_CATEGORY_LANGGENIUS,
+	}
+}

--- a/pkg/plugin_packager/decoder/fs.go
+++ b/pkg/plugin_packager/decoder/fs.go
@@ -169,7 +169,7 @@ func (d *FSPluginDecoder) CreateTime() (int64, error) {
 	return 0, nil
 }
 
-func (d *FSPluginDecoder) Verification(ignoreVerifySignature bool) (*Verification, error) {
+func (d *FSPluginDecoder) Verification() (*Verification, error) {
 	return nil, nil
 }
 

--- a/pkg/plugin_packager/decoder/verifier.go
+++ b/pkg/plugin_packager/decoder/verifier.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/langgenius/dify-plugin-daemon/internal/core/license/public_key"
 	"github.com/langgenius/dify-plugin-daemon/internal/utils/encryption"
-	"github.com/langgenius/dify-plugin-daemon/internal/utils/parser"
 )
 
 // VerifyPlugin is a function that verifies the signature of a plugin
@@ -96,21 +95,8 @@ func VerifyPluginWithPublicKeys(decoder PluginDecoder, publicKeys []*rsa.PublicK
 		return err
 	}
 
-	// get the verification, at this point, verification is used to verify checksum
-	// just ignore verifying signature
-	verification, err := decoder.Verification(true)
-	if err != nil {
-		return err
-	}
-
 	// write the time into data
 	data.Write([]byte(strconv.FormatInt(createdAt, 10)))
-
-	if verification != nil {
-		// marshal
-		verificationBytes := parser.MarshalJsonBytes(verification)
-		data.Write(verificationBytes)
-	}
 
 	sigBytes, err := base64.StdEncoding.DecodeString(signature)
 	if err != nil {


### PR DESCRIPTION
- Updated the  method in the  interface to remove the  parameter, simplifying its usage.
- Introduced a new  function to provide a default verification structure.
- Added a  file to store verification data, improving the plugin signing process.
- Enhanced tests in  to validate the verification process, ensuring proper handling of success and failure scenarios.
- Refactored related code to accommodate the new verification structure and improve overall maintainability.