### PR TITLE
Add Redis caching to FetchPluginInstallation middleware for performance optimization

### DIFF
--- a/internal/server/endpoint.go
+++ b/internal/server/endpoint.go
@@ -2,9 +2,11 @@ package server
 
 import (
 	"errors"
-	"github.com/langgenius/dify-plugin-daemon/internal/utils/cache"
 	"strings"
 	"time"
+
+	"github.com/langgenius/dify-plugin-daemon/internal/utils/cache"
+	"github.com/langgenius/dify-plugin-daemon/internal/utils/cache/helper"
 
 	"github.com/gin-gonic/gin"
 	"github.com/langgenius/dify-plugin-daemon/internal/db"
@@ -70,15 +72,7 @@ func (app *App) EndpointHandler(ctx *gin.Context, hookId string, maxExecutionTim
 	}
 
 	// get plugin installation
-	pluginInstallationCacheKey := strings.Join(
-		[]string{
-			"plugin_id",
-			endpoint.PluginID,
-			"tenant_id",
-			endpoint.TenantID,
-		},
-		":",
-	)
+	pluginInstallationCacheKey := helper.PluginInstallationCacheKey(endpoint.PluginID, endpoint.TenantID)
 	pluginInstallation, err := cache.AutoGetWithGetter[models.PluginInstallation](
 		pluginInstallationCacheKey,
 		func() (*models.PluginInstallation, error) {

--- a/internal/service/install_plugin.go
+++ b/internal/service/install_plugin.go
@@ -12,6 +12,7 @@ import (
 	"github.com/langgenius/dify-plugin-daemon/internal/types/exception"
 	"github.com/langgenius/dify-plugin-daemon/internal/types/models"
 	"github.com/langgenius/dify-plugin-daemon/internal/types/models/curd"
+	"github.com/langgenius/dify-plugin-daemon/internal/utils/cache"
 	"github.com/langgenius/dify-plugin-daemon/internal/utils/cache/helper"
 	"github.com/langgenius/dify-plugin-daemon/internal/utils/log"
 	"github.com/langgenius/dify-plugin-daemon/internal/utils/routine"
@@ -488,6 +489,10 @@ func UpgradePlugin(
 				return err
 			}
 
+			// invalidate plugin installation cache
+			pluginInstallationCacheKey := helper.PluginInstallationCacheKey(original_plugin_unique_identifier.PluginID(), tenant_id)
+			_, _ = cache.AutoDelete[models.PluginInstallation](pluginInstallationCacheKey)
+
 			if upgradeResponse.IsOriginalPluginDeleted {
 				// delete the plugin if no installation left
 				manager := plugin_manager.Manager()
@@ -686,6 +691,10 @@ func UninstallPlugin(
 	if err != nil {
 		return exception.InternalServerError(fmt.Errorf("failed to uninstall plugin: %s", err.Error())).ToResponse()
 	}
+
+	// invalidate plugin installation cache
+	pluginInstallationCacheKey := helper.PluginInstallationCacheKey(pluginUniqueIdentifier.PluginID(), tenant_id)
+	_, _ = cache.AutoDelete[models.PluginInstallation](pluginInstallationCacheKey)
 
 	if deleteResponse.IsPluginDeleted {
 		// delete the plugin if no installation left

--- a/internal/types/models/curd/atomic.go
+++ b/internal/types/models/curd/atomic.go
@@ -188,10 +188,6 @@ func UninstallPlugin(
 		db.Equal("tenant_id", tenantId),
 	)
 
-	pluginInstallationCacheKey := helper.PluginInstallationCacheKey(pluginUniqueIdentifier.PluginID(), tenantId)
-
-	_, _ = cache.AutoDelete[models.PluginInstallation](pluginInstallationCacheKey)
-
 	if err != nil {
 		if err == db.ErrDatabaseNotFound {
 			return nil, errors.New("plugin has not been installed")
@@ -290,6 +286,9 @@ func UninstallPlugin(
 	if err != nil {
 		return nil, err
 	}
+
+	pluginInstallationCacheKey := helper.PluginInstallationCacheKey(pluginUniqueIdentifier.PluginID(), tenantId)
+	_, _ = cache.AutoDelete[models.PluginInstallation](pluginInstallationCacheKey)
 
 	return &DeletePluginResponse{
 		Plugin:          pluginToBeReturns,
@@ -498,6 +497,10 @@ func UpgradePlugin(
 	if err != nil {
 		return nil, err
 	}
+
+	// invalidate original plugin installation cache
+	cacheKey := helper.PluginInstallationCacheKey(originalPluginUniqueIdentifier.PluginID(), tenantId)
+	_, _ = cache.AutoDelete[models.PluginInstallation](cacheKey)
 
 	return &response, nil
 }

--- a/internal/types/models/curd/atomic.go
+++ b/internal/types/models/curd/atomic.go
@@ -3,9 +3,6 @@ package curd
 import (
 	"errors"
 
-	"github.com/langgenius/dify-plugin-daemon/internal/utils/cache"
-	"github.com/langgenius/dify-plugin-daemon/internal/utils/cache/helper"
-
 	"github.com/langgenius/dify-plugin-daemon/internal/db"
 	"github.com/langgenius/dify-plugin-daemon/internal/types/models"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/manifest_entities"
@@ -287,8 +284,6 @@ func UninstallPlugin(
 		return nil, err
 	}
 
-	pluginInstallationCacheKey := helper.PluginInstallationCacheKey(pluginUniqueIdentifier.PluginID(), tenantId)
-	_, _ = cache.AutoDelete[models.PluginInstallation](pluginInstallationCacheKey)
 
 	return &DeletePluginResponse{
 		Plugin:          pluginToBeReturns,
@@ -498,9 +493,6 @@ func UpgradePlugin(
 		return nil, err
 	}
 
-	// invalidate original plugin installation cache
-	cacheKey := helper.PluginInstallationCacheKey(originalPluginUniqueIdentifier.PluginID(), tenantId)
-	_, _ = cache.AutoDelete[models.PluginInstallation](cacheKey)
 
 	return &response, nil
 }

--- a/internal/types/models/curd/atomic.go
+++ b/internal/types/models/curd/atomic.go
@@ -2,9 +2,9 @@ package curd
 
 import (
 	"errors"
-	"strings"
 
 	"github.com/langgenius/dify-plugin-daemon/internal/utils/cache"
+	"github.com/langgenius/dify-plugin-daemon/internal/utils/cache/helper"
 
 	"github.com/langgenius/dify-plugin-daemon/internal/db"
 	"github.com/langgenius/dify-plugin-daemon/internal/types/models"
@@ -188,15 +188,7 @@ func UninstallPlugin(
 		db.Equal("tenant_id", tenantId),
 	)
 
-	pluginInstallationCacheKey := strings.Join(
-		[]string{
-			"plugin_id",
-			pluginUniqueIdentifier.PluginID(),
-			"tenant_id",
-			tenantId,
-		},
-		":",
-	)
+	pluginInstallationCacheKey := helper.PluginInstallationCacheKey(pluginUniqueIdentifier.PluginID(), tenantId)
 
 	_, _ = cache.AutoDelete[models.PluginInstallation](pluginInstallationCacheKey)
 

--- a/internal/utils/cache/helper/keys.go
+++ b/internal/utils/cache/helper/keys.go
@@ -13,3 +13,13 @@ func PluginInstallationCacheKey(pluginId, tenantId string) string {
 		":",
 	)
 }
+
+func EndpointCacheKey(hookId string) string {
+	return strings.Join(
+		[]string{
+			"hook_id",
+			hookId,
+		},
+		":",
+	)
+}

--- a/internal/utils/cache/helper/keys.go
+++ b/internal/utils/cache/helper/keys.go
@@ -1,0 +1,15 @@
+package helper
+
+import "strings"
+
+func PluginInstallationCacheKey(pluginId, tenantId string) string {
+	return strings.Join(
+		[]string{
+			"plugin_id",
+			pluginId,
+			"tenant_id",
+			tenantId,
+		},
+		":",
+	)
+}


### PR DESCRIPTION
## Description

This PR implements Redis caching for the `FetchPluginInstallation` middleware to improve performance by reducing database queries for frequently accessed plugin installation data.

**Problem**: The `FetchPluginInstallation` middleware was called frequently and performed a database query on each request, causing performance issues due to repeated database access for the same plugin installation data.

**Solution**: Added Redis caching using the existing `AutoGetWithGetter` pattern to reduce database load and improve response times for frequent plugin installation lookups.

Closes #399 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Performance improvement
- [ ] Other

## Essential Checklist

### Testing
- [x] I have tested the changes locally and confirmed they work as expected
- [] I have added unit tests where necessary and they pass successfully

### Bug Fix (if applicable)
- [ ] I have used GitHub syntax to close the related issue (e.g., `Fixes #123` or `Closes #123`)

## Additional Information

### Implementation Details

**Files Modified:**
1. **`internal/utils/cache/helper/keys.go`** (new file)
   - Added `PluginInstallationCacheKey()` function for consistent cache key generation
   - Format: `"plugin_id:{pluginId}:tenant_id:{tenantId}"`

2. **`internal/server/middleware.go`** 
   - Modified `FetchPluginInstallation()` to use `cache.AutoGetWithGetter()`
   - Added cache and helper package imports
   - Maintains existing error handling logic
   - Fixed pointer dereferencing for context storage

3. **`internal/server/endpoint.go`**
   - Updated `EndpointHandler()` to use shared cache key helper
   - Replaced inline cache key construction with centralized function
   - Improved import organization

4. **`internal/types/models/curd/atomic.go`**
   - Updated `UninstallPlugin()` to use shared cache key helper
   - Replaced inline cache key construction with centralized function
   - Removed unused `strings` import

### Benefits:
- **Performance**: Reduces database queries for frequently accessed plugin installations
- **Consistency**: Uses existing Redis infrastructure and follows established patterns
- **Maintainability**: Centralized cache key construction prevents inconsistencies
- **Automatic TTL**: 30-minute cache expiration via `AutoGetWithGetter`

### Cache Strategy:
- Cache hit: Returns cached plugin installation immediately
- Cache miss: Fetches from database, caches result, then returns
- Cache invalidation: Handled automatically on plugin uninstall 