### PR TITLE
fix(service/controller): add support for paginated and non-paginated plugin list responses with backward compatibility

### DIFF
--- a/internal/server/controllers/plugins.go
+++ b/internal/server/controllers/plugins.go
@@ -241,11 +241,12 @@ func FetchPluginFromIdentifier(c *gin.Context) {
 
 func ListPlugins(c *gin.Context) {
 	BindRequest(c, func(request struct {
-		TenantID string `uri:"tenant_id" validate:"required"`
-		Page     int    `form:"page" validate:"required,min=1"`
-		PageSize int    `form:"page_size" validate:"required,min=1,max=256"`
+		TenantID     string `uri:"tenant_id" validate:"required"`
+		Page         int    `form:"page" validate:"required,min=1"`
+		PageSize     int    `form:"page_size" validate:"required,min=1,max=256"`
+		ResponseType string `form:"response_type" validate:"omitempty,oneof=paged"`
 	}) {
-		c.JSON(http.StatusOK, service.ListPlugins(request.TenantID, request.Page, request.PageSize))
+		c.JSON(http.StatusOK, service.ListPlugins(request.TenantID, request.Page, request.PageSize, request.ResponseType))
 	})
 }
 

--- a/internal/service/manage_plugin.go
+++ b/internal/service/manage_plugin.go
@@ -14,7 +14,7 @@ import (
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/plugin_entities"
 )
 
-func ListPlugins(tenant_id string, page int, page_size int) *entities.Response {
+func ListPlugins(tenant_id string, page int, page_size int, response_type string) *entities.Response {
 	type installation struct {
 		ID                     string                             `json:"id"`
 		Name                   string                             `json:"name"`
@@ -96,12 +96,15 @@ func ListPlugins(tenant_id string, page int, page_size int) *entities.Response {
 		})
 	}
 
-	finalData := responseData{
-		List: 	data,
-		Total: 	totalCount,
-	}
+	if response_type == "paged" {
+		finalData := responseData{
+			List:  data,
+			Total: totalCount,
+		}
 
-	return entities.NewSuccessResponse(finalData)
+		return entities.NewSuccessResponse(finalData)
+	}
+	return entities.NewSuccessResponse(data)
 }
 
 // Using plugin_ids to fetch plugin installations


### PR DESCRIPTION
… plugin list responses with backward compatibility

## Description

Fixes https://github.com/langgenius/dify/issues/22250
During the upgrade process, we encountered an error (reference issue: xxx). I resolved this by introducing a new response_type parameter in the Plugin Daemon.

**Fix Details:**

1. Added an optional response_type parameter to the /plugin/{tenantId}/management/list API:
 -  If response_type=paged is specified, the endpoint returns a paginated response.
 -  Otherwise, it returns the legacy non-paginated format, ensuring backward compatibility with older versions of Dify.

2. In Dify v1.6.0, the response_type=paged parameter is now included by default when calling this endpoint, aligning it with the updated Plugin Daemon behavior.

**Recommended Upgrade Paths:**

- **For users who have not yet upgraded:**

It's recommended to upgrade Plugin Daemon first, followed by Dify. This ensures a smooth and error-free transition.

- **For users who have already upgraded:**

You should first upgrade Dify to v1.6.0 before upgrading Plugin Daemon, to ensure compatibility between components.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Other

## Essential Checklist

### Testing
- [x] I have tested the changes locally and confirmed they work as expected
- [ ] I have added unit tests where necessary and they pass successfully

### Bug Fix (if applicable)
- [x] I have used GitHub syntax to close the related issue (e.g., `Fixes #123` or `Closes #123`)

## Additional Information

Please provide any additional context that would help reviewers understand the changes. 