### PR TITLE
fix(plugin): support customized stdio buffer size, align serverless runtime with local runtime

### DIFF
--- a/internal/core/plugin_manager/serverless.go
+++ b/internal/core/plugin_manager/serverless.go
@@ -44,22 +44,26 @@ func (p *PluginManager) getServerlessPluginRuntime(
 	runtimeEntity.InitState()
 
 	// convert to plugin runtime
-	pluginRuntime := serverless_runtime.ServerlessPluginRuntime{
-		BasicChecksum: basic_runtime.BasicChecksum{
+	pluginRuntime := serverless_runtime.NewServerlessPluginRuntime(
+		basic_runtime.BasicChecksum{
 			MediaTransport: basic_runtime.NewMediaTransport(p.mediaBucket),
 			InnerChecksum:  model.Checksum,
 		},
-		PluginRuntime:             runtimeEntity,
-		LambdaURL:                 model.FunctionURL,
-		LambdaName:                model.FunctionName,
-		PluginMaxExecutionTimeout: p.config.PluginMaxExecutionTimeout,
-	}
+		runtimeEntity,
+		serverless_runtime.ServerlessPluginRuntimeConfig{
+			LambdaURL:                 model.FunctionURL,
+			LambdaName:                model.FunctionName,
+			PluginMaxExecutionTimeout: p.config.PluginMaxExecutionTimeout,
+			StdoutBufferSize:          p.config.PluginStdioBufferSize,
+			StdoutMaxBufferSize:       p.config.PluginStdioMaxBufferSize,
+		},
+	)
 
 	if err := pluginRuntime.InitEnvironment(); err != nil {
 		return nil, err
 	}
 
-	return &pluginRuntime, nil
+	return pluginRuntime, nil
 }
 
 func (p *PluginManager) getServerlessPluginRuntimeModel(

--- a/internal/core/plugin_manager/serverless_runtime/io.go
+++ b/internal/core/plugin_manager/serverless_runtime/io.go
@@ -87,8 +87,7 @@ func (r *ServerlessPluginRuntime) Write(sessionId string, action access_types.Pl
 		scanner := bufio.NewScanner(response.Body)
 		defer response.Body.Close()
 
-		// TODO: set a reasonable buffer size or use a reader, this is a temporary solution
-		scanner.Buffer(make([]byte, 1024), 5*1024*1024)
+		scanner.Buffer(make([]byte, r.stdoutBufferSize), r.stdoutMaxBufferSize)
 
 		sessionAlive := true
 		for scanner.Scan() && sessionAlive {

--- a/internal/core/plugin_manager/serverless_runtime/type.go
+++ b/internal/core/plugin_manager/serverless_runtime/type.go
@@ -23,4 +23,41 @@ type ServerlessPluginRuntime struct {
 	client *http.Client
 
 	PluginMaxExecutionTimeout int // in seconds
+
+	stdoutBufferSize    int
+	stdoutMaxBufferSize int
+}
+
+type ServerlessPluginRuntimeConfig struct {
+	LambdaURL                 string
+	LambdaName                string
+	PluginMaxExecutionTimeout int
+	StdoutBufferSize          int
+	StdoutMaxBufferSize       int
+}
+
+func NewServerlessPluginRuntime(
+	basicChecksum basic_runtime.BasicChecksum,
+	pluginRuntime plugin_entities.PluginRuntime,
+	config ServerlessPluginRuntimeConfig,
+) *ServerlessPluginRuntime {
+	// set default buffer sizes if not configured
+	stdoutBufferSize := config.StdoutBufferSize
+	if stdoutBufferSize <= 0 {
+		stdoutBufferSize = 1024
+	}
+	stdoutMaxBufferSize := config.StdoutMaxBufferSize
+	if stdoutMaxBufferSize <= 0 {
+		stdoutMaxBufferSize = 5 * 1024 * 1024
+	}
+
+	return &ServerlessPluginRuntime{
+		BasicChecksum:             basicChecksum,
+		PluginRuntime:             pluginRuntime,
+		LambdaURL:                 config.LambdaURL,
+		LambdaName:                config.LambdaName,
+		PluginMaxExecutionTimeout: config.PluginMaxExecutionTimeout,
+		stdoutBufferSize:          stdoutBufferSize,
+		stdoutMaxBufferSize:       stdoutMaxBufferSize,
+	}
 }


### PR DESCRIPTION
## Description

support customized stdio buffer size, align serverless runtime with local runtime

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Other

## Essential Checklist

### Testing
- [ ] I have tested the changes locally and confirmed they work as expected
- [ ] I have added unit tests where necessary and they pass successfully

### Bug Fix (if applicable)
- [ ] I have used GitHub syntax to close the related issue (e.g., `Fixes #123` or `Closes #123`)

## Additional Information

Please provide any additional context that would help reviewers understand the changes. 