### PR TITLE
feat: add InvokeLLMWithStructuredOutput functionality

### DIFF
--- a/internal/core/dify_invocation/invcation.go
+++ b/internal/core/dify_invocation/invcation.go
@@ -9,6 +9,9 @@ import (
 type BackwardsInvocation interface {
 	// InvokeLLM
 	InvokeLLM(payload *InvokeLLMRequest) (*stream.Stream[model_entities.LLMResultChunk], error)
+	// InvokeLLMWithStructuredOutput
+	InvokeLLMWithStructuredOutput(payload *InvokeLLMWithStructuredOutputRequest) (
+		*stream.Stream[model_entities.LLMResultChunkWithStructuredOutput], error)
 	// InvokeTextEmbedding
 	InvokeTextEmbedding(payload *InvokeTextEmbeddingRequest) (*model_entities.TextEmbeddingResult, error)
 	// InvokeRerank

--- a/internal/core/dify_invocation/real/http_request.go
+++ b/internal/core/dify_invocation/real/http_request.go
@@ -115,6 +115,12 @@ func (i *RealBackwardsInvocation) InvokeLLM(payload *dify_invocation.InvokeLLMRe
 	return StreamResponse[model_entities.LLMResultChunk](i, "POST", "invoke/llm", http_requests.HttpPayloadJson(payload))
 }
 
+func (i *RealBackwardsInvocation) InvokeLLMWithStructuredOutput(payload *dify_invocation.InvokeLLMWithStructuredOutputRequest) (
+	*stream.Stream[model_entities.LLMResultChunkWithStructuredOutput], error,
+) {
+	return StreamResponse[model_entities.LLMResultChunkWithStructuredOutput](i, "POST", "/invoke/llm/structured-output", http_requests.HttpPayloadJson(payload))
+}
+
 func (i *RealBackwardsInvocation) InvokeTextEmbedding(payload *dify_invocation.InvokeTextEmbeddingRequest) (*model_entities.TextEmbeddingResult, error) {
 	return Request[model_entities.TextEmbeddingResult](i, "POST", "invoke/text-embedding", http_requests.HttpPayloadJson(payload))
 }

--- a/internal/core/dify_invocation/tester/mock.go
+++ b/internal/core/dify_invocation/tester/mock.go
@@ -163,29 +163,25 @@ func (m *MockedDifyInvocation) InvokeLLMWithStructuredOutput(payload *dify_invoc
 	routine.Submit(nil, func() {
 		for i, part := range parts {
 			stream.Write(model_entities.LLMResultChunkWithStructuredOutput{
-				LLMResultChunk: model_entities.LLMResultChunk{
-					Model:             model_entities.LLMModel(payload.Model),
-					SystemFingerprint: "test",
-					Delta: model_entities.LLMResultChunkDelta{
-						Index: &[]int{i}[0],
-						Message: model_entities.PromptMessage{
-							Role:      model_entities.PROMPT_MESSAGE_ROLE_ASSISTANT,
-							Content:   part,
-							Name:      "test",
-							ToolCalls: []model_entities.PromptMessageToolCall{},
-						},
+				Model:             model_entities.LLMModel(payload.Model),
+				SystemFingerprint: "test",
+				Delta: model_entities.LLMResultChunkDelta{
+					Index: &[]int{i}[0],
+					Message: model_entities.PromptMessage{
+						Role:      model_entities.PROMPT_MESSAGE_ROLE_ASSISTANT,
+						Content:   part,
+						Name:      "test",
+						ToolCalls: []model_entities.PromptMessageToolCall{},
 					},
 				},
 			})
 		}
 		// write the last part
 		stream.Write(model_entities.LLMResultChunkWithStructuredOutput{
-			LLMResultChunk: model_entities.LLMResultChunk{
-				Model:             model_entities.LLMModel(payload.Model),
-				SystemFingerprint: "test",
-				Delta: model_entities.LLMResultChunkDelta{
-					Index: &[]int{10}[0],
-				},
+			Model:             model_entities.LLMModel(payload.Model),
+			SystemFingerprint: "test",
+			Delta: model_entities.LLMResultChunkDelta{
+				Index: &[]int{10}[0],
 			},
 			LLMStructuredOutput: model_entities.LLMStructuredOutput{
 				StructuredOutput: structuredOutput,

--- a/internal/core/dify_invocation/tester/mock.go
+++ b/internal/core/dify_invocation/tester/mock.go
@@ -136,6 +136,66 @@ func (m *MockedDifyInvocation) InvokeLLM(payload *dify_invocation.InvokeLLMReque
 	return stream, nil
 }
 
+func (m *MockedDifyInvocation) InvokeLLMWithStructuredOutput(payload *dify_invocation.InvokeLLMWithStructuredOutputRequest) (
+	*stream.Stream[model_entities.LLMResultChunkWithStructuredOutput], error,
+) {
+	// generate json from payload.StructuredOutputSchema
+	structuredOutput, err := jsonschema.GenerateValidateJson(payload.StructuredOutputSchema)
+	if err != nil {
+		return nil, err
+	}
+
+	// marshal jsonSchema to string
+	structuredOutputString := parser.MarshalJson(structuredOutput)
+
+	// split structuredOutputString into 10 parts and write them to the stream
+	parts := []string{}
+	for i := 0; i < 10; i++ {
+		start := i * len(structuredOutputString) / 10
+		end := (i + 1) * len(structuredOutputString) / 10
+		if i == 9 { // last part
+			end = len(structuredOutputString)
+		}
+		parts = append(parts, structuredOutputString[start:end])
+	}
+
+	stream := stream.NewStream[model_entities.LLMResultChunkWithStructuredOutput](11)
+	routine.Submit(nil, func() {
+		for i, part := range parts {
+			stream.Write(model_entities.LLMResultChunkWithStructuredOutput{
+				LLMResultChunk: model_entities.LLMResultChunk{
+					Model:             model_entities.LLMModel(payload.Model),
+					SystemFingerprint: "test",
+					Delta: model_entities.LLMResultChunkDelta{
+						Index: &[]int{i}[0],
+						Message: model_entities.PromptMessage{
+							Role:      model_entities.PROMPT_MESSAGE_ROLE_ASSISTANT,
+							Content:   part,
+							Name:      "test",
+							ToolCalls: []model_entities.PromptMessageToolCall{},
+						},
+					},
+				},
+			})
+		}
+		// write the last part
+		stream.Write(model_entities.LLMResultChunkWithStructuredOutput{
+			LLMResultChunk: model_entities.LLMResultChunk{
+				Model:             model_entities.LLMModel(payload.Model),
+				SystemFingerprint: "test",
+				Delta: model_entities.LLMResultChunkDelta{
+					Index: &[]int{10}[0],
+				},
+			},
+			LLMStructuredOutput: model_entities.LLMStructuredOutput{
+				StructuredOutput: structuredOutput,
+			},
+		})
+		stream.Close()
+	})
+	return stream, nil
+}
+
 func (m *MockedDifyInvocation) InvokeTextEmbedding(payload *dify_invocation.InvokeTextEmbeddingRequest) (*model_entities.TextEmbeddingResult, error) {
 	result := model_entities.TextEmbeddingResult{
 		Model: payload.Model,

--- a/internal/core/dify_invocation/types.go
+++ b/internal/core/dify_invocation/types.go
@@ -18,6 +18,7 @@ type InvokeType string
 
 const (
 	INVOKE_TYPE_LLM                      InvokeType = "llm"
+	INVOKE_TYPE_LLM_STRUCTURED_OUTPUT    InvokeType = "llm_structured_output"
 	INVOKE_TYPE_TEXT_EMBEDDING           InvokeType = "text_embedding"
 	INVOKE_TYPE_RERANK                   InvokeType = "rerank"
 	INVOKE_TYPE_TTS                      InvokeType = "tts"
@@ -49,6 +50,15 @@ type InvokeLLMRequest struct {
 	// requests.InvokeLLMSchema,
 	// TODO: as completion_params in requests.InvokeLLMSchema is "model_parameters", we declare another one here
 	InvokeLLMSchema
+}
+
+type InvokeLLMWithStructuredOutputRequest struct {
+	BaseInvokeDifyRequest
+	requests.BaseRequestInvokeModel
+	// requests.InvokeLLMSchema
+	// TODO: as completion_params in requests.InvokeLLMSchema is "model_parameters", we declare another one here
+	InvokeLLMSchema
+	StructuredOutputSchema map[string]any `json:"structured_output_schema" validate:"required"`
 }
 
 type InvokeTextEmbeddingRequest struct {

--- a/pkg/entities/model_entities/llm.go
+++ b/pkg/entities/model_entities/llm.go
@@ -188,6 +188,15 @@ type LLMResultChunk struct {
 	Delta             LLMResultChunkDelta `json:"delta" validate:"required"`
 }
 
+type LLMStructuredOutput struct {
+	StructuredOutput map[string]any `json:"structured_output" validate:"omitempty"`
+}
+
+type LLMResultChunkWithStructuredOutput struct {
+	LLMResultChunk
+	LLMStructuredOutput
+}
+
 /*
 This is a compatibility layer for the old LLMResultChunk format.
 The old one has the `PromptMessages` field, we need to ensure the new one is backward compatible.

--- a/pkg/entities/model_entities/llm.go
+++ b/pkg/entities/model_entities/llm.go
@@ -193,7 +193,14 @@ type LLMStructuredOutput struct {
 }
 
 type LLMResultChunkWithStructuredOutput struct {
-	LLMResultChunk
+	// You might argue that why not embed LLMResultChunk directly?
+	// `LLMResultChunk` has implemented interface `MarshalJSON`, due to Golang's type embedding,
+	// it also effectively implements the `MarshalJSON` method of `LLMResultChunkWithStructuredOutput`,
+	// resulting in a unexpected JSON marshaling of `LLMResultChunkWithStructuredOutput`
+	Model             LLMModel            `json:"model" validate:"required"`
+	SystemFingerprint string              `json:"system_fingerprint" validate:"omitempty"`
+	Delta             LLMResultChunkDelta `json:"delta" validate:"required"`
+
 	LLMStructuredOutput
 }
 


### PR DESCRIPTION
- Introduced a new method InvokeLLMWithStructuredOutput to the BackwardsInvocation interface for handling structured output requests.
- Added corresponding request and response types to support structured output.
- Implemented the method in both RealBackwardsInvocation and MockedDifyInvocation for testing purposes.
- Updated permission handling and task execution for the new structured output invocation type.

This enhancement allows for more flexible and detailed responses from the LLM, improving the overall functionality of the invocation system.

## Description

Please provide a brief description of the changes made in this pull request.
Please also include the issue number if this is related to an issue using the format `Fixes #123` or `Closes #123`.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Other

## Essential Checklist

### Testing
- [x] I have tested the changes locally and confirmed they work as expected
- [x] I have added unit tests where necessary and they pass successfully

### Bug Fix (if applicable)
- [ ] I have used GitHub syntax to close the related issue (e.g., `Fixes #123` or `Closes #123`)

## Additional Information

Please provide any additional context that would help reviewers understand the changes. 