### PR TITLE
fix:response data will be discard if tool/llm response buffer overflow

### DIFF
--- a/internal/core/plugin_daemon/generic.go
+++ b/internal/core/plugin_daemon/generic.go
@@ -37,7 +37,7 @@ func GenericInvokePlugin[Req any, Rsp any](
 				response.Close()
 				return
 			} else {
-				response.Write(chunk)
+				response.WriteBlocking(chunk)
 			}
 		case plugin_entities.SESSION_MESSAGE_TYPE_INVOKE:
 			// check if the request contains a aws_event_id


### PR DESCRIPTION
**Description:**  
When the `plugin-daemon` receives responses from a tool, if the tool returns data too quickly, the queue of the stream will be full, finally causing data to be discarded without any error log.  

**Steps to Reproduce:**  
1. Develop an `unzip` plugin.  
2. Package 100 PDF files (each ~500KB) into a single ZIP archive.  
3. Use the `unzip` plugin in a workflow to extract the files.  
4. **Result:** The `unzip` plugin outputs only 20 to 50+ PDFs each time, losing a significant portion of the files.  

**Proposed Fix:**  
Replace the stream object’s `Write` method with `WriteBlocking` to ensure synchronous handling.  

