### PR TITLE
feat/tool oauth cli template

### DIFF
--- a/cmd/commandline/plugin/templates/python/requirements.txt
+++ b/cmd/commandline/plugin/templates/python/requirements.txt
@@ -1,1 +1,1 @@
-dify_plugin>=0.2.0,<0.3.0
+dify_plugin>=0.4.2

--- a/cmd/commandline/plugin/templates/python/requirements.txt
+++ b/cmd/commandline/plugin/templates/python/requirements.txt
@@ -1,1 +1,1 @@
-dify_plugin>=0.4.2
+dify_plugin>=0.2.0,<0.3.0

--- a/cmd/commandline/plugin/templates/python/tool_provider.py
+++ b/cmd/commandline/plugin/templates/python/tool_provider.py
@@ -1,8 +1,7 @@
-from typing import Any, Mapping
+from typing import Any
 
 from dify_plugin import ToolProvider
-from dify_plugin.errors.tool import ToolProviderCredentialValidationError, ToolProviderOAuthError
-from dify_plugin.interfaces.tool import Request
+from dify_plugin.errors.tool import ToolProviderCredentialValidationError
 
 
 class {{ .PluginName | SnakeToCamel }}Provider(ToolProvider):
@@ -15,28 +14,32 @@ class {{ .PluginName | SnakeToCamel }}Provider(ToolProvider):
         except Exception as e:
             raise ToolProviderCredentialValidationError(str(e))
 
-    def _oauth_get_authorization_url(self, redirect_uri: str, system_credentials: Mapping[str, Any]) -> str:
-        """
-        Generate the authorization URL for {{ .PluginName }} OAuth.
-        """
-        try:
-            """
-            IMPLEMENT YOUR AUTHORIZATION URL GENERATION HERE
-            """
-        except Exception as e:
-            raise ToolProviderOAuthError(str(e))
-        return ""
+    #########################################################################################
+    # If OAuth is supported, uncomment the following functions.
+    # Warning: please make sure that the sdk version is 0.4.2 or higher.
+    #########################################################################################
+    # def _oauth_get_authorization_url(self, redirect_uri: str, system_credentials: Mapping[str, Any]) -> str:
+    #     """
+    #     Generate the authorization URL for {{ .PluginName }} OAuth.
+    #     """
+    #     try:
+    #         """
+    #         IMPLEMENT YOUR AUTHORIZATION URL GENERATION HERE
+    #         """
+    #     except Exception as e:
+    #         raise ToolProviderOAuthError(str(e))
+    #     return ""
         
-    def _oauth_get_credentials(
-        self, redirect_uri: str, system_credentials: Mapping[str, Any], request: Request
-    ) -> Mapping[str, Any]:
-        """
-        Exchange code for access_token.
-        """
-        try:
-            """
-            IMPLEMENT YOUR CREDENTIALS EXCHANGE HERE
-            """
-        except Exception as e:
-            raise ToolProviderOAuthError(str(e))
-        return dict()
+    # def _oauth_get_credentials(
+    #     self, redirect_uri: str, system_credentials: Mapping[str, Any], request: Request
+    # ) -> Mapping[str, Any]:
+    #     """
+    #     Exchange code for access_token.
+    #     """
+    #     try:
+    #         """
+    #         IMPLEMENT YOUR CREDENTIALS EXCHANGE HERE
+    #         """
+    #     except Exception as e:
+    #         raise ToolProviderOAuthError(str(e))
+    #     return dict()

--- a/cmd/commandline/plugin/templates/python/tool_provider.py
+++ b/cmd/commandline/plugin/templates/python/tool_provider.py
@@ -1,10 +1,12 @@
-from typing import Any
+from typing import Any, Mapping
 
 from dify_plugin import ToolProvider
-from dify_plugin.errors.tool import ToolProviderCredentialValidationError
+from dify_plugin.errors.tool import ToolProviderCredentialValidationError, ToolProviderOAuthError
+from dify_plugin.interfaces.tool import Request
 
 
 class {{ .PluginName | SnakeToCamel }}Provider(ToolProvider):
+    
     def _validate_credentials(self, credentials: dict[str, Any]) -> None:
         try:
             """
@@ -12,3 +14,29 @@ class {{ .PluginName | SnakeToCamel }}Provider(ToolProvider):
             """
         except Exception as e:
             raise ToolProviderCredentialValidationError(str(e))
+
+    def _oauth_get_authorization_url(self, redirect_uri: str, system_credentials: Mapping[str, Any]) -> str:
+        """
+        Generate the authorization URL for {{ .PluginName }} OAuth.
+        """
+        try:
+            """
+            IMPLEMENT YOUR AUTHORIZATION URL GENERATION HERE
+            """
+        except Exception as e:
+            raise ToolProviderOAuthError(str(e))
+        return ""
+        
+    def _oauth_get_credentials(
+        self, redirect_uri: str, system_credentials: Mapping[str, Any], request: Request
+    ) -> Mapping[str, Any]:
+        """
+        Exchange code for access_token.
+        """
+        try:
+            """
+            IMPLEMENT YOUR CREDENTIALS EXCHANGE HERE
+            """
+        except Exception as e:
+            raise ToolProviderOAuthError(str(e))
+        return dict()

--- a/cmd/commandline/plugin/templates/python/tool_provider.yaml
+++ b/cmd/commandline/plugin/templates/python/tool_provider.yaml
@@ -10,6 +10,49 @@ identity:
     zh_Hans: "{{ .PluginDescription }}"
     pt_BR: "{{ .PluginDescription }}"
   icon: "icon.svg"
+
+#########################################################################################
+# If you want to support OAuth, you can uncomment the following code.
+#########################################################################################
+# oauth_schema:
+#   client_schema:
+#     - name: "client_id"
+#       type: "secret-input"
+#       required: true
+#       url: https://example.com/oauth/authorize
+#       placeholder:
+#         en_US: "Please input your Client ID"
+#         zh_Hans: "请输入你的 Client ID"
+#         pt_BR: "Insira seu Client ID"
+#       help:
+#         en_US: "Client ID is used to authenticate requests to the example.com API."
+#         zh_Hans: "Client ID 用于认证请求到 example.com API。"
+#         pt_BR: "Client ID é usado para autenticar solicitações à API do example.com."
+#       label:
+#         zh_Hans: "Client ID"
+#         en_US: "Client ID"
+#     - name: "client_secret"
+#       type: "secret-input"
+#       required: true
+#       url: https://example.com/oauth/authorize
+#       placeholder:
+#         en_US: "Please input your Client Secret"
+#         zh_Hans: "请输入你的 Client Secret"
+#         pt_BR: "Insira seu Client Secret"
+#       help:
+#         en_US: "Client Secret is used to authenticate requests to the example.com API."
+#         zh_Hans: "Client Secret 用于认证请求到 example.com API。"
+#         pt_BR: "Client Secret é usado para autenticar solicitações à API do example.com."
+#       label:
+#         zh_Hans: "Client Secret"
+#         en_US: "Client Secret"
+#   credentials_schema:
+#     - name: "access_token"
+#       type: "secret-input"
+#       label:
+#         zh_Hans: "Access Token"
+#         en_US: "Access Token"
+
 tools:
   - tools/{{ .PluginName }}.yaml
 extra:


### PR DESCRIPTION
## Description
This pull request introduces changes to enhance OAuth support in the Python tool provider template. It includes updates to the Python implementation and the YAML configuration to provide a foundation for OAuth integration, though the relevant code is currently commented out for optional use.

### OAuth-related changes:

* **Python Implementation (`tool_provider.py`)**:
  - Added placeholder methods `_oauth_get_authorization_url` and `_oauth_get_credentials` to support OAuth functionality, with instructions for implementation. These methods are commented out by default.
  - Imported the `Request` interface from `dify_plugin.interfaces.tool` to support OAuth request handling.

* **YAML Configuration (`tool_provider.yaml`)**:
  - Added a commented-out `oauth_schema` section, which defines the client and credential schemas for OAuth integration, including fields for `client_id`, `client_secret`, and `access_token`, with multi-language support for placeholders, help texts, and labels.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [x] Other

## Essential Checklist

### Testing
- [ ] I have tested the changes locally and confirmed they work as expected
- [ ] I have added unit tests where necessary and they pass successfully

## Additional Information

Please provide any additional context that would help reviewers understand the changes. 