### PR TITLE
packaging: add dependencies required by bowenliang123/md_exporter plugin

### DIFF
--- a/docker/local.dockerfile
+++ b/docker/local.dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM golang:1.23-alpine AS builder
 
 ARG VERSION=unknown
@@ -30,20 +31,43 @@ WORKDIR /app
 ARG PLATFORM=local
 
 # Install python3.12 if PLATFORM is local
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y curl python3.12 python3.12-venv python3.12-dev python3-pip ffmpeg build-essential git \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1;
+RUN <<EOF bash
+
+set -ex
+set -o pipefail
+trap 'echo "Exit status $? at line $LINENO from: $BASH_COMMAND"' ERR
+
+apt-get update
+
+DEBIAN_FRONTEND=noninteractive apt-get install -y curl python3.12 \
+    python3.12-venv python3.12-dev python3-pip ffmpeg \
+    build-essential git \
+    cmake pkg-config \
+    libcairo2-dev libjpeg-dev libgif-dev
+
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1;
+EOF
 
 # preload tiktoken
 ENV TIKTOKEN_CACHE_DIR=/app/.tiktoken
 
 # Install dify_plugin to speedup the environment setup, test uv and preload tiktoken
-RUN mv /usr/lib/python3.12/EXTERNALLY-MANAGED /usr/lib/python3.12/EXTERNALLY-MANAGED.bk \
-    && python3 -m pip install uv \
-    && uv pip install --system dify_plugin \
-    && python3 -c "from uv._find_uv import find_uv_bin;print(find_uv_bin());" \
-    && python3 -c "import tiktoken; encodings = ['o200k_base', 'cl100k_base', 'p50k_base', 'r50k_base', 'p50k_edit', 'gpt2']; [tiktoken.get_encoding(encoding).special_tokens_set for encoding in encodings]"
+RUN <<EOF bash
+
+set -ex
+set -o pipefail
+trap 'echo "Exit status $? at line $LINENO from: $BASH_COMMAND"' ERR
+
+mv /usr/lib/python3.12/EXTERNALLY-MANAGED /usr/lib/python3.12/EXTERNALLY-MANAGED.bk
+python3 -m pip install uv
+uv pip install --system dify_plugin
+
+python3 -c "from uv._find_uv import find_uv_bin;print(find_uv_bin());"
+
+python3 -c "import tiktoken; encodings = ['o200k_base', 'cl100k_base', 'p50k_base', 'r50k_base', 'p50k_edit', 'gpt2']; [tiktoken.get_encoding(encoding).special_tokens_set for encoding in encodings]"
+EOF
 
 ENV UV_PATH=/usr/local/bin/uv
 ENV PLATFORM=$PLATFORM


### PR DESCRIPTION
## Description

Introduce the following dependencies required by the plugin bowenliang123/md_exporter:

- cmake
- pkg-config
- libcairo2-dev
- libjpeg-dev
- libgif-dev

These tools and libraries are required when building pycairo.

Simplify local.dockerfile with heredoc.

Please note that this only affects local runtime. For serverless runtime some other modification is required, AFAIK.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [x] Other

## Essential Checklist

### Testing
- [x] I have tested the changes locally and confirmed they work as expected
- [ ] I have added unit tests where necessary and they pass successfully

### Bug Fix (if applicable)
- [ ] I have used GitHub syntax to close the related issue (e.g., `Fixes #123` or `Closes #123`)

## Additional Information

https://github.com/bowenliang123/md_exporter/issues/100#issuecomment-3339230687