### PR TITLE
feat: support passthrough propagation to plugins

### DIFF
--- a/internal/core/session_manager/session.go
+++ b/internal/core/session_manager/session.go
@@ -40,6 +40,7 @@ type Session struct {
 	AppID          *string        `json:"app_id"`
 	EndpointID     *string        `json:"endpoint_id"`
 	Context        map[string]any `json:"context"`
+	Passthrough    *string        `json:"passthrough"`
 }
 
 func sessionKey(id string) string {
@@ -61,6 +62,7 @@ type NewSessionPayload struct {
 	AppID                  *string                                `json:"app_id"`
 	EndpointID             *string                                `json:"endpoint_id"`
 	Context                map[string]any                         `json:"context"`
+	Passthrough            *string                                `json:"passthrough"`
 }
 
 func NewSession(payload NewSessionPayload) *Session {
@@ -79,6 +81,7 @@ func NewSession(payload NewSessionPayload) *Session {
 		AppID:                  payload.AppID,
 		EndpointID:             payload.EndpointID,
 		Context:                payload.Context,
+		Passthrough:            payload.Passthrough,
 	}
 
 	session_lock.Lock()
@@ -175,6 +178,7 @@ func (s *Session) Message(event PLUGIN_IN_STREAM_EVENT, data any) []byte {
 		"app_id":          s.AppID,
 		"endpoint_id":     s.EndpointID,
 		"context":         s.Context,
+		"passthrough":     s.Passthrough,
 		"event":           event,
 		"data":            data,
 	})

--- a/internal/service/session.go
+++ b/internal/service/session.go
@@ -43,6 +43,7 @@ func createSession[T any](
 			AppID:                  r.AppID,
 			EndpointID:             r.EndpointID,
 			Context:                r.Context,
+			Passthrough:            r.Passthrough,
 		},
 	)
 

--- a/pkg/entities/plugin_entities/request.go
+++ b/pkg/entities/plugin_entities/request.go
@@ -19,6 +19,7 @@ type InvokePluginRequest[T any] struct {
 	AppID            *string                `json:"app_id"`
 	EndpointID       *string                `json:"endpoint_id"`
 	Context          map[string]any         `json:"context"`
+    Passthrough      *string                `json:"passthrough"`
 
 	Data T `json:"data" validate:"required"`
 }


### PR DESCRIPTION
## Passthrough Propagation to Plugins

- Add top-level `passthrough` to `InvokePluginRequest` and `Session`, and include it in `Session.Message()` so it reaches the Python SDK as a first-class field (similar to `conversation_id`).
- Keep `InvokeTool` data payload strictly for business parameters; carry `passthrough` via session to avoid schema drift.
- Remove temporary debug logs and unused helpers; retain only necessary code for passthrough propagation.
- Backward compatible; existing tools continue to work without changes.
- Corresponding upstream changes in Dify main repo: [feat: add passthrough parameter support for workflow tools](https://github.com/langgenius/dify/pull/27078).


