### PR TITLE
Refine install task orchestration

### DIFF
--- a/internal/core/plugin_manager/getter.go
+++ b/internal/core/plugin_manager/getter.go
@@ -7,3 +7,15 @@ func (p *PluginManager) GetPluginRuntime(
 ) (plugin_entities.PluginRuntimeSessionIOInterface, error) {
 	return p.controlPanel.GetPluginRuntime(pluginUniqueIdentifier)
 }
+
+func (p *PluginManager) RemoveLocalPlugin(
+	pluginUniqueIdentifier plugin_entities.PluginUniqueIdentifier,
+) error {
+	return p.controlPanel.RemoveLocalPlugin(pluginUniqueIdentifier)
+}
+
+func (p *PluginManager) ShutdownLocalPluginGracefully(
+	pluginUniqueIdentifier plugin_entities.PluginUniqueIdentifier,
+) (<-chan error, error) {
+	return p.controlPanel.ShutdownLocalPluginGracefully(pluginUniqueIdentifier)
+}

--- a/internal/service/install_plugin.go
+++ b/internal/service/install_plugin.go
@@ -13,6 +13,7 @@ import (
 	"github.com/langgenius/dify-plugin-daemon/internal/types/models/curd"
 	"github.com/langgenius/dify-plugin-daemon/internal/utils/cache"
 	"github.com/langgenius/dify-plugin-daemon/internal/utils/cache/helper"
+	"github.com/langgenius/dify-plugin-daemon/internal/utils/log"
 	"github.com/langgenius/dify-plugin-daemon/internal/utils/routine"
 	"github.com/langgenius/dify-plugin-daemon/internal/utils/stream"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities"
@@ -21,14 +22,41 @@ import (
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/plugin_entities"
 )
 
-// // invalidate plugin installation cache
-// TODO: invalidate plugin installation cache
-// pluginInstallationCacheKey := helper.PluginInstallationCacheKey(originalPluginUniqueIdentifier.PluginID(), tenantId)
-// _, _ = cache.AutoDelete[models.PluginInstallation](pluginInstallationCacheKey)
-
 type InstallPluginResponse struct {
 	AllInstalled bool   `json:"all_installed"`
 	TaskID       string `json:"task_id"`
+}
+
+type pluginInstallJob struct {
+	identifier          plugin_entities.PluginUniqueIdentifier
+	declaration         *plugin_entities.PluginDeclaration
+	meta                map[string]any
+	needsRuntimeInstall bool
+}
+
+type installTaskRegistry struct {
+	order []string
+	tasks map[string]*models.InstallTask
+}
+
+func (r *installTaskRegistry) IDs() []string {
+	ids := make([]string, 0, len(r.order))
+	for _, tenantID := range r.order {
+		if task, ok := r.tasks[tenantID]; ok {
+			ids = append(ids, task.ID)
+		}
+	}
+	return ids
+}
+
+func (r *installTaskRegistry) PrimaryID() string {
+	if len(r.order) == 0 {
+		return ""
+	}
+	if task, ok := r.tasks[r.order[0]]; ok {
+		return task.ID
+	}
+	return ""
 }
 
 func InstallMultiplePluginsToTenant(
@@ -37,125 +65,271 @@ func InstallMultiplePluginsToTenant(
 	pluginUniqueIdentifiers []plugin_entities.PluginUniqueIdentifier,
 	source string,
 	metas []map[string]any,
-) *InstallPluginResponse {
+) *entities.Response {
+	runtimeType := config.Platform.ToPluginRuntimeType()
+	manager := plugin_manager.Manager()
+	if manager == nil {
+		return exception.InternalServerError(errors.New("plugin manager is not initialized")).ToResponse()
+	}
 
-	// TODO: implement this, create task firstly (including EE)
+	jobs := make([]pluginInstallJob, 0, len(pluginUniqueIdentifiers))
+	declarations := make([]*plugin_entities.PluginDeclaration, 0, len(pluginUniqueIdentifiers))
+	allInstalled := true
+
 	for i, pluginUniqueIdentifier := range pluginUniqueIdentifiers {
-		// fetch plugin declaration first, before installing, we need to ensure pkg is uploaded
-		pluginDeclaration, err := helper.CombinedGetPluginDeclaration(
+		declaration, err := helper.CombinedGetPluginDeclaration(
 			pluginUniqueIdentifier,
 			runtimeType,
 		)
 		if err != nil {
-			return nil, err
+			return exception.InternalServerError(errors.Join(err, errors.New("failed to get plugin declaration"))).ToResponse()
 		}
 
-		// check if plugin is already installed
 		_, err = db.GetOne[models.Plugin](
 			db.Equal("plugin_unique_identifier", pluginUniqueIdentifier.String()),
 		)
 
-		task.Plugins = append(task.Plugins, models.InstallTaskPluginStatus{
-			PluginUniqueIdentifier: pluginUniqueIdentifier,
-			PluginID:               pluginUniqueIdentifier.PluginID(),
-			Status:                 models.InstallTaskStatusPending,
-			Icon:                   pluginDeclaration.Icon,
-			IconDark:               pluginDeclaration.IconDark,
-			Labels:                 pluginDeclaration.Label,
-			Message:                "",
-		})
-
-		// found the global plugin installation, no need to start install task
-		// just to create a reference to the plugin will make sene
-		if err == nil {
-			// EE: enterprise only feature, allow orphans
-			if config.PluginAllowOrphans {
-				if err := curd.EnsureGlobalReference(
-					pluginUniqueIdentifier,
-					tenantId,
-					runtimeType,
-					pluginDeclaration,
-					source,
-					metas[i],
-				); err != nil {
-					return nil, err
-				}
-			}
-
-			// just create the reference
-			_, _, err = curd.InstallPlugin(
-				tenantId,
-				pluginUniqueIdentifier,
-				runtimeType,
-				pluginDeclaration,
-				source,
-				metas[i],
-			)
-			if err != nil {
-				return nil, errors.Join(err, errors.New("failed on plugin installation"))
-			} else {
-				task.CompletedPlugins++
-				task.Plugins[i].Status = models.InstallTaskStatusSuccess
-				task.Plugins[i].Message = "Installed"
-			}
-
-			continue
+		needsRuntimeInstall := false
+		if err == db.ErrDatabaseNotFound {
+			needsRuntimeInstall = true
+			allInstalled = false
+		} else if err != nil {
+			return exception.InternalServerError(err).ToResponse()
 		}
 
-		if err != db.ErrDatabaseNotFound {
+		job := pluginInstallJob{
+			identifier:          pluginUniqueIdentifier,
+			declaration:         declaration,
+			meta:                metas[i],
+			needsRuntimeInstall: needsRuntimeInstall,
+		}
+
+		jobs = append(jobs, job)
+		declarations = append(declarations, declaration)
+	}
+
+	tenants := resolveInstallTenants(config, tenantId)
+
+	if allInstalled {
+		for i := range jobs {
+			if err := installForTenants(
+				tenants,
+				jobs[i],
+				runtimeType,
+				source,
+			); err != nil {
+				return exception.InternalServerError(errors.Join(err, errors.New("failed on plugin installation"))).ToResponse()
+			}
+		}
+
+		return entities.NewSuccessResponse(&InstallPluginResponse{
+			AllInstalled: true,
+			TaskID:       "",
+		})
+	}
+
+	statuses := buildTaskStatuses(pluginUniqueIdentifiers, declarations)
+	taskRegistry, err := createInstallTasks(tenants, statuses)
+	if err != nil {
+		return exception.InternalServerError(err).ToResponse()
+	}
+	taskIDs := taskRegistry.IDs()
+
+	for _, job := range jobs {
+		jobCopy := job
+		routine.Submit(map[string]string{
+			"module": "service",
+			"func":   "InstallPlugin",
+		}, func() {
+			processInstallJob(
+				manager,
+				tenants,
+				runtimeType,
+				source,
+				taskIDs,
+				jobCopy,
+			)
+		})
+	}
+
+	return entities.NewSuccessResponse(&InstallPluginResponse{
+		AllInstalled: false,
+		TaskID:       taskRegistry.PrimaryID(),
+	})
+}
+
+func processInstallJob(
+	manager *plugin_manager.PluginManager,
+	tenants []string,
+	runtimeType plugin_entities.PluginRuntimeType,
+	source string,
+	taskIDs []string,
+	job pluginInstallJob,
+) {
+	if !job.needsRuntimeInstall {
+		if err := installForTenants(tenants, job, runtimeType, source); err != nil {
+			setTaskStatus(taskIDs, job.identifier, models.InstallTaskStatusFailed, err.Error())
+			return
+		}
+		setTaskStatus(taskIDs, job.identifier, models.InstallTaskStatusSuccess, "Installed")
+		return
+	}
+
+	installationStream, err := manager.Install(job.identifier)
+	if err != nil {
+		setTaskStatus(taskIDs, job.identifier, models.InstallTaskStatusFailed, fmt.Sprintf("failed to start installation: %v", err))
+		return
+	}
+
+	err = installationStream.Async(func(resp installation_entities.PluginInstallResponse) {
+		switch resp.Event {
+		case installation_entities.PluginInstallEventInfo:
+			setTaskMessage(taskIDs, job.identifier, resp.Data)
+		case installation_entities.PluginInstallEventError:
+			setTaskStatus(taskIDs, job.identifier, models.InstallTaskStatusFailed, resp.Data)
+		case installation_entities.PluginInstallEventDone:
+			if err := installForTenants(tenants, job, runtimeType, source); err != nil {
+				setTaskStatus(taskIDs, job.identifier, models.InstallTaskStatusFailed, err.Error())
+				return
+			}
+			setTaskStatus(taskIDs, job.identifier, models.InstallTaskStatusSuccess, "Installed")
+		}
+	})
+	if err != nil {
+		setTaskStatus(taskIDs, job.identifier, models.InstallTaskStatusFailed, err.Error())
+	}
+}
+
+func installForTenants(
+	tenants []string,
+	job pluginInstallJob,
+	runtimeType plugin_entities.PluginRuntimeType,
+	source string,
+) error {
+	for _, tenantID := range tenants {
+		if err := installForTenant(tenantID, job, runtimeType, source); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func installForTenant(
+	tenantID string,
+	job pluginInstallJob,
+	runtimeType plugin_entities.PluginRuntimeType,
+	source string,
+) error {
+	_, _, err := curd.InstallPlugin(
+		tenantID,
+		job.identifier,
+		runtimeType,
+		job.declaration,
+		source,
+		job.meta,
+	)
+	if err != nil && err != curd.ErrPluginAlreadyInstalled {
+		return err
+	}
+	return nil
+}
+
+func buildTaskStatuses(
+	pluginUniqueIdentifiers []plugin_entities.PluginUniqueIdentifier,
+	declarations []*plugin_entities.PluginDeclaration,
+) []models.InstallTaskPluginStatus {
+	statuses := make([]models.InstallTaskPluginStatus, len(pluginUniqueIdentifiers))
+	for i, identifier := range pluginUniqueIdentifiers {
+		statuses[i] = models.InstallTaskPluginStatus{
+			PluginUniqueIdentifier: identifier,
+			PluginID:               identifier.PluginID(),
+			Status:                 models.InstallTaskStatusPending,
+			Icon:                   declarations[i].Icon,
+			IconDark:               declarations[i].IconDark,
+			Labels:                 declarations[i].Label,
+			Message:                "",
+		}
+	}
+	return statuses
+}
+
+func createInstallTasks(
+	tenants []string,
+	statuses []models.InstallTaskPluginStatus,
+) (*installTaskRegistry, error) {
+	registry := &installTaskRegistry{
+		order: append([]string{}, tenants...),
+		tasks: make(map[string]*models.InstallTask, len(tenants)),
+	}
+
+	for _, tenantID := range tenants {
+		statusCopy := make([]models.InstallTaskPluginStatus, len(statuses))
+		copy(statusCopy, statuses)
+
+		task := &models.InstallTask{
+			Status:           models.InstallTaskStatusRunning,
+			TenantID:         tenantID,
+			TotalPlugins:     len(statusCopy),
+			CompletedPlugins: 0,
+			Plugins:          statusCopy,
+		}
+
+		if err := db.Create(task); err != nil {
 			return nil, err
 		}
 
-		pluginsWaitForInstallation = append(pluginsWaitForInstallation, pluginUniqueIdentifier)
+		registry.tasks[tenantID] = task
 	}
 
-	if len(pluginsWaitForInstallation) == 0 {
-		response.AllInstalled = true
-		response.TaskID = ""
-		return response, nil
-	}
-
-	err := db.Create(task)
-	if err != nil {
-		return nil, err
-	}
-
-	response.TaskID = task.ID
-	manager := plugin_manager.Manager()
-
-	tasks := []func(){}
-	for i, pluginUniqueIdentifier := range pluginsWaitForInstallation {
-		i := i
-		tasks = append(tasks, func() {
-			installOnePluginRuntimeToTenant(
-				config,
-				task,
-				pluginUniqueIdentifier,
-				source,
-				metas[i],
-				runtimeType,
-				manager,
-			)
-		})
-	}
-
-	// TODO: submit async tasks
-
-	return nil, nil
+	return registry, nil
 }
 
-func InstallPluginRuntimeToTenant(
-	config *app.Config,
-	task *models.InstallTask,
+func setTaskStatus(
+	taskIDs []string,
 	pluginUniqueIdentifier plugin_entities.PluginUniqueIdentifier,
-	source string,
-	meta map[string]any,
-) (*InstallPluginResponse, error) {
-	response := &InstallPluginResponse{}
-	pluginsWaitForInstallation := []plugin_entities.PluginUniqueIdentifier{}
-	runtimeType := config.Platform.ToPluginRuntimeType()
+	status models.InstallTaskStatus,
+	message string,
+) {
+	for _, taskID := range taskIDs {
+		if err := updateTaskStatus(taskID, pluginUniqueIdentifier, func(task *models.InstallTask, plugin *models.InstallTaskPluginStatus) {
+			previousStatus := plugin.Status
+			plugin.Status = status
+			plugin.Message = message
+			if status == models.InstallTaskStatusSuccess && previousStatus != models.InstallTaskStatusSuccess {
+				task.CompletedPlugins++
+			}
+			if status == models.InstallTaskStatusFailed {
+				task.Status = models.InstallTaskStatusFailed
+				if previousStatus == models.InstallTaskStatusSuccess && task.CompletedPlugins > 0 {
+					task.CompletedPlugins--
+				}
+			}
+		}); err != nil {
+			log.Error("failed to update task status for %s: %v", pluginUniqueIdentifier.String(), err)
+		}
+	}
+}
 
-	return response, nil
+func setTaskMessage(
+	taskIDs []string,
+	pluginUniqueIdentifier plugin_entities.PluginUniqueIdentifier,
+	message string,
+) {
+	for _, taskID := range taskIDs {
+		if err := updateTaskStatus(taskID, pluginUniqueIdentifier, func(task *models.InstallTask, plugin *models.InstallTaskPluginStatus) {
+			plugin.Message = message
+		}); err != nil {
+			log.Error("failed to update task message for %s: %v", pluginUniqueIdentifier.String(), err)
+		}
+	}
+}
+
+func resolveInstallTenants(config *app.Config, tenantId string) []string {
+	tenants := []string{tenantId}
+	if tenantId != constants.GlobalTenantId && config.PluginAllowOrphans {
+		tenants = append(tenants, constants.GlobalTenantId)
+	}
+	return tenants
 }
 
 /*
@@ -182,50 +356,71 @@ func ReinstallPluginFromIdentifier(
 			return nil, errors.Join(err, errors.New("failed to get plugin"))
 		}
 
-		retStream := stream.NewStream[installation_entities.PluginInstallResponse](128)
-		task := &models.InstallTask{
-			Status:           models.InstallTaskStatusRunning,
-			TenantID:         constants.GlobalTenantId,
-			TotalPlugins:     1,
-			CompletedPlugins: 0,
-			Plugins:          []models.InstallTaskPluginStatus{},
-		}
-		task.Plugins = append(task.Plugins, models.InstallTaskPluginStatus{
-			PluginUniqueIdentifier: pluginUniqueIdentifier,
-			PluginID:               pluginUniqueIdentifier.PluginID(),
-			Status:                 models.InstallTaskStatusPending,
-			Icon:                   pluginDeclaration.Icon,
-			IconDark:               pluginDeclaration.IconDark,
-			Labels:                 pluginDeclaration.Label,
-			Message:                "",
-		})
+		statuses := buildTaskStatuses(
+			[]plugin_entities.PluginUniqueIdentifier{pluginUniqueIdentifier},
+			[]*plugin_entities.PluginDeclaration{pluginDeclaration},
+		)
 
-		err = db.Create(task)
+		taskRegistry, err := createInstallTasks([]string{constants.GlobalTenantId}, statuses)
 		if err != nil {
 			return nil, err
 		}
 
-		f := func() {
-			doInstallPluginRuntime(
-				plugin_entities.PLUGIN_RUNTIME_TYPE_SERVERLESS,
-				plugin_manager.Manager(),
-				config,
-				constants.GlobalTenantId,
-				plugin.Source,
-				pluginUniqueIdentifier,
-				map[string]any{},
-				task,
-				pluginDeclaration,
-				true,
-				func(message plugin_manager.PluginInstallResponse) {
-					retStream.Write(message)
-				},
-				func(pluginUniqueIdentifier plugin_entities.PluginUniqueIdentifier, declaration *plugin_entities.PluginDeclaration, meta map[string]any) error {
-					retStream.Close()
-					return nil
-				})
+		manager := plugin_manager.Manager()
+		if manager == nil {
+			return nil, errors.New("plugin manager is not initialized")
 		}
-		routine.Submit(nil, f)
+
+		retStream := stream.NewStream[installation_entities.PluginInstallResponse](128)
+		routine.Submit(map[string]string{
+			"module": "service",
+			"func":   "ReinstallPlugin",
+		}, func() {
+			defer retStream.Close()
+
+			reinstallStream, err := manager.Reinstall(pluginUniqueIdentifier)
+			if err != nil {
+				setTaskStatus(taskRegistry.IDs(), pluginUniqueIdentifier, models.InstallTaskStatusFailed, err.Error())
+				retStream.Write(installation_entities.PluginInstallResponse{
+					Event: installation_entities.PluginInstallEventError,
+					Data:  err.Error(),
+				})
+				return
+			}
+
+			err = reinstallStream.Async(func(resp installation_entities.PluginInstallResponse) {
+				retStream.Write(resp)
+				switch resp.Event {
+				case installation_entities.PluginInstallEventInfo:
+					setTaskMessage(taskRegistry.IDs(), pluginUniqueIdentifier, resp.Data)
+				case installation_entities.PluginInstallEventError:
+					setTaskStatus(taskRegistry.IDs(), pluginUniqueIdentifier, models.InstallTaskStatusFailed, resp.Data)
+				case installation_entities.PluginInstallEventDone:
+					_, _, installErr := curd.InstallPlugin(
+						constants.GlobalTenantId,
+						pluginUniqueIdentifier,
+						plugin.InstallType,
+						pluginDeclaration,
+						plugin.Source,
+						map[string]any{},
+					)
+					if installErr != nil && installErr != curd.ErrPluginAlreadyInstalled {
+						setTaskStatus(taskRegistry.IDs(), pluginUniqueIdentifier, models.InstallTaskStatusFailed, installErr.Error())
+						return
+					}
+					setTaskStatus(taskRegistry.IDs(), pluginUniqueIdentifier, models.InstallTaskStatusSuccess, "Reinstalled")
+				}
+			})
+
+			if err != nil {
+				setTaskStatus(taskRegistry.IDs(), pluginUniqueIdentifier, models.InstallTaskStatusFailed, err.Error())
+				retStream.Write(installation_entities.PluginInstallResponse{
+					Event: installation_entities.PluginInstallEventError,
+					Data:  err.Error(),
+				})
+			}
+		})
+
 		return retStream, nil
 	}, ctx, 1800)
 }
@@ -246,7 +441,6 @@ func UpgradePlugin(
 		return exception.BadRequestError(errors.New("original and new plugin id are different")).ToResponse()
 	}
 
-	// uninstall the original plugin
 	installation, err := db.GetOne[models.PluginInstallation](
 		db.Equal("tenant_id", tenantId),
 		db.Equal("plugin_unique_identifier", originalPluginUniqueIdentifier.String()),
@@ -261,14 +455,59 @@ func UpgradePlugin(
 		return exception.InternalServerError(err).ToResponse()
 	}
 
-	// TODO: upgrade process
+	runtimeType := plugin_entities.PluginRuntimeType(installation.RuntimeType)
+
+	originalDeclaration, err := helper.CombinedGetPluginDeclaration(originalPluginUniqueIdentifier, runtimeType)
+	if err != nil {
+		return exception.InternalServerError(err).ToResponse()
+	}
+
+	newDeclaration, err := helper.CombinedGetPluginDeclaration(newPluginUniqueIdentifier, runtimeType)
+	if err != nil {
+		return exception.InternalServerError(err).ToResponse()
+	}
+
+	response, err := curd.UpgradePlugin(
+		tenantId,
+		originalPluginUniqueIdentifier,
+		newPluginUniqueIdentifier,
+		originalDeclaration,
+		newDeclaration,
+		runtimeType,
+		source,
+		meta,
+	)
+	if err != nil {
+		return exception.InternalServerError(err).ToResponse()
+	}
+
+	if response.IsOriginalPluginDeleted && response.DeletedPlugin != nil && response.DeletedPlugin.InstallType == plugin_entities.PLUGIN_RUNTIME_TYPE_LOCAL {
+		manager := plugin_manager.Manager()
+		if manager == nil {
+			return exception.InternalServerError(errors.New("plugin manager is not initialized")).ToResponse()
+		}
+
+		if err := manager.RemoveLocalPlugin(originalPluginUniqueIdentifier); err != nil {
+			return exception.InternalServerError(err).ToResponse()
+		}
+
+		shutdownCh, err := manager.ShutdownLocalPluginGracefully(originalPluginUniqueIdentifier)
+		if err != nil {
+			return exception.InternalServerError(err).ToResponse()
+		}
+
+		if err := waitGracefulShutdown(shutdownCh); err != nil {
+			return exception.InternalServerError(err).ToResponse()
+		}
+	}
+
+	return entities.NewSuccessResponse(true)
 }
 
 func UninstallPlugin(
 	tenant_id string,
 	plugin_installation_id string,
 ) *entities.Response {
-	// Check if the plugin exists for the tenant
 	installation, err := db.GetOne[models.PluginInstallation](
 		db.Equal("tenant_id", tenant_id),
 		db.Equal("id", plugin_installation_id),
@@ -285,7 +524,6 @@ func UninstallPlugin(
 		return exception.UniqueIdentifierError(err).ToResponse()
 	}
 
-	// get declaration
 	declaration, err := helper.CombinedGetPluginDeclaration(
 		pluginUniqueIdentifier,
 		plugin_entities.PluginRuntimeType(installation.RuntimeType),
@@ -294,7 +532,6 @@ func UninstallPlugin(
 		return exception.InternalServerError(err).ToResponse()
 	}
 
-	// Uninstall the plugin
 	deleteResponse, err := curd.UninstallPlugin(
 		tenant_id,
 		pluginUniqueIdentifier,
@@ -305,22 +542,42 @@ func UninstallPlugin(
 		return exception.InternalServerError(fmt.Errorf("failed to uninstall plugin: %s", err.Error())).ToResponse()
 	}
 
-	// invalidate plugin installation cache
 	pluginInstallationCacheKey := helper.PluginInstallationCacheKey(pluginUniqueIdentifier.PluginID(), tenant_id)
 	_, _ = cache.AutoDelete[models.PluginInstallation](pluginInstallationCacheKey)
 
-	if deleteResponse.IsPluginDeleted {
-		// delete the plugin if no installation left
+	if deleteResponse.IsPluginDeleted && deleteResponse.Plugin != nil && deleteResponse.Plugin.InstallType == plugin_entities.PLUGIN_RUNTIME_TYPE_LOCAL {
 		manager := plugin_manager.Manager()
-		if deleteResponse.Installation.RuntimeType == string(
-			plugin_entities.PLUGIN_RUNTIME_TYPE_LOCAL,
-		) {
-			err = manager.UninstallFromLocal(pluginUniqueIdentifier)
-			if err != nil {
-				return exception.InternalServerError(fmt.Errorf("failed to uninstall plugin: %s", err.Error())).ToResponse()
-			}
+		if manager == nil {
+			return exception.InternalServerError(errors.New("plugin manager is not initialized")).ToResponse()
+		}
+
+		if err := manager.RemoveLocalPlugin(pluginUniqueIdentifier); err != nil {
+			return exception.InternalServerError(err).ToResponse()
+		}
+
+		shutdownCh, err := manager.ShutdownLocalPluginGracefully(pluginUniqueIdentifier)
+		if err != nil {
+			return exception.InternalServerError(err).ToResponse()
+		}
+
+		if err := waitGracefulShutdown(shutdownCh); err != nil {
+			return exception.InternalServerError(err).ToResponse()
 		}
 	}
 
 	return entities.NewSuccessResponse(true)
+}
+
+func waitGracefulShutdown(ch <-chan error) error {
+	if ch == nil {
+		return nil
+	}
+
+	for err := range ch {
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
## Summary
- replace mirrored install task tracking with a registry that treats tenant and global tasks uniformly
- install plugins for every resolved tenant, including global references, using shared helpers for synchronous and async flows
- update plugin reinstall streaming to use the unified task registry helpers

## Testing
- go test ./... *(fails: internal/core/license/private_key/key.go:5:12: pattern PRIVATE_KEY.pem: no matching files found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690dc3fb75808326bdd61e558b8e8245)