### PR TITLE
feat(redis): add REDIS_SSL_CERT_REQS and TLS config support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,6 +79,13 @@ REDIS_PORT=6379
 REDIS_PASSWORD=difyai123456
 REDIS_DB=0
 
+# redis TLS
+REDIS_USE_SSL=false
+## CERT_NONE | CERT_OPTIONAL | CERT_REQUIRED
+#REDIS_SSL_CERT_REQS=CERT_REQUIRED
+## Optional custom CA bundle (PEM) if not using public CAs
+#REDIS_SSL_CA_CERTS=
+
 # Whether to use Redis Sentinel mode.
 # If set to true, the application will automatically discover and connect to the master node through Sentinel.
 REDIS_USE_SENTINEL=false

--- a/internal/core/plugin_manager/manager.go
+++ b/internal/core/plugin_manager/manager.go
@@ -113,6 +113,12 @@ func (p *PluginManager) GetAsset(id string) ([]byte, error) {
 func (p *PluginManager) Launch(configuration *app.Config) {
 	log.Info("start plugin manager daemon...")
 
+	// Build TLS config for Redis (nil when RedisUseSsl=false)
+	tlsConf, err := configuration.RedisTLSConfig()
+	if err != nil {
+		log.Panic("invalid Redis TLS config: %s", err.Error())
+	}
+
 	// init redis client
 	if configuration.RedisUseSentinel {
 		// use Redis Sentinel
@@ -127,6 +133,7 @@ func (p *PluginManager) Launch(configuration *app.Config) {
 			configuration.RedisUseSsl,
 			configuration.RedisDB,
 			configuration.RedisSentinelSocketTimeout,
+			tlsConf, // pass TLS to cache initializer
 		); err != nil {
 			log.Panic("init redis sentinel client failed: %s", err.Error())
 		}
@@ -137,6 +144,7 @@ func (p *PluginManager) Launch(configuration *app.Config) {
 			configuration.RedisPass,
 			configuration.RedisUseSsl,
 			configuration.RedisDB,
+			tlsConf, // pass TLS to cache initializer
 		); err != nil {
 			log.Panic("init redis client failed: %s", err.Error())
 		}

--- a/internal/types/app/config.go
+++ b/internal/types/app/config.go
@@ -1,7 +1,11 @@
 package app
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/go-playground/validator/v10"
 )
@@ -108,6 +112,10 @@ type Config struct {
 	RedisUser   string `envconfig:"REDIS_USERNAME"`
 	RedisUseSsl bool   `envconfig:"REDIS_USE_SSL"`
 	RedisDB     int    `envconfig:"REDIS_DB"`
+
+	// redis TLS extras
+	RedisSSLCertReqs string `envconfig:"REDIS_SSL_CERT_REQS" default:"CERT_REQUIRED"`
+	RedisSSLCACerts  string `envconfig:"REDIS_SSL_CA_CERTS"`
 
 	// redis sentinel
 	RedisUseSentinel           bool    `envconfig:"REDIS_USE_SENTINEL"`
@@ -251,6 +259,42 @@ func (c *Config) Validate() error {
 	}
 
 	return nil
+}
+
+// RedisTLSConfig builds a *tls.Config for Redis based on envs.
+func (c *Config) RedisTLSConfig() (*tls.Config, error) {
+	if !c.RedisUseSsl {
+		return nil, nil
+	}
+
+	tlsConf := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
+
+	if strings.TrimSpace(c.RedisSSLCACerts) != "" {
+		pem, err := os.ReadFile(c.RedisSSLCACerts)
+		if err != nil {
+			return nil, fmt.Errorf("read REDIS_SSL_CA_CERTS: %w", err)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(pem) {
+			return nil, fmt.Errorf("failed to append CA certs from %s", c.RedisSSLCACerts)
+		}
+		tlsConf.RootCAs = pool
+	}
+
+	switch strings.ToUpper(strings.TrimSpace(c.RedisSSLCertReqs)) {
+	case "CERT_NONE":
+		tlsConf.InsecureSkipVerify = true
+	case "CERT_OPTIONAL":
+		tlsConf.InsecureSkipVerify = false
+	case "CERT_REQUIRED", "":
+		tlsConf.InsecureSkipVerify = false
+	default:
+		tlsConf.InsecureSkipVerify = false
+	}
+
+	return tlsConf, nil
 }
 
 type PlatformType string


### PR DESCRIPTION
## Description

Added REDIS_SSL_CERT_REQS option to the Redis connection to allow configuring TLS certificate verification (e.g. CERT_NONE, CERT_REQUIRED).

Fixes #450

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Other

## Essential Checklist

### Testing
- [X] I have tested the changes locally and confirmed they work as expected
- [ ] I have added unit tests where necessary and they pass successfully

### Bug Fix (if applicable)
- [X] I have used GitHub syntax to close the related issue (e.g., `Fixes #123` or `Closes #123`)

## Additional Information

Please provide any additional context that would help reviewers understand the changes. 