### PR TITLE
fix: launch error when using redis sentinel

### DIFF
--- a/internal/types/app/config.go
+++ b/internal/types/app/config.go
@@ -98,8 +98,8 @@ type Config struct {
 	RoutinePoolSize int `envconfig:"ROUTINE_POOL_SIZE" validate:"required"`
 
 	// redis
-	RedisHost   string `envconfig:"REDIS_HOST" validate:"required"`
-	RedisPort   uint16 `envconfig:"REDIS_PORT" validate:"required"`
+	RedisHost   string `envconfig:"REDIS_HOST"`
+	RedisPort   uint16 `envconfig:"REDIS_PORT"`
 	RedisPass   string `envconfig:"REDIS_PASSWORD"`
 	RedisUser   string `envconfig:"REDIS_USERNAME"`
 	RedisUseSsl bool   `envconfig:"REDIS_USE_SSL"`


### PR DESCRIPTION
when using redis sentinel, REDIS_HOST and REDIS_PORT are useless, but leading to the error

```
main.go:25: [PANIC]Invalid configuration: Key: 'Config.RedisHost' Error:Field validation for 'RedisHost' failed on the 'required' tag
```