### PR TITLE
The s3 signature_version supports transparent passing of environment

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -30,6 +30,7 @@ func initOSS(config *app.Config) oss.OSS {
 			Bucket:       config.PluginStorageOSSBucket,
 			Region:       config.AWSRegion,
 			UseIamRole:   config.S3UseAwsManagedIam,
+			SignatureVersion: config.S3SignatureVersion,
 		},
 		TencentCOS: &oss.TencentCOS{
 			Region:    config.TencentCOSRegion,

--- a/internal/types/app/config.go
+++ b/internal/types/app/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	S3UseAWS           bool   `envconfig:"S3_USE_AWS" default:"true"`
 	S3Endpoint         string `envconfig:"S3_ENDPOINT"`
 	S3UsePathStyle     bool   `envconfig:"S3_USE_PATH_STYLE" default:"true"`
+	S3SignatureVersion string `envconfig:"S3_SIGNATURE_VERSION" default:"s3"`
 	AWSAccessKey       string `envconfig:"AWS_ACCESS_KEY"`
 	AWSSecretKey       string `envconfig:"AWS_SECRET_KEY"`
 	AWSRegion          string `envconfig:"AWS_REGION"`

--- a/internal/types/app/config.go
+++ b/internal/types/app/config.go
@@ -29,7 +29,7 @@ type Config struct {
 	S3UseAWS           bool   `envconfig:"S3_USE_AWS" default:"true"`
 	S3Endpoint         string `envconfig:"S3_ENDPOINT"`
 	S3UsePathStyle     bool   `envconfig:"S3_USE_PATH_STYLE" default:"true"`
-	S3SignatureVersion string `envconfig:"S3_SIGNATURE_VERSION" default:"s3"`
+	S3SignatureVersion string `envconfig:"S3_SIGNATURE_VERSION" default:"v4"`
 	AWSAccessKey       string `envconfig:"AWS_ACCESS_KEY"`
 	AWSSecretKey       string `envconfig:"AWS_SECRET_KEY"`
 	AWSRegion          string `envconfig:"AWS_REGION"`


### PR DESCRIPTION
# Enhanced S3 Configuration Support

This update enhances the S3 storage configuration in the `internal/server/server.go` and `internal/types/app/config.go` files by introducing support for the `S3SignatureVersion` parameter. The changes include:

- Added `S3SignatureVersion` to the `initOSS` function in `internal/server/server.go` to pass the signature version configuration to the OSS setup.
- Extended the `Config` struct in `internal/types/app/config.go` with a new field `S3SignatureVersion string`, defaulting to `"v4"`, allowing flexible specification of the S3 signature version.

These modifications enable better customization of S3 storage operations, providing support for different signature versions to enhance compatibility and flexibility.