### PR TITLE
feat: add length-prefixed HTTP chunking functionality

### DIFF
--- a/internal/utils/http_requests/http_options.go
+++ b/internal/utils/http_requests/http_options.go
@@ -7,33 +7,48 @@ type HttpOptions struct {
 	Value interface{}
 }
 
+const (
+	HttpOptionTypeWriteTimeout                     = "write_timeout"
+	HttpOptionTypeReadTimeout                      = "read_timeout"
+	HttpOptionTypeHeader                           = "header"
+	HttpOptionTypeParams                           = "params"
+	HttpOptionTypePayload                          = "payload"
+	HttpOptionTypePayloadText                      = "payloadText"
+	HttpOptionTypePayloadJson                      = "payloadJson"
+	HttpOptionTypePayloadMultipart                 = "payloadMultipart"
+	HttpOptionTypeRaiseErrorWhenStreamDataNotMatch = "raiseErrorWhenStreamDataNotMatch"
+	HttpOptionTypeDirectReferer                    = "directReferer"
+	HttpOptionTypeRetCode                          = "retCode"
+	HttpOptionTypeUsingLengthPrefixed              = "usingLengthPrefixed"
+)
+
 // milliseconds
 func HttpWriteTimeout(timeout int64) HttpOptions {
-	return HttpOptions{"write_timeout", timeout}
+	return HttpOptions{HttpOptionTypeWriteTimeout, timeout}
 }
 
 // milliseconds
 func HttpReadTimeout(timeout int64) HttpOptions {
-	return HttpOptions{"read_timeout", timeout}
+	return HttpOptions{HttpOptionTypeReadTimeout, timeout}
 }
 
 func HttpHeader(header map[string]string) HttpOptions {
-	return HttpOptions{"header", header}
+	return HttpOptions{HttpOptionTypeHeader, header}
 }
 
 // which is used for params with in url
 func HttpParams(params map[string]string) HttpOptions {
-	return HttpOptions{"params", params}
+	return HttpOptions{HttpOptionTypeParams, params}
 }
 
 // which is used for POST method only
 func HttpPayload(payload map[string]string) HttpOptions {
-	return HttpOptions{"payload", payload}
+	return HttpOptions{HttpOptionTypePayload, payload}
 }
 
 // which is used for POST method only
 func HttpPayloadText(payload string) HttpOptions {
-	return HttpOptions{"payloadText", payload}
+	return HttpOptions{HttpOptionTypePayloadText, payload}
 }
 
 // which is used for POST method only
@@ -43,7 +58,7 @@ func HttpPayloadReader(reader io.ReadCloser) HttpOptions {
 
 // which is used for POST method only
 func HttpPayloadJson(payload interface{}) HttpOptions {
-	return HttpOptions{"payloadJson", payload}
+	return HttpOptions{HttpOptionTypePayloadJson, payload}
 }
 
 type HttpPayloadMultipartFile struct {
@@ -54,20 +69,43 @@ type HttpPayloadMultipartFile struct {
 // which is used for POST method only
 // payload follows the form data format, and files is a map from filename to file
 func HttpPayloadMultipart(payload map[string]string, files map[string]HttpPayloadMultipartFile) HttpOptions {
-	return HttpOptions{"payloadMultipart", map[string]interface{}{
+	return HttpOptions{HttpOptionTypePayloadMultipart, map[string]interface{}{
 		"payload": payload,
 		"files":   files,
 	}}
 }
 
 func HttpRaiseErrorWhenStreamDataNotMatch(raise bool) HttpOptions {
-	return HttpOptions{"raiseErrorWhenStreamDataNotMatch", raise}
+	return HttpOptions{HttpOptionTypeRaiseErrorWhenStreamDataNotMatch, raise}
 }
 
 func HttpWithDirectReferer() HttpOptions {
-	return HttpOptions{"directReferer", true}
+	return HttpOptions{HttpOptionTypeDirectReferer, true}
 }
 
 func HttpWithRetCode(retCode *int) HttpOptions {
-	return HttpOptions{"retCode", retCode}
+	return HttpOptions{HttpOptionTypeRetCode, retCode}
+}
+
+// For standard SSE protocol, response are split by \n\n
+// Which leads a bad performance when decoding, we need a larger chunk to store temporary data
+// This option is used to enable length-prefixed mode, which is faster but less memory-friendly
+// We uses following format:
+//
+//	| Field         | Size     | Description                     |
+//	|---------------|----------|---------------------------------|
+//	| Magic Number  | 1 byte   | Magic number identifier         |
+//	| Reserved      | 1 byte   | Reserved field                  |
+//	| Header Length | 2 bytes  | Header length (usually 0xa)    |
+//	| Data Length   | 4 bytes  | Length of the data              |
+//	| Reserved      | 6 bytes  | Reserved fields                 |
+//	| Data          | Variable | Actual data content             |
+//
+//	| Reserved Fields | Header   | Data     |
+//	|-----------------|----------|----------|
+//	| 4 bytes total   | Variable | Variable |
+//
+// with the above format, we can achieve a better performance, avoid unexpected memory growth
+func HttpUsingLengthPrefixed(using bool) HttpOptions {
+	return HttpOptions{HttpOptionTypeUsingLengthPrefixed, using}
 }

--- a/internal/utils/parser/chunking.go
+++ b/internal/utils/parser/chunking.go
@@ -1,0 +1,107 @@
+package parser
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+)
+
+func LineBasedChunking(reader io.Reader, maxChunkSize int, processor func([]byte) error) error {
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 1024), maxChunkSize)
+	scanner.Split(bufio.ScanLines)
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) > maxChunkSize {
+			return fmt.Errorf("line is too long: %d", len(line))
+		}
+
+		if err := processor(line); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// We uses following format:
+// All data is stored in little endian format
+//
+//	| Field         | Size     | Description                     |
+//	|---------------|----------|---------------------------------|
+//	| Magic Number  | 1 byte   | Magic number identifier         |
+//	| Reserved      | 1 byte   | Reserved field                  |
+//	| Header Length | 2 bytes  | Header length (usually 0xa)    |
+//	| Data Length   | 4 bytes  | Length of the data              |
+//	| Reserved      | 6 bytes  | Reserved fields                 |
+//	| Data          | Variable | Actual data content             |
+//
+//	| Reserved Fields | Header   | Data     |
+//	|-----------------|----------|----------|
+//	| 4 bytes total   | Variable | Variable |
+//
+// NOTE: this function is not thread safe
+func LengthPrefixedChunking(
+	reader io.Reader,
+	magicNumber byte,
+	maxChunkSize uint32,
+	processor func([]byte) error,
+) error {
+	// read until EOF
+	buf := bytes.NewBuffer(nil)
+
+	for {
+		// read length
+		length := make([]byte, 4)
+		_, err := io.ReadFull(reader, length)
+		if err != nil {
+			if err == io.EOF {
+				return nil // Normal EOF, processing complete
+			}
+			return errors.Join(err, fmt.Errorf("failed to read system header"))
+		}
+
+		// check magic number
+		if length[0] != magicNumber {
+			return fmt.Errorf("magic number mismatch: %d", length[0])
+		}
+
+		// read header length
+		headerLength := binary.LittleEndian.Uint16(length[2:4])
+		if headerLength != 0xa {
+			return fmt.Errorf("header length mismatch: %d", headerLength)
+		}
+
+		// read header
+		header := make([]byte, headerLength)
+		_, err = io.ReadFull(reader, header)
+		if err != nil {
+			return errors.Join(err, fmt.Errorf("failed to read header"))
+		}
+
+		// decoding data length
+		dataLength := binary.LittleEndian.Uint32(header[4:8])
+		if dataLength > maxChunkSize {
+			return fmt.Errorf("data length is too long: %d", dataLength)
+		}
+
+		// Reset buffer for new data
+		buf.Reset()
+
+		// Read data into buffer
+		// io.CopyN will not return io.EOF if dataLength equals to actual data length
+		_, err = io.CopyN(buf, reader, int64(dataLength))
+		if err != nil {
+			return errors.Join(err, fmt.Errorf("failed to read data"))
+		}
+
+		// Process the data
+		err = processor(buf.Bytes())
+		if err != nil {
+			return errors.Join(err, fmt.Errorf("failed to process data"))
+		}
+	}
+}

--- a/internal/utils/parser/chunking_test.go
+++ b/internal/utils/parser/chunking_test.go
@@ -1,0 +1,268 @@
+package parser
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+func TestLineBasedChunking(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        string
+		maxChunkSize int
+		expected     []string
+		expectError  bool
+	}{
+		{
+			name:         "simple lines",
+			input:        "line1\nline2\nline3",
+			maxChunkSize: 100,
+			expected:     []string{"line1", "line2", "line3"},
+			expectError:  false,
+		},
+		{
+			name:         "empty lines",
+			input:        "line1\n\nline3",
+			maxChunkSize: 100,
+			expected:     []string{"line1", "", "line3"},
+			expectError:  false,
+		},
+		{
+			name:         "single line",
+			input:        "single line",
+			maxChunkSize: 100,
+			expected:     []string{"single line"},
+			expectError:  false,
+		},
+		{
+			name:         "line too long",
+			input:        "this is a very long line that exceeds the maximum chunk size",
+			maxChunkSize: 10,
+			expected:     nil,
+			expectError:  true,
+		},
+		{
+			name:         "empty input",
+			input:        "",
+			maxChunkSize: 100,
+			expected:     []string{},
+			expectError:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reader := bytes.NewReader([]byte(tt.input))
+			var result []string
+
+			err := LineBasedChunking(reader, tt.maxChunkSize, func(data []byte) error {
+				result = append(result, string(data))
+				return nil
+			})
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if len(result) != len(tt.expected) {
+				t.Errorf("expected %d lines, got %d", len(tt.expected), len(result))
+				return
+			}
+
+			for i, expected := range tt.expected {
+				if result[i] != expected {
+					t.Errorf("line %d: expected %q, got %q", i, expected, result[i])
+				}
+			}
+		})
+	}
+}
+
+func TestLengthPrefixedChunking(t *testing.T) {
+	tests := []struct {
+		name        string
+		data        [][]byte
+		magicNumber byte
+		expectError bool
+	}{
+		{
+			name:        "valid single chunk",
+			data:        [][]byte{[]byte("hello world")},
+			magicNumber: 0x0f,
+			expectError: false,
+		},
+		{
+			name:        "valid multiple chunks",
+			data:        [][]byte{[]byte("chunk1"), []byte("chunk2"), []byte("chunk3")},
+			magicNumber: 0x0f,
+			expectError: false,
+		},
+		{
+			name:        "empty chunk",
+			data:        [][]byte{[]byte("")},
+			magicNumber: 0x0f,
+			expectError: false,
+		},
+		{
+			name:        "large chunk",
+			data:        [][]byte{bytes.Repeat([]byte("a"), 1000)},
+			magicNumber: 0x0f,
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create test data with proper format
+			var buf bytes.Buffer
+			for _, chunk := range tt.data {
+				// Write magic number
+				buf.WriteByte(tt.magicNumber)
+				// Write reserved byte
+				buf.WriteByte(0x00)
+				// Write header length (0x000a in little endian)
+				buf.Write([]byte{0x0a, 0x00})
+
+				// Create header (10 bytes total)
+				header := make([]byte, 10)
+				// First 4 bytes are already used for data length placeholder
+				// Write data length in bytes 4-7 (little endian)
+				dataLen := uint32(len(chunk))
+				binary.LittleEndian.PutUint32(header[4:8], dataLen)
+				// Remaining 6 bytes are reserved (already zero)
+
+				buf.Write(header)
+				buf.Write(chunk)
+			}
+
+			reader := bytes.NewReader(buf.Bytes())
+			var result [][]byte
+
+			err := LengthPrefixedChunking(reader, tt.magicNumber, 1024*1024, func(data []byte) error {
+				// Make a copy of the data since it might be reused
+				chunk := make([]byte, len(data))
+				copy(chunk, data)
+				result = append(result, chunk)
+				return nil
+			})
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if len(result) != len(tt.data) {
+				t.Errorf("expected %d chunks, got %d", len(tt.data), len(result))
+				return
+			}
+
+			for i, expected := range tt.data {
+				if !bytes.Equal(result[i], expected) {
+					t.Errorf("chunk %d: expected %q, got %q", i, expected, result[i])
+				}
+			}
+		})
+	}
+}
+
+func TestLengthPrefixedChunking_ErrorCases(t *testing.T) {
+	tests := []struct {
+		name        string
+		data        []byte
+		magicNumber byte
+		maxSize     uint32
+		expectError string
+	}{
+		{
+			name:        "wrong magic number",
+			data:        []byte{0x10, 0x00, 0x0a, 0x00}, // wrong magic number
+			magicNumber: 0x0f,
+			maxSize:     1024,
+			expectError: "magic number mismatch",
+		},
+		{
+			name:        "wrong header length",
+			data:        []byte{0x0f, 0x00, 0x0b, 0x00}, // wrong header length
+			magicNumber: 0x0f,
+			maxSize:     1024,
+			expectError: "header length mismatch",
+		},
+		{
+			name:        "incomplete header",
+			data:        []byte{0x0f, 0x00, 0x0a, 0x00, 0x01, 0x00}, // incomplete header
+			magicNumber: 0x0f,
+			maxSize:     1024,
+			expectError: "failed to read header",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reader := bytes.NewReader(tt.data)
+
+			err := LengthPrefixedChunking(reader, tt.magicNumber, tt.maxSize, func(data []byte) error {
+				return nil
+			})
+
+			if err == nil {
+				t.Errorf("expected error containing %q but got none", tt.expectError)
+				return
+			}
+
+			if err.Error() == "" {
+				t.Errorf("expected error containing %q but got empty error", tt.expectError)
+			}
+		})
+	}
+}
+
+func TestLengthPrefixedChunking_DataTooLarge(t *testing.T) {
+	var buf bytes.Buffer
+
+	// Create a chunk that exceeds maxChunkSize
+	largeDataSize := uint32(100)
+	maxChunkSize := uint32(50)
+
+	// Write magic number and reserved
+	buf.WriteByte(0x0f)
+	buf.WriteByte(0x00)
+	// Write header length
+	buf.Write([]byte{0x0a, 0x00})
+
+	// Create header with large data size
+	header := make([]byte, 10)
+	binary.LittleEndian.PutUint32(header[4:8], largeDataSize)
+
+	buf.Write(header)
+
+	reader := bytes.NewReader(buf.Bytes())
+
+	err := LengthPrefixedChunking(reader, 0x0f, maxChunkSize, func(data []byte) error {
+		return nil
+	})
+
+	if err == nil {
+		t.Error("expected error for data too large but got none")
+		return
+	}
+
+	if err.Error() == "" {
+		t.Error("expected error message but got empty")
+	}
+}


### PR DESCRIPTION
- Introduced new constants for HTTP option types to improve code readability and maintainability.
- Updated existing HTTP option functions to utilize the new constants.
- Implemented line-based and length-prefixed chunking methods for improved data processing in HTTP requests.
- Added comprehensive tests for chunking functionality to ensure reliability and correctness.