### PR TITLE
refactor: centralize routine labels

### DIFF
--- a/internal/cluster/cluster_lifetime.go
+++ b/internal/cluster/cluster_lifetime.go
@@ -6,6 +6,7 @@ import (
 	"github.com/langgenius/dify-plugin-daemon/internal/utils/cache"
 	"github.com/langgenius/dify-plugin-daemon/internal/utils/log"
 	"github.com/langgenius/dify-plugin-daemon/internal/utils/routine"
+	routinepkg "github.com/langgenius/dify-plugin-daemon/pkg/routine"
 )
 
 const (
@@ -79,9 +80,9 @@ func (c *Cluster) clusterLifetime() {
 	defer pluginSchedulerTicker.Stop()
 
 	// vote for all ips and find the best one, prepare for later traffic scheduling
-	routine.Submit(map[string]string{
-		"module":   "cluster",
-		"function": "voteAddressesWhenInit",
+	routine.Submit(routinepkg.Labels{
+		routinepkg.RoutineLabelKeyModule:   "cluster",
+		routinepkg.RoutineLabelKeyFunction: "voteAddressesWhenInit",
 	}, func() {
 		if err := c.updateNodeStatus(); err != nil {
 			log.Error("failed to update the status of the node: %s", err.Error())

--- a/internal/core/control_panel/launcher_local.go
+++ b/internal/core/control_panel/launcher_local.go
@@ -8,6 +8,7 @@ import (
 	"github.com/langgenius/dify-plugin-daemon/internal/core/plugin_manager/local_runtime"
 	"github.com/langgenius/dify-plugin-daemon/internal/utils/routine"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/plugin_entities"
+	routinepkg "github.com/langgenius/dify-plugin-daemon/pkg/routine"
 )
 
 // Launches a local plugin runtime
@@ -156,9 +157,9 @@ func (c *ControlPanel) ShutdownLocalPluginForcefully(
 
 	ch := make(chan error, 1)
 
-	routine.Submit(map[string]string{
-		"module": "controlpanel",
-		"func":   "ShutdownLocalPluginForcefully",
+	routine.Submit(routinepkg.Labels{
+		routinepkg.RoutineLabelKeyModule:   "controlpanel",
+		routinepkg.RoutineLabelKeyFunction: "ShutdownLocalPluginForcefully",
 	}, func() {
 		runtime.Stop(false)
 
@@ -185,9 +186,9 @@ func (c *ControlPanel) ShutdownLocalPluginGracefully(
 	ch := make(chan error, 1)
 
 	// wait for runtime to be shutdown in a goroutine
-	routine.Submit(map[string]string{
-		"module": "controlpanel",
-		"func":   "ShutdownLocalPluginGracefully",
+	routine.Submit(routinepkg.Labels{
+		routinepkg.RoutineLabelKeyModule:   "controlpanel",
+		routinepkg.RoutineLabelKeyFunction: "ShutdownLocalPluginGracefully",
 	}, func() {
 		runtime.GracefulStop(false)
 

--- a/internal/core/control_panel/server_local.go
+++ b/internal/core/control_panel/server_local.go
@@ -8,6 +8,7 @@ import (
 	"github.com/langgenius/dify-plugin-daemon/internal/utils/log"
 	"github.com/langgenius/dify-plugin-daemon/internal/utils/routine"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/plugin_entities"
+	routinepkg "github.com/langgenius/dify-plugin-daemon/pkg/routine"
 )
 
 func (c *ControlPanel) startLocalMonitor() {
@@ -95,9 +96,9 @@ func (c *ControlPanel) handleNewLocalPlugins() {
 		}
 
 		wg.Add(1)
-		routine.Submit(map[string]string{
-			"module":   "plugin_manager",
-			"function": "handleNewLocalPlugins",
+		routine.Submit(routinepkg.Labels{
+			routinepkg.RoutineLabelKeyModule:   "plugin_manager",
+			routinepkg.RoutineLabelKeyFunction: "handleNewLocalPlugins",
 		}, func() {
 			defer wg.Done()
 			_, ch, err := c.LaunchLocalPlugin(uniquePluginIdentifier)

--- a/internal/core/dify_invocation/real/http_request.go
+++ b/internal/core/dify_invocation/real/http_request.go
@@ -10,6 +10,7 @@ import (
 	"github.com/langgenius/dify-plugin-daemon/internal/utils/stream"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/model_entities"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/tool_entities"
+	routinepkg "github.com/langgenius/dify-plugin-daemon/pkg/routine"
 	"github.com/langgenius/dify-plugin-daemon/pkg/validators"
 )
 
@@ -74,9 +75,9 @@ func StreamResponse[T any](i *RealBackwardsInvocation, method string, path strin
 	newResponse.OnClose(func() {
 		response.Close()
 	})
-	routine.Submit(map[string]string{
-		"module":   "dify_invocation",
-		"function": "StreamResponse",
+	routine.Submit(routinepkg.Labels{
+		routinepkg.RoutineLabelKeyModule:   "dify_invocation",
+		routinepkg.RoutineLabelKeyFunction: "StreamResponse",
 	}, func() {
 		defer newResponse.Close()
 		for response.Next() {

--- a/internal/core/plugin_daemon/agent_service.go
+++ b/internal/core/plugin_daemon/agent_service.go
@@ -11,6 +11,7 @@ import (
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/agent_entities"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/requests"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/tool_entities"
+	routinepkg "github.com/langgenius/dify-plugin-daemon/pkg/routine"
 )
 
 func InvokeAgentStrategy(
@@ -37,8 +38,9 @@ func InvokeAgentStrategy(
 	newResponse := stream.NewStream[agent_entities.AgentStrategyResponseChunk](128)
 	files := make(map[string]*bytes.Buffer)
 
-	routine.Submit(map[string]string{
-		"agent_service": "invoke_agent_strategy",
+	routine.Submit(routinepkg.Labels{
+		routinepkg.RoutineLabelKeyModule: "agent_service",
+		routinepkg.RoutineLabelKeyAction: "invoke_agent_strategy",
 	}, func() {
 		defer newResponse.Close()
 

--- a/internal/core/plugin_daemon/backwards_invocation/task.go
+++ b/internal/core/plugin_daemon/backwards_invocation/task.go
@@ -12,6 +12,7 @@ import (
 	"github.com/langgenius/dify-plugin-daemon/internal/utils/parser"
 	"github.com/langgenius/dify-plugin-daemon/internal/utils/routine"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/plugin_entities"
+	routinepkg "github.com/langgenius/dify-plugin-daemon/pkg/routine"
 )
 
 // returns error only if payload is not correct
@@ -56,9 +57,9 @@ func InvokeDify(
 	}
 
 	// dispatch invocation task
-	routine.Submit(map[string]string{
-		"module":   "plugin_daemon",
-		"function": "InvokeDify",
+	routine.Submit(routinepkg.Labels{
+		routinepkg.RoutineLabelKeyModule:   "plugin_daemon",
+		routinepkg.RoutineLabelKeyFunction: "InvokeDify",
 	}, func() {
 		dispatchDifyInvocationTask(requestHandle)
 		defer requestHandle.EndResponse()

--- a/internal/core/plugin_daemon/endpoint_service.go
+++ b/internal/core/plugin_daemon/endpoint_service.go
@@ -9,6 +9,7 @@ import (
 	"github.com/langgenius/dify-plugin-daemon/internal/utils/stream"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/endpoint_entities"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/requests"
+	routinepkg "github.com/langgenius/dify-plugin-daemon/pkg/routine"
 )
 
 func InvokeEndpoint(
@@ -60,10 +61,10 @@ func InvokeEndpoint(
 			}
 
 			response.Write(dehexed)
-			routine.Submit(map[string]string{
-				"module":   "plugin_daemon",
-				"function": "InvokeEndpoint",
-				"type":     "body_write",
+			routine.Submit(routinepkg.Labels{
+				routinepkg.RoutineLabelKeyModule:   "plugin_daemon",
+				routinepkg.RoutineLabelKeyFunction: "InvokeEndpoint",
+				routinepkg.RoutineLabelKeyType:     "body_write",
 			}, func() {
 				defer response.Close()
 				for resp.Next() {

--- a/internal/core/plugin_manager/debugging_runtime/io.go
+++ b/internal/core/plugin_manager/debugging_runtime/io.go
@@ -11,6 +11,7 @@ import (
 	"github.com/langgenius/dify-plugin-daemon/internal/utils/routine"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/plugin_entities"
+	routinepkg "github.com/langgenius/dify-plugin-daemon/pkg/routine"
 	"github.com/panjf2000/gnet/v2"
 )
 
@@ -18,9 +19,9 @@ func (r *RemotePluginRuntime) Listen(sessionId string) (*entities.Broadcast[plug
 	listener := entities.NewCallbackHandler[plugin_entities.SessionMessage]()
 	listener.OnClose(func() {
 		// execute in new goroutine to avoid deadlock
-		routine.Submit(map[string]string{
-			"module": "debugging_runtime",
-			"method": "removeMessageCallbackHandler",
+		routine.Submit(routinepkg.Labels{
+			routinepkg.RoutineLabelKeyModule: "debugging_runtime",
+			routinepkg.RoutineLabelKeyMethod: "removeMessageCallbackHandler",
 		}, func() {
 			r.removeMessageCallbackHandler(sessionId)
 			r.removeSessionMessageCloser(sessionId)

--- a/internal/core/plugin_manager/debugging_runtime/runtime_intialization_handlers.go
+++ b/internal/core/plugin_manager/debugging_runtime/runtime_intialization_handlers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/langgenius/dify-plugin-daemon/internal/utils/parser"
 	"github.com/langgenius/dify-plugin-daemon/internal/utils/routine"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/plugin_entities"
+	routinepkg "github.com/langgenius/dify-plugin-daemon/pkg/routine"
 )
 
 func (d *DifyServer) handleHandleShake(
@@ -114,13 +115,19 @@ func (d *DifyServer) handleInitializationEndEvent(
 
 	// spawn a core to handle CPU-intensive tasks
 	routine.Submit(
-		map[string]string{"module": "debugging_runtime", "action": "spawnCore"},
+		routinepkg.Labels{
+			routinepkg.RoutineLabelKeyModule: "debugging_runtime",
+			routinepkg.RoutineLabelKeyAction: "spawnCore",
+		},
 		func() { runtime.SpawnCore() },
 	)
 
 	// start heartbeat monitor
 	routine.Submit(
-		map[string]string{"module": "debugging_runtime", "action": "heartbeatMonitor"},
+		routinepkg.Labels{
+			routinepkg.RoutineLabelKeyModule: "debugging_runtime",
+			routinepkg.RoutineLabelKeyAction: "heartbeatMonitor",
+		},
 		func() { runtime.HeartbeatMonitor() },
 	)
 

--- a/internal/core/plugin_manager/installer.go
+++ b/internal/core/plugin_manager/installer.go
@@ -15,6 +15,7 @@ import (
 	"github.com/langgenius/dify-plugin-daemon/internal/utils/stream"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/installation_entities"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/plugin_entities"
+	routinepkg "github.com/langgenius/dify-plugin-daemon/pkg/routine"
 )
 
 var (
@@ -55,9 +56,9 @@ func (p *PluginManager) Reinstall(
 
 	responseStream := stream.NewStream[installation_entities.PluginInstallResponse](128)
 
-	routine.Submit(map[string]string{
-		"module": "plugin_manager",
-		"action": "reinstallServerless",
+	routine.Submit(routinepkg.Labels{
+		routinepkg.RoutineLabelKeyModule: "plugin_manager",
+		routinepkg.RoutineLabelKeyAction: "reinstallServerless",
 	}, func() {
 		defer responseStream.Close()
 
@@ -161,9 +162,9 @@ func (p *PluginManager) installServerless(
 
 	responseStream := stream.NewStream[installation_entities.PluginInstallResponse](128)
 
-	routine.Submit(map[string]string{
-		"module": "plugin_manager",
-		"action": "installServerless",
+	routine.Submit(routinepkg.Labels{
+		routinepkg.RoutineLabelKeyModule: "plugin_manager",
+		routinepkg.RoutineLabelKeyAction: "installServerless",
 	}, func() {
 		defer responseStream.Close()
 
@@ -253,9 +254,9 @@ func (p *PluginManager) installLocal(
 ) (*stream.Stream[installation_entities.PluginInstallResponse], error) {
 	responseStream := stream.NewStream[installation_entities.PluginInstallResponse](128)
 
-	routine.Submit(map[string]string{
-		"module": "plugin_manager",
-		"action": "installLocal",
+	routine.Submit(routinepkg.Labels{
+		routinepkg.RoutineLabelKeyModule: "plugin_manager",
+		routinepkg.RoutineLabelKeyAction: "installLocal",
 	}, func() {
 		// firstly, install the plugin, then launch it, delete it if process fails
 		var success bool = false

--- a/internal/core/plugin_manager/local_runtime/control.go
+++ b/internal/core/plugin_manager/local_runtime/control.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/langgenius/dify-plugin-daemon/internal/utils/routine"
+	routinepkg "github.com/langgenius/dify-plugin-daemon/pkg/routine"
 )
 
 const (
@@ -19,8 +20,9 @@ func (r *LocalPluginRuntime) Schedule() error {
 	}
 
 	// start schedule loop
-	routine.Submit(map[string]string{
-		"module": "local_runtime", "method": "scheduleLoop",
+	routine.Submit(routinepkg.Labels{
+		routinepkg.RoutineLabelKeyModule: "local_runtime",
+		routinepkg.RoutineLabelKeyMethod: "scheduleLoop",
 	}, r.scheduleLoop)
 
 	return nil
@@ -102,8 +104,9 @@ func (r *LocalPluginRuntime) Stop(async bool) {
 	if !async {
 		r.waitForAllInstancesToBeShutdown()
 	} else {
-		routine.Submit(map[string]string{
-			"module": "local_runtime", "method": "waitForAllInstancesToBeShutdown",
+		routine.Submit(routinepkg.Labels{
+			routinepkg.RoutineLabelKeyModule: "local_runtime",
+			routinepkg.RoutineLabelKeyMethod: "waitForAllInstancesToBeShutdown",
 		}, func() {
 			r.waitForAllInstancesToBeShutdown()
 		})
@@ -123,8 +126,9 @@ func (r *LocalPluginRuntime) GracefulStop(async bool) {
 	if !async {
 		r.stopAndWaitForAllInstancesToBeShutdown()
 	} else {
-		routine.Submit(map[string]string{
-			"module": "local_runtime", "method": "stopAndWaitForAllInstancesToBeShutdown",
+		routine.Submit(routinepkg.Labels{
+			routinepkg.RoutineLabelKeyModule: "local_runtime",
+			routinepkg.RoutineLabelKeyMethod: "stopAndWaitForAllInstancesToBeShutdown",
 		}, func() {
 			r.stopAndWaitForAllInstancesToBeShutdown()
 		})

--- a/internal/core/plugin_manager/local_runtime/setup_python_environment.go
+++ b/internal/core/plugin_manager/local_runtime/setup_python_environment.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/langgenius/dify-plugin-daemon/internal/utils/log"
 	"github.com/langgenius/dify-plugin-daemon/internal/utils/routine"
+	routinepkg "github.com/langgenius/dify-plugin-daemon/pkg/routine"
 )
 
 func (p *LocalPluginRuntime) prepareUV() (string, error) {
@@ -108,9 +109,9 @@ func (p *LocalPluginRuntime) installDependencies(
 
 	lastActiveAt := time.Now()
 
-	routine.Submit(map[string]string{
-		"module":   "plugin_manager",
-		"function": "InitPythonEnvironment",
+	routine.Submit(routinepkg.Labels{
+		routinepkg.RoutineLabelKeyModule:   "plugin_manager",
+		routinepkg.RoutineLabelKeyFunction: "InitPythonEnvironment",
 	}, func() {
 		defer wg.Done()
 		// read stdout
@@ -126,9 +127,9 @@ func (p *LocalPluginRuntime) installDependencies(
 		}
 	})
 
-	routine.Submit(map[string]string{
-		"module":   "plugin_manager",
-		"function": "InitPythonEnvironment",
+	routine.Submit(routinepkg.Labels{
+		routinepkg.RoutineLabelKeyModule:   "plugin_manager",
+		routinepkg.RoutineLabelKeyFunction: "InitPythonEnvironment",
 	}, func() {
 		defer wg.Done()
 		// read stderr
@@ -150,9 +151,9 @@ func (p *LocalPluginRuntime) installDependencies(
 		}
 	})
 
-	routine.Submit(map[string]string{
-		"module":   "plugin_manager",
-		"function": "InitPythonEnvironment",
+	routine.Submit(routinepkg.Labels{
+		routinepkg.RoutineLabelKeyModule:   "plugin_manager",
+		routinepkg.RoutineLabelKeyFunction: "InitPythonEnvironment",
 	}, func() {
 		ticker := time.NewTicker(5 * time.Second)
 		defer ticker.Stop()
@@ -332,9 +333,9 @@ func (p *LocalPluginRuntime) preCompile(
 	var compileWg sync.WaitGroup
 	compileWg.Add(2)
 
-	routine.Submit(map[string]string{
-		"module":   "plugin_manager",
-		"function": "InitPythonEnvironment",
+	routine.Submit(routinepkg.Labels{
+		routinepkg.RoutineLabelKeyModule:   "plugin_manager",
+		routinepkg.RoutineLabelKeyFunction: "InitPythonEnvironment",
 	}, func() {
 		defer compileWg.Done()
 		// read compileStdout
@@ -361,9 +362,9 @@ func (p *LocalPluginRuntime) preCompile(
 		}
 	})
 
-	routine.Submit(map[string]string{
-		"module":   "plugin_manager",
-		"function": "InitPythonEnvironment",
+	routine.Submit(routinepkg.Labels{
+		routinepkg.RoutineLabelKeyModule:   "plugin_manager",
+		routinepkg.RoutineLabelKeyFunction: "InitPythonEnvironment",
 	}, func() {
 		defer compileWg.Done()
 		// read stderr

--- a/internal/core/plugin_manager/local_runtime/subprocess.go
+++ b/internal/core/plugin_manager/local_runtime/subprocess.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/langgenius/dify-plugin-daemon/internal/utils/routine"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/constants"
+	routinepkg "github.com/langgenius/dify-plugin-daemon/pkg/routine"
 )
 
 // getCmd prepares the exec.Cmd for the plugin based on its language
@@ -149,13 +150,21 @@ func (r *LocalPluginRuntime) startNewInstance() error {
 
 	// listen to plugin stdout
 	routine.Submit(
-		map[string]string{"module": "plugin_manager", "type": "local", "function": "StartStdout"},
+		routinepkg.Labels{
+			routinepkg.RoutineLabelKeyModule:   "plugin_manager",
+			routinepkg.RoutineLabelKeyType:     "local",
+			routinepkg.RoutineLabelKeyFunction: "StartStdout",
+		},
 		instance.StartStdout,
 	)
 
 	// listen to plugin stderr
 	routine.Submit(
-		map[string]string{"module": "plugin_manager", "type": "local", "function": "StartStderr"},
+		routinepkg.Labels{
+			routinepkg.RoutineLabelKeyModule:   "plugin_manager",
+			routinepkg.RoutineLabelKeyType:     "local",
+			routinepkg.RoutineLabelKeyFunction: "StartStderr",
+		},
 		instance.StartStderr,
 	)
 
@@ -173,7 +182,11 @@ func (r *LocalPluginRuntime) startNewInstance() error {
 
 	// monitor plugin
 	routine.Submit(
-		map[string]string{"module": "plugin_manager", "type": "local", "function": "Monitor"},
+		routinepkg.Labels{
+			routinepkg.RoutineLabelKeyModule:   "plugin_manager",
+			routinepkg.RoutineLabelKeyType:     "local",
+			routinepkg.RoutineLabelKeyFunction: "Monitor",
+		},
 		func() {
 			instance.Monitor()
 		},

--- a/internal/core/plugin_manager/serverless_connector/connector.go
+++ b/internal/core/plugin_manager/serverless_connector/connector.go
@@ -12,6 +12,7 @@ import (
 	"github.com/langgenius/dify-plugin-daemon/internal/utils/routine"
 	"github.com/langgenius/dify-plugin-daemon/internal/utils/stream"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/plugin_entities"
+	routinepkg "github.com/langgenius/dify-plugin-daemon/pkg/routine"
 )
 
 type ServerlessFunction struct {
@@ -157,9 +158,9 @@ func SetupFunction(
 
 	response := stream.NewStream[LaunchFunctionResponse](10)
 
-	routine.Submit(map[string]string{
-		"module": "serverless_connector",
-		"func":   "SetupFunction",
+	routine.Submit(routinepkg.Labels{
+		routinepkg.RoutineLabelKeyModule:   "serverless_connector",
+		routinepkg.RoutineLabelKeyFunction: "SetupFunction",
 	}, func() {
 		defer response.Close()
 		if err := serverless_connector_response.Async(func(chunk LaunchFunctionResponseChunk) {

--- a/internal/core/plugin_manager/serverless_runtime/io.go
+++ b/internal/core/plugin_manager/serverless_runtime/io.go
@@ -14,6 +14,7 @@ import (
 	"github.com/langgenius/dify-plugin-daemon/internal/utils/routine"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/plugin_entities"
+	routinepkg "github.com/langgenius/dify-plugin-daemon/pkg/routine"
 )
 
 func (r *ServerlessPluginRuntime) Listen(sessionId string) (
@@ -42,11 +43,11 @@ func (r *ServerlessPluginRuntime) Write(
 		return errors.Join(err, errors.New("failed to join lambda url"))
 	}
 
-	routine.Submit(map[string]string{
-		"module":     "serverless_runtime",
-		"function":   "Write",
-		"session_id": sessionId,
-		"lambda_url": r.LambdaURL,
+	routine.Submit(routinepkg.Labels{
+		routinepkg.RoutineLabelKeyModule:    "serverless_runtime",
+		routinepkg.RoutineLabelKeyFunction:  "Write",
+		routinepkg.RoutineLabelKeySessionID: sessionId,
+		routinepkg.RoutineLabelKeyTarget:    r.LambdaURL,
 	}, func() {
 		// remove the session from listeners
 		defer r.listeners.Delete(sessionId)

--- a/internal/service/base_sse.go
+++ b/internal/service/base_sse.go
@@ -14,6 +14,7 @@ import (
 	"github.com/langgenius/dify-plugin-daemon/internal/utils/stream"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/plugin_entities"
+	routinepkg "github.com/langgenius/dify-plugin-daemon/pkg/routine"
 )
 
 // baseSSEService is a helper function to handle SSE service
@@ -49,9 +50,9 @@ func baseSSEService[R any](
 		return
 	}
 
-	routine.Submit(map[string]string{
-		"module":   "service",
-		"function": "baseSSEService",
+	routine.Submit(routinepkg.Labels{
+		routinepkg.RoutineLabelKeyModule:   "service",
+		routinepkg.RoutineLabelKeyFunction: "baseSSEService",
 	}, func() {
 		for pluginDaemonResponse.Next() {
 			chunk, err := pluginDaemonResponse.Read()

--- a/internal/service/endpoint.go
+++ b/internal/service/endpoint.go
@@ -30,6 +30,7 @@ import (
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/endpoint_entities"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/plugin_entities"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/requests"
+	routinepkg "github.com/langgenius/dify-plugin-daemon/pkg/routine"
 )
 
 func copyRequest(req *http.Request, hookId string, path string) (*bytes.Buffer, error) {
@@ -195,9 +196,9 @@ func Endpoint(
 	}
 	defer close()
 
-	routine.Submit(map[string]string{
-		"module":   "service",
-		"function": "Endpoint",
+	routine.Submit(routinepkg.Labels{
+		routinepkg.RoutineLabelKeyModule:   "service",
+		routinepkg.RoutineLabelKeyFunction: "Endpoint",
 	}, func() {
 		defer close()
 		for response.Next() {

--- a/internal/service/install_plugin.go
+++ b/internal/service/install_plugin.go
@@ -20,6 +20,7 @@ import (
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/constants"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/installation_entities"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/plugin_entities"
+	routinepkg "github.com/langgenius/dify-plugin-daemon/pkg/routine"
 )
 
 type InstallPluginResponse struct {
@@ -115,9 +116,9 @@ func InstallMultiplePluginsToTenant(
 	for _, job := range jobs {
 		jobCopy := job
 		// start a new goroutine to install the plugin
-		routine.Submit(map[string]string{
-			"module": "service",
-			"func":   "InstallPlugin",
+		routine.Submit(routinepkg.Labels{
+			routinepkg.RoutineLabelKeyModule:   "service",
+			routinepkg.RoutineLabelKeyFunction: "InstallPlugin",
 		}, func() {
 			tasks.ProcessInstallJob(
 				manager,
@@ -178,9 +179,9 @@ func ReinstallPluginFromIdentifier(
 		}
 
 		retStream := stream.NewStream[installation_entities.PluginInstallResponse](128)
-		routine.Submit(map[string]string{
-			"module": "service",
-			"func":   "ReinstallPlugin",
+		routine.Submit(routinepkg.Labels{
+			routinepkg.RoutineLabelKeyModule:   "service",
+			routinepkg.RoutineLabelKeyFunction: "ReinstallPlugin",
 		}, func() {
 			defer retStream.Close()
 

--- a/internal/utils/http_requests/http_warpper.go
+++ b/internal/utils/http_requests/http_warpper.go
@@ -12,6 +12,7 @@ import (
 	"github.com/langgenius/dify-plugin-daemon/internal/utils/parser"
 	"github.com/langgenius/dify-plugin-daemon/internal/utils/routine"
 	"github.com/langgenius/dify-plugin-daemon/internal/utils/stream"
+	routinepkg "github.com/langgenius/dify-plugin-daemon/pkg/routine"
 )
 
 func parseJsonBody(resp *http.Response, ret interface{}) error {
@@ -123,9 +124,9 @@ func RequestAndParseStream[T any](client *http.Client, url string, method string
 		return nil
 	}
 
-	routine.Submit(map[string]string{
-		"module":   "http_requests",
-		"function": "RequestAndParseStream",
+	routine.Submit(routinepkg.Labels{
+		routinepkg.RoutineLabelKeyModule:   "http_requests",
+		routinepkg.RoutineLabelKeyFunction: "RequestAndParseStream",
 	}, func() {
 		defer resp.Body.Close()
 

--- a/internal/utils/routine/pool.go
+++ b/internal/utils/routine/pool.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/getsentry/sentry-go"
 	"github.com/langgenius/dify-plugin-daemon/internal/utils/log"
+	routinelabels "github.com/langgenius/dify-plugin-daemon/pkg/routine"
 	"github.com/panjf2000/ants/v2"
 )
 
@@ -39,9 +40,9 @@ func InitPool(size int, sentryOption ...sentry.ClientOptions) {
 	}
 }
 
-func Submit(labels map[string]string, f func()) {
+func Submit(labels routinelabels.Labels, f func()) {
 	if labels == nil {
-		labels = map[string]string{}
+		labels = routinelabels.Labels{}
 	}
 
 	p.Submit(func() {
@@ -50,7 +51,7 @@ func Submit(labels map[string]string, f func()) {
 		}
 		if len(labels) > 0 {
 			for k, v := range labels {
-				label = append(label, k, v)
+				label = append(label, string(k), v)
 			}
 		}
 		pprof.Do(context.Background(), pprof.Labels(label...), func(ctx context.Context) {
@@ -69,9 +70,9 @@ func WithMaxRoutine(maxRoutine int, tasks []func(), onFinish ...func()) {
 		maxRoutine = len(tasks)
 	}
 
-	Submit(map[string]string{
-		"module":   "routine",
-		"function": "WithMaxRoutine",
+	Submit(routinelabels.Labels{
+		routinelabels.RoutineLabelKeyModule:   "routine",
+		routinelabels.RoutineLabelKeyFunction: "WithMaxRoutine",
 	}, func() {
 		wg := sync.WaitGroup{}
 		taskIndex := int32(0)

--- a/pkg/routine/labels.go
+++ b/pkg/routine/labels.go
@@ -1,0 +1,15 @@
+package routine
+
+type RoutineLabelKey string
+
+type Labels map[RoutineLabelKey]string
+
+const (
+	RoutineLabelKeyModule    RoutineLabelKey = "module"
+	RoutineLabelKeyFunction  RoutineLabelKey = "function"
+	RoutineLabelKeyAction    RoutineLabelKey = "action"
+	RoutineLabelKeyType      RoutineLabelKey = "type"
+	RoutineLabelKeyMethod    RoutineLabelKey = "method"
+	RoutineLabelKeySessionID RoutineLabelKey = "session_id"
+	RoutineLabelKeyTarget    RoutineLabelKey = "target"
+)


### PR DESCRIPTION
## Summary
- add pkg/routine with shared label key constants and type alias for routine labels
- update internal/utils/routine.Submit to consume the shared type and emit consistent profiler labels
- replace ad-hoc label maps across services and plugin manager code with the centralized constants

## Testing
- go test ./... *(fails: requires network access to download go modules and PRIVATE_KEY.pem)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6916dd3ee8288326b62257f506e1cf00)