### PR TITLE
fixed:issues #292 fatal error: concurrent map iteration and map write

### DIFF
--- a/internal/utils/stream/stream.go
+++ b/internal/utils/stream/stream.go
@@ -182,9 +182,12 @@ func (r *Stream[T]) Close() {
 		return
 	}
 
+	// fixed:issues #292 fatal error: concurrent map iteration and map write
+	r.l.Lock()
 	for _, f := range r.beforeClose {
 		f()
 	}
+	r.l.Unlock()
 
 	select {
 	case r.sig <- false:


### PR DESCRIPTION
As described by # 292 Issuse, using both 'output_Schema' and 'create_variable_message' will verify whether the format of the data is correct.
However, the problem is that the read() and close() of the stream are executed by different goroutines. At this point, the plugin daemon receives an error message from the plugin ("SESSION_MESSAGE_TYPE_ERROR"), and then executes the stream's close(). Close() internally calls the stream's before Close callback function, while stream's read() calls the filter callback function. The problem lies here, the stream's before Close callback function and read () callback function access the critical resource variables (a map variable). This critical resource variable was accessed in multiple goroutines but was not protected, resulting in a 'concurrent map iteration and map write' error and ultimately causing the daemon to crash.
Simply put, the error message sent by dify-plugin triggered the crash bug of dify-plugin-daemon
Solution:
Use locks to protect critical resources