### PR TITLE
fix: add missing types of tool_parameter

### DIFF
--- a/pkg/entities/plugin_entities/constant.go
+++ b/pkg/entities/plugin_entities/constant.go
@@ -16,6 +16,8 @@ const (
 	ANY            = "any"
 	// DynamicSelect
 	DYNAMIC_SELECT = "dynamic-select"
+	ARRAY          = "array"
+	OBJECT         = "object"
 )
 
 type ParameterOption struct {

--- a/pkg/entities/plugin_entities/tool_declaration.go
+++ b/pkg/entities/plugin_entities/tool_declaration.go
@@ -48,6 +48,8 @@ const (
 	// TOOL_PARAMETER_TYPE_TOOL_SELECTOR  ToolParameterType = TOOL_SELECTOR
 	TOOL_PARAMETER_TYPE_ANY            ToolParameterType = ANY
 	TOOL_PARAMETER_TYPE_DYNAMIC_SELECT ToolParameterType = DYNAMIC_SELECT
+	TOOL_PARAMETER_ARRAY               ToolParameterType = ARRAY
+	TOOL_PARAMETER_OBJECT              ToolParameterType = OBJECT
 )
 
 func isToolParameterType(fl validator.FieldLevel) bool {
@@ -64,7 +66,9 @@ func isToolParameterType(fl validator.FieldLevel) bool {
 		string(TOOL_PARAMETER_TYPE_APP_SELECTOR),
 		string(TOOL_PARAMETER_TYPE_MODEL_SELECTOR),
 		string(TOOL_PARAMETER_TYPE_ANY),
-		string(TOOL_PARAMETER_TYPE_DYNAMIC_SELECT):
+		string(TOOL_PARAMETER_TYPE_DYNAMIC_SELECT),
+		string(TOOL_PARAMETER_ARRAY),
+		string(TOOL_PARAMETER_OBJECT):
 		return true
 	}
 	return false


### PR DESCRIPTION
## Description

<!--
Please provide a brief description of the changes made in this pull request.
Please also include the issue number if this is related to an issue using the format `Fixes #123` or `Closes #123`.
-->

Add missing types of tool_parameter:

```Go
	TOOL_PARAMETER_ARRAY               ToolParameterType = ARRAY
	TOOL_PARAMETER_OBJECT              ToolParameterType = OBJECT
```


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Other

## Essential Checklist

### Testing
- [x] I have tested the changes locally and confirmed they work as expected
- [ ] I have added unit tests where necessary and they pass successfully

### Bug Fix (if applicable)
- [ ] I have used GitHub syntax to close the related issue (e.g., `Fixes #123` or `Closes #123`)

## Additional Information

Please provide any additional context that would help reviewers understand the changes. 