### PR TITLE
fix(env): update REMOTE_INSTALL_URL format in .env.example

### DIFF
--- a/cmd/commandline/plugin/templates/.env.example
+++ b/cmd/commandline/plugin/templates/.env.example
@@ -1,4 +1,3 @@
 INSTALL_METHOD=remote
-REMOTE_INSTALL_URL=debug.dify.ai
-REMOTE_INSTALL_PORT=5003
+REMOTE_INSTALL_URL=debug.dify.ai:5003
 REMOTE_INSTALL_KEY=********-****-****-****-************


### PR DESCRIPTION
- Combined REMOTE_INSTALL_URL and REMOTE_INSTALL_PORT into a single line for clarity.
- This change improves the configuration format for easier understanding and usage.

## Description

Please provide a brief description of the changes made in this pull request.
Please also include the issue number if this is related to an issue using the format `Fixes #123` or `Closes #123`.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Other

## Essential Checklist

### Testing
- [ ] I have tested the changes locally and confirmed they work as expected
- [ ] I have added unit tests where necessary and they pass successfully

### Bug Fix (if applicable)
- [ ] I have used GitHub syntax to close the related issue (e.g., `Fixes #123` or `Closes #123`)

## Additional Information

Please provide any additional context that would help reviewers understand the changes. 