### PR TITLE
feat(plugin_manager): dark icons

### DIFF
--- a/internal/core/plugin_manager/media_transport/assets.go
+++ b/internal/core/plugin_manager/media_transport/assets.go
@@ -34,62 +34,38 @@ func (m *MediaBucket) RemapAssets(declaration *plugin_entities.PluginDeclaration
 	var err error
 
 	if declaration.Model != nil {
-		if declaration.Model.IconSmall != nil {
-			if declaration.Model.IconSmall.EnUS != "" {
-				declaration.Model.IconSmall.EnUS, err = remap(declaration.Model.IconSmall.EnUS)
-				if err != nil {
-					return nil, errors.Join(err, fmt.Errorf("failed to remap model icon small en_US"))
-				}
-			}
-
-			if declaration.Model.IconSmall.ZhHans != "" {
-				declaration.Model.IconSmall.ZhHans, err = remap(declaration.Model.IconSmall.ZhHans)
-				if err != nil {
-					return nil, errors.Join(err, fmt.Errorf("failed to remap model icon small zh_Hans"))
-				}
-			}
-
-			if declaration.Model.IconSmall.JaJp != "" {
-				declaration.Model.IconSmall.JaJp, err = remap(declaration.Model.IconSmall.JaJp)
-				if err != nil {
-					return nil, errors.Join(err, fmt.Errorf("failed to remap model icon small ja_JP"))
-				}
-			}
-
-			if declaration.Model.IconSmall.PtBr != "" {
-				declaration.Model.IconSmall.PtBr, err = remap(declaration.Model.IconSmall.PtBr)
-				if err != nil {
-					return nil, errors.Join(err, fmt.Errorf("failed to remap model icon small pt_BR"))
-				}
-			}
+		iconFields := []struct {
+			icon      *plugin_entities.I18nObject
+			iconType  string
+			fieldName string
+		}{
+			{declaration.Model.IconSmall, "model icon small", ""},
+			{declaration.Model.IconLarge, "model icon large", ""},
+			{declaration.Model.IconSmallDark, "model icon small dark", ""},
+			{declaration.Model.IconLargeDark, "model icon large dark", ""},
 		}
 
-		if declaration.Model.IconLarge != nil {
-			if declaration.Model.IconLarge.EnUS != "" {
-				declaration.Model.IconLarge.EnUS, err = remap(declaration.Model.IconLarge.EnUS)
-				if err != nil {
-					return nil, errors.Join(err, fmt.Errorf("failed to remap model icon large en_US"))
-				}
-			}
+		langFields := []struct {
+			get    func(*plugin_entities.I18nObject) *string
+			suffix string
+		}{
+			{func(i *plugin_entities.I18nObject) *string { return &i.EnUS }, "en_US"},
+			{func(i *plugin_entities.I18nObject) *string { return &i.ZhHans }, "zh_Hans"},
+			{func(i *plugin_entities.I18nObject) *string { return &i.JaJp }, "ja_JP"},
+			{func(i *plugin_entities.I18nObject) *string { return &i.PtBr }, "pt_BR"},
+		}
 
-			if declaration.Model.IconLarge.ZhHans != "" {
-				declaration.Model.IconLarge.ZhHans, err = remap(declaration.Model.IconLarge.ZhHans)
-				if err != nil {
-					return nil, errors.Join(err, fmt.Errorf("failed to remap model icon large zh_Hans"))
-				}
+		for _, iconField := range iconFields {
+			if iconField.icon == nil {
+				continue
 			}
-
-			if declaration.Model.IconLarge.JaJp != "" {
-				declaration.Model.IconLarge.JaJp, err = remap(declaration.Model.IconLarge.JaJp)
-				if err != nil {
-					return nil, errors.Join(err, fmt.Errorf("failed to remap model icon large ja_JP"))
-				}
-			}
-
-			if declaration.Model.IconLarge.PtBr != "" {
-				declaration.Model.IconLarge.PtBr, err = remap(declaration.Model.IconLarge.PtBr)
-				if err != nil {
-					return nil, errors.Join(err, fmt.Errorf("failed to remap model icon large pt_BR"))
+			for _, langField := range langFields {
+				valPtr := langField.get(iconField.icon)
+				if valPtr != nil && *valPtr != "" {
+					*valPtr, err = remap(*valPtr)
+					if err != nil {
+						return nil, errors.Join(err, fmt.Errorf("failed to remap %s %s", iconField.iconType, langField.suffix))
+					}
 				}
 			}
 		}
@@ -102,6 +78,13 @@ func (m *MediaBucket) RemapAssets(declaration *plugin_entities.PluginDeclaration
 				return nil, errors.Join(err, fmt.Errorf("failed to remap tool icon"))
 			}
 		}
+
+		if declaration.Tool.Identity.IconDark != "" {
+			declaration.Tool.Identity.IconDark, err = remap(declaration.Tool.Identity.IconDark)
+			if err != nil {
+				return nil, errors.Join(err, fmt.Errorf("failed to remap tool icon dark"))
+			}
+		}
 	}
 
 	if declaration.AgentStrategy != nil {
@@ -109,6 +92,13 @@ func (m *MediaBucket) RemapAssets(declaration *plugin_entities.PluginDeclaration
 			declaration.AgentStrategy.Identity.Icon, err = remap(declaration.AgentStrategy.Identity.Icon)
 			if err != nil {
 				return nil, errors.Join(err, fmt.Errorf("failed to remap agent icon"))
+			}
+		}
+
+		if declaration.AgentStrategy.Identity.IconDark != "" {
+			declaration.AgentStrategy.Identity.IconDark, err = remap(declaration.AgentStrategy.Identity.IconDark)
+			if err != nil {
+				return nil, errors.Join(err, fmt.Errorf("failed to remap agent icon dark"))
 			}
 		}
 	}

--- a/pkg/entities/plugin_entities/model_declaration.go
+++ b/pkg/entities/plugin_entities/model_declaration.go
@@ -628,6 +628,8 @@ type ModelProviderDeclaration struct {
 	Description              *I18nObject                      `json:"description" yaml:"description,omitempty" validate:"omitempty"`
 	IconSmall                *I18nObject                      `json:"icon_small" yaml:"icon_small,omitempty" validate:"omitempty"`
 	IconLarge                *I18nObject                      `json:"icon_large" yaml:"icon_large,omitempty" validate:"omitempty"`
+	IconSmallDark            *I18nObject                      `json:"icon_small_dark" yaml:"icon_small_dark,omitempty" validate:"omitempty"`
+	IconLargeDark            *I18nObject                      `json:"icon_large_dark" yaml:"icon_large_dark,omitempty" validate:"omitempty"`
 	Background               *string                          `json:"background" yaml:"background,omitempty" validate:"omitempty"`
 	Help                     *ModelProviderHelpEntity         `json:"help" yaml:"help,omitempty" validate:"omitempty"`
 	SupportedModelTypes      []ModelType                      `json:"supported_model_types" yaml:"supported_model_types" validate:"required,lte=16,dive,model_type"`

--- a/pkg/entities/plugin_entities/tool_declaration.go
+++ b/pkg/entities/plugin_entities/tool_declaration.go
@@ -202,6 +202,7 @@ type ToolProviderIdentity struct {
 	Name        string                        `json:"name" validate:"required,tool_provider_identity_name"`
 	Description I18nObject                    `json:"description"`
 	Icon        string                        `json:"icon" validate:"required"`
+	IconDark    string                        `json:"icon_dark" validate:"omitempty"`
 	Label       I18nObject                    `json:"label" validate:"required"`
 	Tags        []manifest_entities.PluginTag `json:"tags" validate:"omitempty,dive,plugin_tag"`
 }


### PR DESCRIPTION
## Description
- Refactored the RemapAssets function to streamline the remapping of icon fields for both models and tools, including support for dark mode icons.
- Introduced new fields IconSmallDark and IconLargeDark in the ModelProviderDeclaration and added IconDark in ToolProviderIdentity to accommodate dark mode assets.
- Improved error handling during the remapping process for better clarity and maintainability.

Related PRs:
- https://github.com/langgenius/dify-plugin-sdks/pull/173/

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Other

## Essential Checklist

### Testing
- [ ] I have tested the changes locally and confirmed they work as expected
- [ ] I have added unit tests where necessary and they pass successfully

### Bug Fix (if applicable)
- [ ] I have used GitHub syntax to close the related issue (e.g., `Fixes #123` or `Closes #123`)

## Additional Information

Please provide any additional context that would help reviewers understand the changes. 