### PR TITLE
refactor(plugin_manager): enhance HTTP client timeout handling in ser…

### DIFF
--- a/internal/core/plugin_manager/serverless_runtime/environment.go
+++ b/internal/core/plugin_manager/serverless_runtime/environment.go
@@ -23,7 +23,6 @@ func (r *ServerlessPluginRuntime) InitEnvironment() error {
 				if err != nil {
 					return nil, err
 				}
-				conn.SetWriteDeadline(time.Now().Add(time.Duration(r.PluginMaxExecutionTimeout) * time.Second))
 				return conn, nil
 			},
 		},

--- a/internal/core/plugin_manager/serverless_runtime/environment.go
+++ b/internal/core/plugin_manager/serverless_runtime/environment.go
@@ -1,6 +1,7 @@
 package serverless_runtime
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -13,11 +14,18 @@ func (r *ServerlessPluginRuntime) InitEnvironment() error {
 	// init http client
 	r.client = &http.Client{
 		Transport: &http.Transport{
-			Dial: (&net.Dialer{
-				Timeout:   5 * time.Second,
-				KeepAlive: 120 * time.Second,
-			}).Dial,
 			IdleConnTimeout: 120 * time.Second,
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				conn, err := (&net.Dialer{
+					Timeout:   time.Duration(r.PluginMaxExecutionTimeout) * time.Second, // write timeout
+					KeepAlive: 120 * time.Second,
+				}).DialContext(ctx, network, addr)
+				if err != nil {
+					return nil, err
+				}
+				conn.SetWriteDeadline(time.Now().Add(time.Duration(r.PluginMaxExecutionTimeout) * time.Second))
+				return conn, nil
+			},
 		},
 	}
 

--- a/internal/core/plugin_manager/serverless_runtime/environment.go
+++ b/internal/core/plugin_manager/serverless_runtime/environment.go
@@ -14,10 +14,11 @@ func (r *ServerlessPluginRuntime) InitEnvironment() error {
 	// init http client
 	r.client = &http.Client{
 		Transport: &http.Transport{
-			IdleConnTimeout: 120 * time.Second,
+			TLSHandshakeTimeout: time.Duration(r.PluginMaxExecutionTimeout) * time.Second,
+			IdleConnTimeout:     120 * time.Second,
 			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
 				conn, err := (&net.Dialer{
-					Timeout:   time.Duration(r.PluginMaxExecutionTimeout) * time.Second, // write timeout
+					Timeout:   time.Duration(r.PluginMaxExecutionTimeout) * time.Second,
 					KeepAlive: 120 * time.Second,
 				}).DialContext(ctx, network, addr)
 				if err != nil {

--- a/internal/core/plugin_manager/serverless_runtime/io.go
+++ b/internal/core/plugin_manager/serverless_runtime/io.go
@@ -69,7 +69,6 @@ func (r *ServerlessPluginRuntime) Write(sessionId string, action access_types.Pl
 				"Dify-Plugin-Session-ID": sessionId,
 			}),
 			http_requests.HttpPayloadReader(io.NopCloser(bytes.NewReader(data))),
-			http_requests.HttpWriteTimeout(int64(r.PluginMaxExecutionTimeout*1000)),
 			http_requests.HttpReadTimeout(int64(r.PluginMaxExecutionTimeout*1000)),
 		)
 		if err != nil {

--- a/internal/utils/http_requests/http_request.go
+++ b/internal/utils/http_requests/http_request.go
@@ -2,13 +2,11 @@ package http_requests
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"io"
 	"mime/multipart"
 	"net/http"
 	"strings"
-	"time"
 )
 
 func buildHttpRequest(method string, url string, options ...HttpOptions) (*http.Request, error) {
@@ -19,11 +17,6 @@ func buildHttpRequest(method string, url string, options ...HttpOptions) (*http.
 
 	for _, option := range options {
 		switch option.Type {
-		case "write_timeout":
-			timeout := time.Second * time.Duration(option.Value.(int64))
-			ctx, cancel := context.WithTimeout(context.Background(), timeout)
-			time.AfterFunc(timeout, cancel) // release resources associated with context asynchronously
-			req = req.WithContext(ctx)
 		case "header":
 			for k, v := range option.Value.(map[string]string) {
 				req.Header.Set(k, v)


### PR DESCRIPTION
…verless runtime with DialContext

- Updated the HTTP client in the ServerlessPluginRuntime to use a context-aware DialContext for better timeout management.
- Removed the write timeout option from the HTTP request builder, streamlining the request handling process.
- Improved connection handling by setting write deadlines based on the PluginMaxExecutionTimeout.

This change enhances the reliability of network operations within the serverless runtime environment.

## Description

Please provide a brief description of the changes made in this pull request.
Please also include the issue number if this is related to an issue using the format `Fixes #123` or `Closes #123`.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Other

## Essential Checklist

### Testing
- [ ] I have tested the changes locally and confirmed they work as expected
- [ ] I have added unit tests where necessary and they pass successfully

### Bug Fix (if applicable)
- [ ] I have used GitHub syntax to close the related issue (e.g., `Fixes #123` or `Closes #123`)

## Additional Information

Please provide any additional context that would help reviewers understand the changes. 