### PR TITLE
refactor: rename AWS references to Serverless in plugin daemon

### DIFF
--- a/internal/core/plugin_daemon/backwards_invocation/request.go
+++ b/internal/core/plugin_daemon/backwards_invocation/request.go
@@ -18,7 +18,7 @@ type BackwardsInvocationWriter interface {
 // For different plugin runtime type, stream handler is different
 //  1. Local and Remote: they are both full duplex, multiplexing could be implemented by different session
 //     different session share the same physical channel.
-//  2. AWS: it is half duplex, one request could have multiple channels, we need to combine them into one stream
+//  2. Serverless: it is half duplex, one request could have multiple channels, we need to combine them into one stream
 //
 // That's why it has a writer, for different transaction, the writer is unique
 type BackwardsInvocation struct {

--- a/internal/core/plugin_daemon/backwards_invocation/transaction/aws_event_writer.go
+++ b/internal/core/plugin_daemon/backwards_invocation/transaction/aws_event_writer.go
@@ -13,28 +13,28 @@ type WriteFlushCloser interface {
 	Flush()
 }
 
-// AWSTransactionWriter is a writer that implements the backwards_invocation.BackwardsInvocationWriter interface
+// ServerlessTransactionWriter is a writer that implements the backwards_invocation.BackwardsInvocationWriter interface
 // it is used to write data to the plugin runtime
-type AWSTransactionWriter struct {
+type ServerlessTransactionWriter struct {
 	session          *session_manager.Session
 	writeFlushCloser WriteFlushCloser
 
 	backwards_invocation.BackwardsInvocationWriter
 }
 
-// NewAWSTransactionWriter creates a new transaction writer
-func NewAWSTransactionWriter(
+// NewServerlessTransactionWriter creates a new transaction writer
+func NewServerlessTransactionWriter(
 	session *session_manager.Session,
 	writeFlushCloser WriteFlushCloser,
-) *AWSTransactionWriter {
-	return &AWSTransactionWriter{
+) *ServerlessTransactionWriter {
+	return &ServerlessTransactionWriter{
 		session:          session,
 		writeFlushCloser: writeFlushCloser,
 	}
 }
 
 // Write writes the event and data to the session
-func (w *AWSTransactionWriter) Write(event session_manager.PLUGIN_IN_STREAM_EVENT, data any) error {
+func (w *ServerlessTransactionWriter) Write(event session_manager.PLUGIN_IN_STREAM_EVENT, data any) error {
 	_, err := w.writeFlushCloser.Write(append(w.session.Message(event, data), '\n', '\n'))
 	if err != nil {
 		return err
@@ -43,6 +43,6 @@ func (w *AWSTransactionWriter) Write(event session_manager.PLUGIN_IN_STREAM_EVEN
 	return err
 }
 
-func (w *AWSTransactionWriter) Done() {
+func (w *ServerlessTransactionWriter) Done() {
 	w.writeFlushCloser.Close()
 }

--- a/internal/core/plugin_daemon/generic.go
+++ b/internal/core/plugin_daemon/generic.go
@@ -40,11 +40,10 @@ func GenericInvokePlugin[Req any, Rsp any](
 				response.WriteBlocking(chunk)
 			}
 		case plugin_entities.SESSION_MESSAGE_TYPE_INVOKE:
-			// check if the request contains a aws_event_id
 			if runtime.Type() == plugin_entities.PLUGIN_RUNTIME_TYPE_SERVERLESS {
 				response.WriteError(errors.New(parser.MarshalJson(map[string]string{
-					"error_type": "aws_event_not_supported",
-					"message":    "aws event is not supported by full duplex",
+					"error_type": "serverless_event_not_supported",
+					"message":    "serverless event is not supported by full duplex",
 				})))
 				response.Close()
 				return

--- a/internal/core/plugin_manager/install_to_serverless.go
+++ b/internal/core/plugin_manager/install_to_serverless.go
@@ -11,8 +11,8 @@ import (
 	"github.com/langgenius/dify-plugin-daemon/pkg/plugin_packager/decoder"
 )
 
-// InstallToAWSFromPkg installs a plugin to AWS Lambda
-func (p *PluginManager) InstallToAWSFromPkg(
+// InstallToServerlessFromPkg installs a plugin to Serverless
+func (p *PluginManager) InstallToServerlessFromPkg(
 	originalPackager []byte,
 	decoder decoder.PluginDecoder,
 	source string,
@@ -43,7 +43,7 @@ func (p *PluginManager) InstallToAWSFromPkg(
 	newResponse := stream.NewStream[PluginInstallResponse](128)
 	routine.Submit(map[string]string{
 		"module":          "plugin_manager",
-		"function":        "InstallToAWSFromPkg",
+		"function":        "InstallToServerlessFromPkg",
 		"checksum":        checksum,
 		"unique_identity": uniqueIdentity.String(),
 		"source":          source,
@@ -122,9 +122,9 @@ func (p *PluginManager) InstallToAWSFromPkg(
 }
 
 /*
- * Reinstall a plugin to AWS Lambda, update function url and name
+ * Reinstall a plugin to Serverless, update function url and name
  */
-func (p *PluginManager) ReinstallToAWSFromPkg(
+func (p *PluginManager) ReinstallToServerlessFromPkg(
 	originalPackager []byte,
 	decoder decoder.PluginDecoder,
 ) (
@@ -168,7 +168,7 @@ func (p *PluginManager) ReinstallToAWSFromPkg(
 	newResponse := stream.NewStream[PluginInstallResponse](128)
 	routine.Submit(map[string]string{
 		"module":          "plugin_manager",
-		"function":        "ReinstallToAWSFromPkg",
+		"function":        "ReinstallToServerlessFromPkg",
 		"checksum":        checksum,
 		"unique_identity": uniqueIdentity.String(),
 	}, func() {

--- a/internal/core/plugin_manager/serverless_connector/launch.go
+++ b/internal/core/plugin_manager/serverless_connector/launch.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	AWS_LAUNCH_LOCK_PREFIX = "aws_launch_lock_"
+	SERVERLESS_LAUNCH_LOCK_PREFIX = "serverless_launch_lock_"
 )
 
 // LaunchPlugin uploads the plugin to specific serverless connector
@@ -27,10 +27,10 @@ func LaunchPlugin(
 	}
 
 	// check if the plugin has already been initialized, at most 300s
-	if err := cache.Lock(AWS_LAUNCH_LOCK_PREFIX+checksum, 300*time.Second, 300*time.Second); err != nil {
+	if err := cache.Lock(SERVERLESS_LAUNCH_LOCK_PREFIX+checksum, 300*time.Second, 300*time.Second); err != nil {
 		return nil, err
 	}
-	defer cache.Unlock(AWS_LAUNCH_LOCK_PREFIX + checksum)
+	defer cache.Unlock(SERVERLESS_LAUNCH_LOCK_PREFIX + checksum)
 
 	manifest, err := decoder.Manifest()
 	if err != nil {

--- a/internal/core/plugin_manager/serverless_runtime/io.go
+++ b/internal/core/plugin_manager/serverless_runtime/io.go
@@ -23,7 +23,7 @@ func (r *ServerlessPluginRuntime) Listen(sessionId string) *entities.Broadcast[p
 	return l
 }
 
-// For AWS Lambda, write is equivalent to http request, it's not a normal stream like stdio and tcp
+// For Serverless, write is equivalent to http request, it's not a normal stream like stdio and tcp
 func (r *ServerlessPluginRuntime) Write(sessionId string, action access_types.PluginAccessAction, data []byte) {
 	l, ok := r.listeners.Load(sessionId)
 	if !ok {
@@ -76,10 +76,10 @@ func (r *ServerlessPluginRuntime) Write(sessionId string, action access_types.Pl
 				Type: plugin_entities.SESSION_MESSAGE_TYPE_ERROR,
 				Data: parser.MarshalJsonBytes(plugin_entities.ErrorResponse{
 					ErrorType: "PluginDaemonInnerError",
-					Message:   fmt.Sprintf("Error sending request to aws lambda: %v", err),
+					Message:   fmt.Sprintf("Error sending request to serverless: %v", err),
 				}),
 			})
-			r.Error(fmt.Sprintf("Error sending request to aws lambda: %v", err))
+			r.Error(fmt.Sprintf("Error sending request to serverless: %v", err))
 			return
 		}
 

--- a/internal/server/app.go
+++ b/internal/server/app.go
@@ -14,7 +14,7 @@ type App struct {
 	// customize behavior of endpoint
 	endpointHandler EndpointHandler
 
-	// aws transaction handler
-	// accept aws transaction request and forward to the plugin daemon
-	awsTransactionHandler *transaction.AWSTransactionHandler
+	// serverless transaction handler
+	// accept serverless transaction request and forward to the plugin daemon
+	serverlessTransactionHandler *transaction.ServerlessTransactionHandler
 }

--- a/internal/service/aws_transaction.go
+++ b/internal/service/aws_transaction.go
@@ -5,7 +5,7 @@ import (
 	"github.com/langgenius/dify-plugin-daemon/internal/core/plugin_daemon/backwards_invocation/transaction"
 )
 
-func HandleAWSPluginTransaction(handler *transaction.AWSTransactionHandler) gin.HandlerFunc {
+func HandleServerlessPluginTransaction(handler *transaction.ServerlessTransactionHandler) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		// get session id from the context
 		sessionId := c.Request.Header.Get("Dify-Plugin-Session-ID")

--- a/internal/service/install_plugin.go
+++ b/internal/service/install_plugin.go
@@ -215,7 +215,7 @@ func InstallPluginRuntimeToTenant(
 					})
 					return
 				}
-				stream, err = manager.InstallToAWSFromPkg(pkgFile, zipDecoder, source, metas[i])
+				stream, err = manager.InstallToServerlessFromPkg(pkgFile, zipDecoder, source, metas[i])
 			} else if config.Platform == app.PLATFORM_LOCAL {
 				stream, err = manager.InstallToLocal(pluginUniqueIdentifier, source, metas[i])
 			} else {
@@ -360,7 +360,7 @@ func ReinstallPluginFromIdentifier(
 		if err != nil {
 			return nil, errors.Join(err, errors.New("failed to create zip decoder"))
 		}
-		stream, err := manager.ReinstallToAWSFromPkg(pkgFile, zipDecoder)
+		stream, err := manager.ReinstallToServerlessFromPkg(pkgFile, zipDecoder)
 		if err != nil {
 			return nil, errors.Join(err, errors.New("failed to reinstall plugin"))
 		}


### PR DESCRIPTION
- Updated AWS-related types and functions to reflect Serverless terminology, including renaming `AWSTransactionHandler` to `ServerlessTransactionHandler` and `AWSTransactionWriter` to `ServerlessTransactionWriter`.
- Adjusted error messages and comments to align with the new naming conventions.
- Modified installation functions to use Serverless terminology for clarity and consistency across the codebase.

## Description

Please provide a brief description of the changes made in this pull request.
Please also include the issue number if this is related to an issue using the format `Fixes #123` or `Closes #123`.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Performance improvement
- [ ] Other

## Essential Checklist

### Testing
- [ ] I have tested the changes locally and confirmed they work as expected
- [ ] I have added unit tests where necessary and they pass successfully

### Bug Fix (if applicable)
- [ ] I have used GitHub syntax to close the related issue (e.g., `Fixes #123` or `Closes #123`)

## Additional Information

Please provide any additional context that would help reviewers understand the changes. 