### PR TITLE
fix: remove restriction of orphan plugins in local mode

### DIFF
--- a/internal/types/app/config.go
+++ b/internal/types/app/config.go
@@ -252,9 +252,6 @@ func (c *Config) Validate() error {
 		if c.PluginWorkingPath == "" {
 			return fmt.Errorf("plugin working path is empty")
 		}
-		if c.PluginAllowOrphans {
-			return fmt.Errorf("orphan plugins are not allowed in local mode")
-		}
 	} else {
 		return fmt.Errorf("invalid platform")
 	}


### PR DESCRIPTION
## Description

local mode is also allowed in enterprise edition

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Other

## Essential Checklist

### Testing
- [ ] I have tested the changes locally and confirmed they work as expected
- [ ] I have added unit tests where necessary and they pass successfully

### Bug Fix (if applicable)
- [ ] I have used GitHub syntax to close the related issue (e.g., `Fixes #123` or `Closes #123`)

## Additional Information

Please provide any additional context that would help reviewers understand the changes. 