### PR TITLE
feat: add support for dark icon

### DIFF
--- a/cmd/commandline/plugin/init.go
+++ b/cmd/commandline/plugin/init.go
@@ -352,6 +352,7 @@ func (m model) createPlugin() {
 			Version:     manifest_entities.Version("0.0.1"),
 			Type:        manifest_entities.PluginType,
 			Icon:        "icon.svg",
+			IconDark:    "icon.svg",
 			Author:      m.subMenus[SUB_MENU_KEY_PROFILE].(profile).Author(),
 			Name:        m.subMenus[SUB_MENU_KEY_PROFILE].(profile).Name(),
 			Description: plugin_entities.NewI18nObject(m.subMenus[SUB_MENU_KEY_PROFILE].(profile).Description()),

--- a/internal/core/plugin_manager/media_transport/assets.go
+++ b/internal/core/plugin_manager/media_transport/assets.go
@@ -120,5 +120,12 @@ func (m *MediaBucket) RemapAssets(declaration *plugin_entities.PluginDeclaration
 		}
 	}
 
+	if declaration.IconDark != "" {
+		declaration.IconDark, err = remap(declaration.IconDark)
+		if err != nil {
+			return nil, errors.Join(err, fmt.Errorf("failed to remap plugin dark icon"))
+		}
+	}
+
 	return assetsIds, nil
 }

--- a/internal/service/install_plugin.go
+++ b/internal/service/install_plugin.go
@@ -81,6 +81,7 @@ func InstallPluginRuntimeToTenant(
 			PluginID:               pluginUniqueIdentifier.PluginID(),
 			Status:                 models.InstallTaskStatusPending,
 			Icon:                   pluginDeclaration.Icon,
+			IconDark:               pluginDeclaration.IconDark,
 			Labels:                 pluginDeclaration.Label,
 			Message:                "",
 		})

--- a/internal/types/models/task.go
+++ b/internal/types/models/task.go
@@ -15,6 +15,7 @@ type InstallTaskPluginStatus struct {
 	PluginUniqueIdentifier plugin_entities.PluginUniqueIdentifier `json:"plugin_unique_identifier"`
 	Labels                 plugin_entities.I18nObject             `json:"labels"`
 	Icon                   string                                 `json:"icon"`
+	IconDark               string                                 `json:"icon_dark"`
 	PluginID               string                                 `json:"plugin_id"`
 	Status                 InstallTaskStatus                      `json:"status"`
 	Message                string                                 `json:"message"`

--- a/pkg/entities/plugin_entities/plugin_declaration.go
+++ b/pkg/entities/plugin_entities/plugin_declaration.go
@@ -147,6 +147,7 @@ type PluginDeclarationWithoutAdvancedFields struct {
 	Label       I18nObject                         `json:"label" yaml:"label" validate:"required"`
 	Description I18nObject                         `json:"description" yaml:"description" validate:"required"`
 	Icon        string                             `json:"icon" yaml:"icon,omitempty" validate:"required,max=128"`
+	IconDark    string                             `json:"icon_dark" yaml:"icon_dark,omitempty" validate:"omitempty,max=128"`
 	Resource    PluginResourceRequirement          `json:"resource" yaml:"resource,omitempty" validate:"required"`
 	Plugins     PluginExtensions                   `json:"plugins" yaml:"plugins,omitempty" validate:"required"`
 	Meta        PluginMeta                         `json:"meta" yaml:"meta,omitempty" validate:"required"`

--- a/pkg/plugin_packager/decoder/helper.go
+++ b/pkg/plugin_packager/decoder/helper.go
@@ -408,6 +408,12 @@ func (p *PluginDecoderHelper) CheckAssetsValid(decoder PluginDecoder) error {
 		}
 	}
 
+	if declaration.IconDark != "" {
+		if _, ok := assets[declaration.IconDark]; !ok {
+			return errors.Join(err, fmt.Errorf("plugin dark icon not found"))
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Related PRs:
- https://github.com/langgenius/dify-plugin-sdks/pull/173

- Introduced IconDark field in PluginDeclaration and related structures to support dark mode icons.
- Updated the installation process to handle dark icons.
- Enhanced asset validation to check for the presence of dark icons.

This change improves the visual consistency of plugins in dark mode environments.

## Description

Please provide a brief description of the changes made in this pull request.
Please also include the issue number if this is related to an issue using the format `Fixes #123` or `Closes #123`.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Other

## Essential Checklist

### Testing
- [ ] I have tested the changes locally and confirmed they work as expected
- [ ] I have added unit tests where necessary and they pass successfully

### Bug Fix (if applicable)
- [ ] I have used GitHub syntax to close the related issue (e.g., `Fixes #123` or `Closes #123`)

## Additional Information

Please provide any additional context that would help reviewers understand the changes. 