### PR TITLE
fix: validate plugin manifest on package upload

### DIFF
--- a/internal/core/plugin_manager/manager.go
+++ b/internal/core/plugin_manager/manager.go
@@ -188,6 +188,10 @@ func (p *PluginManager) SavePackage(plugin_unique_identifier plugin_entities.Plu
 		return nil, err
 	}
 
+	if err := declaration.ManifestValidate(); err != nil {
+		return nil, errors.Join(err, fmt.Errorf("illegal plugin manifest"))
+	}
+
 	// get the assets
 	assets, err := packageDecoder.Assets()
 	if err != nil {


### PR DESCRIPTION
## Summary
- ensure plugin package uploads validate manifests via ManifestValidate before saving
- surface an error for illegal manifests so upload endpoints reject bad packages

## Testing
- go test ./... *(fails: internal/core/license/private_key/key.go:5:12: pattern PRIVATE_KEY.pem: no matching files found)*

------
https://chatgpt.com/codex/tasks/task_b_68da25048b188326b404db3efeb065f4