### PR TITLE
Fix .env.example Refer to Official Document

### DIFF
--- a/cmd/commandline/plugin/templates/.env.example
+++ b/cmd/commandline/plugin/templates/.env.example
@@ -1,3 +1,4 @@
 INSTALL_METHOD=remote
-REMOTE_INSTALL_URL=debug.dify.ai:5003
+REMOTE_INSTALL_URL=debug.dify.ai
+REMOTE_INSTALL_PORT=5003
 REMOTE_INSTALL_KEY=********-****-****-****-************


### PR DESCRIPTION

Refer to the official document , should separate the host and port of remote install addr.

![a96a28c9edc0414f053e4c6e2569e2e](https://github.com/user-attachments/assets/f14be78c-3f2f-4a56-b7d0-9cdf0763a936)
