### PR TITLE
feat: propagate plugin unique identifier to serverless control plane

### DIFF
--- a/internal/core/plugin_manager/install_to_serverless.go
+++ b/internal/core/plugin_manager/install_to_serverless.go
@@ -8,7 +8,6 @@ import (
 	"github.com/langgenius/dify-plugin-daemon/internal/types/models"
 	"github.com/langgenius/dify-plugin-daemon/internal/utils/routine"
 	"github.com/langgenius/dify-plugin-daemon/internal/utils/stream"
-	"github.com/langgenius/dify-plugin-daemon/pkg/entities/plugin_entities"
 	"github.com/langgenius/dify-plugin-daemon/pkg/plugin_packager/decoder"
 )
 
@@ -126,7 +125,6 @@ func (p *PluginManager) InstallToServerlessFromPkg(
  * Reinstall a plugin to Serverless, update function url and name
  */
 func (p *PluginManager) ReinstallToServerlessFromPkg(
-	pluginUniqueIdentifier plugin_entities.PluginUniqueIdentifier,
 	originalPackager []byte,
 	decoder decoder.PluginDecoder,
 ) (
@@ -158,7 +156,7 @@ func (p *PluginManager) ReinstallToServerlessFromPkg(
 	}
 
 	response, err := serverless.LaunchPlugin(
-		pluginUniqueIdentifier,
+		uniqueIdentity,
 		originalPackager,
 		decoder,
 		p.config.DifyPluginServerlessConnectorLaunchTimeout,

--- a/internal/core/plugin_manager/install_to_serverless.go
+++ b/internal/core/plugin_manager/install_to_serverless.go
@@ -8,6 +8,7 @@ import (
 	"github.com/langgenius/dify-plugin-daemon/internal/types/models"
 	"github.com/langgenius/dify-plugin-daemon/internal/utils/routine"
 	"github.com/langgenius/dify-plugin-daemon/internal/utils/stream"
+	"github.com/langgenius/dify-plugin-daemon/pkg/entities/plugin_entities"
 	"github.com/langgenius/dify-plugin-daemon/pkg/plugin_packager/decoder"
 )
 
@@ -35,7 +36,7 @@ func (p *PluginManager) InstallToServerlessFromPkg(
 	}
 
 	// serverless.LaunchPlugin will check if the plugin has already been launched, if so, it returns directly
-	response, err := serverless.LaunchPlugin(originalPackager, decoder, p.config.DifyPluginServerlessConnectorLaunchTimeout, false)
+	response, err := serverless.LaunchPlugin(uniqueIdentity, originalPackager, decoder, p.config.DifyPluginServerlessConnectorLaunchTimeout, false)
 	if err != nil {
 		return nil, err
 	}
@@ -125,6 +126,7 @@ func (p *PluginManager) InstallToServerlessFromPkg(
  * Reinstall a plugin to Serverless, update function url and name
  */
 func (p *PluginManager) ReinstallToServerlessFromPkg(
+	pluginUniqueIdentifier plugin_entities.PluginUniqueIdentifier,
 	originalPackager []byte,
 	decoder decoder.PluginDecoder,
 ) (
@@ -156,6 +158,7 @@ func (p *PluginManager) ReinstallToServerlessFromPkg(
 	}
 
 	response, err := serverless.LaunchPlugin(
+		pluginUniqueIdentifier,
 		originalPackager,
 		decoder,
 		p.config.DifyPluginServerlessConnectorLaunchTimeout,

--- a/internal/core/plugin_manager/serverless_connector/launch.go
+++ b/internal/core/plugin_manager/serverless_connector/launch.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/langgenius/dify-plugin-daemon/internal/utils/cache"
 	"github.com/langgenius/dify-plugin-daemon/internal/utils/stream"
+	"github.com/langgenius/dify-plugin-daemon/pkg/entities/plugin_entities"
 	"github.com/langgenius/dify-plugin-daemon/pkg/plugin_packager/decoder"
 )
 
@@ -16,6 +17,7 @@ var (
 // LaunchPlugin uploads the plugin to specific serverless connector
 // return the function url and name
 func LaunchPlugin(
+	pluginUniqueIdentifier plugin_entities.PluginUniqueIdentifier,
 	originPackage []byte,
 	decoder decoder.PluginDecoder,
 	timeout int, // in seconds
@@ -63,7 +65,7 @@ func LaunchPlugin(
 		}
 	}
 
-	response, err := SetupFunction(manifest, checksum, bytes.NewReader(originPackage), timeout)
+	response, err := SetupFunction(pluginUniqueIdentifier, manifest, checksum, bytes.NewReader(originPackage), timeout)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/service/install_plugin.go
+++ b/internal/service/install_plugin.go
@@ -361,7 +361,7 @@ func ReinstallPluginFromIdentifier(
 		if err != nil {
 			return nil, errors.Join(err, errors.New("failed to create zip decoder"))
 		}
-		stream, err := manager.ReinstallToServerlessFromPkg(pkgFile, zipDecoder)
+		stream, err := manager.ReinstallToServerlessFromPkg(pluginUniqueIdentifier, pkgFile, zipDecoder)
 		if err != nil {
 			return nil, errors.Join(err, errors.New("failed to reinstall plugin"))
 		}

--- a/internal/service/install_plugin.go
+++ b/internal/service/install_plugin.go
@@ -361,7 +361,7 @@ func ReinstallPluginFromIdentifier(
 		if err != nil {
 			return nil, errors.Join(err, errors.New("failed to create zip decoder"))
 		}
-		stream, err := manager.ReinstallToServerlessFromPkg(pluginUniqueIdentifier, pkgFile, zipDecoder)
+		stream, err := manager.ReinstallToServerlessFromPkg(pkgFile, zipDecoder)
 		if err != nil {
 			return nil, errors.Join(err, errors.New("failed to reinstall plugin"))
 		}


### PR DESCRIPTION
## Description

When installing plugin to serverless, propagate plugin unique identifier to serverless control plane for easier resource aggregation.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Other

## Essential Checklist

### Testing
- [x] I have tested the changes locally and confirmed they work as expected
- [ ] I have added unit tests where necessary and they pass successfully

### Bug Fix (if applicable)
- [ ] I have used GitHub syntax to close the related issue (e.g., `Fixes #123` or `Closes #123`)

## Additional Information

Please provide any additional context that would help reviewers understand the changes. 