### PR TITLE
feat: add active request tracking to health check and dispatch routes

### DIFF
--- a/internal/server/controllers/health_check.go
+++ b/internal/server/controllers/health_check.go
@@ -1,20 +1,45 @@
 package controllers
 
 import (
+	"sync/atomic"
+
 	"github.com/gin-gonic/gin"
 	"github.com/langgenius/dify-plugin-daemon/internal/manifest"
 	"github.com/langgenius/dify-plugin-daemon/internal/types/app"
 	"github.com/langgenius/dify-plugin-daemon/internal/utils/routine"
 )
 
+var (
+	activeRequests         int32 = 0 // how many requests are active
+	activeDispatchRequests int32 = 0 // how many plugin dispatching requests are active
+)
+
+func CollectActiveRequests() gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		atomic.AddInt32(&activeRequests, 1)
+		ctx.Next()
+		atomic.AddInt32(&activeRequests, -1)
+	}
+}
+
+func CollectActiveDispatchRequests() gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		atomic.AddInt32(&activeDispatchRequests, 1)
+		ctx.Next()
+		atomic.AddInt32(&activeDispatchRequests, -1)
+	}
+}
+
 func HealthCheck(app *app.Config) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		c.JSON(200, gin.H{
-			"status":      "ok",
-			"pool_status": routine.FetchRoutineStatus(),
-			"version":     manifest.VersionX,
-			"build_time":  manifest.BuildTimeX,
-			"platform":    app.Platform,
+			"status":                   "ok",
+			"pool_status":              routine.FetchRoutineStatus(),
+			"version":                  manifest.VersionX,
+			"build_time":               manifest.BuildTimeX,
+			"platform":                 app.Platform,
+			"active_requests":          activeRequests,
+			"active_dispatch_requests": activeDispatchRequests,
 		})
 	}
 }

--- a/internal/server/http_server.go
+++ b/internal/server/http_server.go
@@ -27,6 +27,7 @@ func (app *App) server(config *app.Config) func() {
 		}))
 	}
 	engine.Use(gin.Recovery())
+	engine.Use(controllers.CollectActiveRequests())
 	engine.GET("/health/check", controllers.HealthCheck(config))
 
 	endpointGroup := engine.Group("/e")
@@ -93,6 +94,7 @@ func (app *App) pluginGroup(group *gin.RouterGroup, config *app.Config) {
 }
 
 func (app *App) pluginDispatchGroup(group *gin.RouterGroup, config *app.Config) {
+	group.Use(controllers.CollectActiveDispatchRequests())
 	group.Use(app.FetchPluginInstallation())
 	group.Use(app.RedirectPluginInvoke())
 	group.Use(app.InitClusterID())


### PR DESCRIPTION
- Implemented middleware to track active requests and active dispatch requests using atomic counters.
- Updated health check response to include counts of active requests and active dispatch requests.
- Integrated the new middleware into the HTTP server and plugin dispatch group for improved monitoring.

## Description

Please provide a brief description of the changes made in this pull request.
Please also include the issue number if this is related to an issue using the format `Fixes #123` or `Closes #123`.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Other

## Essential Checklist

### Testing
- [ ] I have tested the changes locally and confirmed they work as expected
- [ ] I have added unit tests where necessary and they pass successfully

### Bug Fix (if applicable)
- [ ] I have used GitHub syntax to close the related issue (e.g., `Fixes #123` or `Closes #123`)

## Additional Information

Please provide any additional context that would help reviewers understand the changes. 