### PR TITLE
fix: release lock if runtime already installed

### DIFF
--- a/internal/core/control_panel/launcher_local.go
+++ b/internal/core/control_panel/launcher_local.go
@@ -26,6 +26,7 @@ func (c *ControlPanel) LaunchLocalPlugin(
 
 	// check if the plugin is already installed
 	if _, exists := c.localPluginRuntimes.Load(pluginUniqueIdentifier); exists {
+		c.localPluginInstallationLock.Unlock(pluginUniqueIdentifier.String())
 		return nil, nil, ErrorPluginAlreadyLaunched
 	}
 


### PR DESCRIPTION
## Description

The lock is not released if the runtime already exists, causing subsequent installations to stuck at `Installing`

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Other

## Essential Checklist

### Testing
- [x] I have tested the changes locally and confirmed they work as expected
- [ ] I have added unit tests where necessary and they pass successfully

### Bug Fix (if applicable)
- [ ] I have used GitHub syntax to close the related issue (e.g., `Fixes #123` or `Closes #123`)

## Additional Information

Please provide any additional context that would help reviewers understand the changes. 