### PR TITLE
Remote plugin debugging: Skip 5-second sleep delay for faster development iteration

### DIFF
--- a/internal/core/plugin_manager/lifecycle/full_duplex.go
+++ b/internal/core/plugin_manager/lifecycle/full_duplex.go
@@ -97,8 +97,10 @@ func FullDuplex(
 			<-c
 		}
 
-		// restart plugin in 5s
-		time.Sleep(5 * time.Second)
+		// restart plugin in 5s (skip for debugging runtime)
+		if r.Type() != plugin_entities.PLUGIN_RUNTIME_TYPE_REMOTE {
+			time.Sleep(5 * time.Second)
+		}
 
 		// add restart times
 		r.AddRestarts()


### PR DESCRIPTION
## Description

This PR fixes a debugging experience issue where remote plugin reconnection fails after quick restart cycles. The problem was caused by a mandatory 5-second sleep delay in the plugin lifecycle that prevents rapid plugin restarts during development.

**Changes made:**
- Modified `internal/core/plugin_manager/lifecycle/full_duplex.go` to skip the 5-second sleep delay for remote runtime plugins
- Added runtime type check to only apply the delay for non-remote plugins
- Improves developer experience during remote plugin debugging without affecting production behavior

This change allows developers to quickly restart remote plugins during debugging without encountering "no available node, plugin not found" errors.

Fixes #386

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Other

## Essential Checklist

### Testing
- [x] I have tested the changes locally and confirmed they work as expected
- [ ] I have added unit tests where necessary and they pass successfully

### Bug Fix (if applicable)
- [x] I have used GitHub syntax to close the related issue (e.g., `Fixes #123` or `Closes #123`)

## Additional Information

**Problem Context:**
When debugging remote plugins, developers frequently need to make code changes and restart plugins quickly. The current 5-second mandatory sleep delay between plugin restarts causes reconnection failures, resulting in "no available node, plugin not found" errors.

**Solution Details:**
The fix conditionally applies the sleep delay based on plugin runtime type:
- Remote plugins: No sleep delay (immediate restart for better debugging experience)
- Non-remote plugins: Keep the 5-second delay (prevents excessive resource consumption)

**Impact:**
- Improves developer experience during remote plugin debugging
- Maintains existing behavior for production/non-remote plugins
- No breaking changes to existing functionality

**Code Change:**
```go
// Before
time.Sleep(5 * time.Second)

// After  
if r.Type() != plugin_entities.PLUGIN_RUNTIME_TYPE_REMOTE {
    time.Sleep(5 * time.Second)
}
```

**Testing:**
Verified that remote plugins can now be restarted quickly without connection errors during debugging sessions.