### PR TITLE
fix: support serverless plugin management with execution timeout

### DIFF
--- a/internal/core/plugin_manager/manager.go
+++ b/internal/core/plugin_manager/manager.go
@@ -95,6 +95,8 @@ type PluginManager struct {
 	// serverless connector launch timeout
 	serverlessConnectorLaunchTimeout int
 
+	pluginMaxExecutionTimeout int
+
 	// plugin stdio buffer size
 	pluginStdioBufferSize    int
 	pluginStdioMaxBufferSize int
@@ -139,6 +141,7 @@ func InitGlobalManager(oss oss.OSS, configuration *app.Config) *PluginManager {
 		serverlessConnectorLaunchTimeout: configuration.DifyPluginServerlessConnectorLaunchTimeout,
 		pluginStdioBufferSize:            configuration.PluginStdioBufferSize,
 		pluginStdioMaxBufferSize:         configuration.PluginStdioMaxBufferSize,
+		pluginMaxExecutionTimeout:        configuration.PluginMaxExecutionTimeout,
 	}
 
 	return manager

--- a/internal/core/plugin_manager/serverless.go
+++ b/internal/core/plugin_manager/serverless.go
@@ -44,14 +44,15 @@ func (p *PluginManager) getServerlessPluginRuntime(
 	runtimeEntity.InitState()
 
 	// convert to plugin runtime
-	pluginRuntime := serverless_runtime.AWSPluginRuntime{
+	pluginRuntime := serverless_runtime.ServerlessPluginRuntime{
 		BasicChecksum: basic_runtime.BasicChecksum{
 			MediaTransport: basic_runtime.NewMediaTransport(p.mediaBucket),
 			InnerChecksum:  model.Checksum,
 		},
-		PluginRuntime: runtimeEntity,
-		LambdaURL:     model.FunctionURL,
-		LambdaName:    model.FunctionName,
+		PluginRuntime:             runtimeEntity,
+		LambdaURL:                 model.FunctionURL,
+		LambdaName:                model.FunctionName,
+		PluginMaxExecutionTimeout: p.pluginMaxExecutionTimeout,
 	}
 
 	if err := pluginRuntime.InitEnvironment(); err != nil {

--- a/internal/core/plugin_manager/serverless_runtime/environment.go
+++ b/internal/core/plugin_manager/serverless_runtime/environment.go
@@ -9,7 +9,7 @@ import (
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/plugin_entities"
 )
 
-func (r *AWSPluginRuntime) InitEnvironment() error {
+func (r *ServerlessPluginRuntime) InitEnvironment() error {
 	// init http client
 	r.client = &http.Client{
 		Transport: &http.Transport{
@@ -24,7 +24,7 @@ func (r *AWSPluginRuntime) InitEnvironment() error {
 	return nil
 }
 
-func (r *AWSPluginRuntime) Identity() (plugin_entities.PluginUniqueIdentifier, error) {
+func (r *ServerlessPluginRuntime) Identity() (plugin_entities.PluginUniqueIdentifier, error) {
 	checksum, err := r.Checksum()
 	if err != nil {
 		return "", err

--- a/internal/core/plugin_manager/serverless_runtime/run.go
+++ b/internal/core/plugin_manager/serverless_runtime/run.go
@@ -2,14 +2,14 @@ package serverless_runtime
 
 import "github.com/langgenius/dify-plugin-daemon/pkg/entities/plugin_entities"
 
-func (r *AWSPluginRuntime) StartPlugin() error {
+func (r *ServerlessPluginRuntime) StartPlugin() error {
 	return nil
 }
 
-func (r *AWSPluginRuntime) Wait() (<-chan bool, error) {
+func (r *ServerlessPluginRuntime) Wait() (<-chan bool, error) {
 	return nil, nil
 }
 
-func (r *AWSPluginRuntime) Type() plugin_entities.PluginRuntimeType {
+func (r *ServerlessPluginRuntime) Type() plugin_entities.PluginRuntimeType {
 	return plugin_entities.PLUGIN_RUNTIME_TYPE_SERVERLESS
 }

--- a/internal/core/plugin_manager/serverless_runtime/type.go
+++ b/internal/core/plugin_manager/serverless_runtime/type.go
@@ -9,7 +9,7 @@ import (
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/plugin_entities"
 )
 
-type AWSPluginRuntime struct {
+type ServerlessPluginRuntime struct {
 	basic_runtime.BasicChecksum
 	plugin_entities.PluginRuntime
 
@@ -21,4 +21,6 @@ type AWSPluginRuntime struct {
 	listeners mapping.Map[string, *entities.Broadcast[plugin_entities.SessionMessage]]
 
 	client *http.Client
+
+	PluginMaxExecutionTimeout int // in seconds
 }

--- a/internal/utils/http_requests/http_options.go
+++ b/internal/utils/http_requests/http_options.go
@@ -37,6 +37,11 @@ func HttpPayloadText(payload string) HttpOptions {
 }
 
 // which is used for POST method only
+func HttpPayloadReader(reader io.ReadCloser) HttpOptions {
+	return HttpOptions{"payloadReader", reader}
+}
+
+// which is used for POST method only
 func HttpPayloadJson(payload interface{}) HttpOptions {
 	return HttpOptions{"payloadJson", payload}
 }

--- a/internal/utils/http_requests/http_request.go
+++ b/internal/utils/http_requests/http_request.go
@@ -75,6 +75,9 @@ func buildHttpRequest(method string, url string, options ...HttpOptions) (*http.
 		case "payloadText":
 			req.Body = io.NopCloser(strings.NewReader(option.Value.(string)))
 			req.Header.Set("Content-Type", "text/plain")
+		case "payloadReader":
+			req.Body = option.Value.(io.ReadCloser)
+			req.Header.Set("Content-Type", "application/octet-stream")
 		case "payloadJson":
 			jsonStr, err := json.Marshal(option.Value)
 			if err != nil {


### PR DESCRIPTION
- Added `pluginMaxExecutionTimeout` to `PluginManager` for configurable execution limits.
- Updated `ServerlessPluginRuntime` to utilize the new timeout setting in HTTP requests.
- Refactored AWSPluginRuntime references to ServerlessPluginRuntime for consistency across the codebase.