### PR TITLE
fix Frequent plugin pulls

### DIFF
--- a/internal/core/plugin_manager/watcher.go
+++ b/internal/core/plugin_manager/watcher.go
@@ -81,6 +81,11 @@ func (p *PluginManager) handleNewLocalPlugins(config *app.Config) {
 	sem := make(chan struct{}, maxConcurrency)
 
 	for _, plugin := range plugins {
+		_, exist := p.m.Load(plugin.String())
+		if exist {
+			continue
+		}
+
 		wg.Add(1)
 		// Fix closure issue: create local variable copy
 		currentPlugin := plugin


### PR DESCRIPTION
## Description

Please provide a brief description of the changes made in this pull request.
Please also include the issue number if this is related to an issue using the format `Fixes #123` or `Closes #123`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Other

## Essential Checklist

### Testing
- [x] I have tested the changes locally and confirmed they work as expected
- [ ] I have added unit tests where necessary and they pass successfully

### Bug Fix (if applicable)
- [x] I have used GitHub syntax to close the related issue (e.g., `Fixes #123` or `Closes #123`)
Fixes #416 

## Additional Information
Fix the frequent pull issue of the plugin by prioritizing the check to see if the plugin is already running. If it is, do not pull the remote file to start it again.

Please provide any additional context that would help reviewers understand the changes. 