### PR TITLE
fix: remote debug not work

### DIFF
--- a/internal/core/plugin_manager/manager.go
+++ b/internal/core/plugin_manager/manager.go
@@ -11,6 +11,7 @@ import (
 	"github.com/langgenius/dify-plugin-daemon/internal/core/dify_invocation/calldify"
 	"github.com/langgenius/dify-plugin-daemon/internal/core/plugin_manager/media_transport"
 	serverless "github.com/langgenius/dify-plugin-daemon/internal/core/serverless_connector"
+	"github.com/langgenius/dify-plugin-daemon/internal/service/install_service"
 	"github.com/langgenius/dify-plugin-daemon/internal/types/app"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/plugin_entities"
 	"github.com/langgenius/dify-plugin-daemon/pkg/plugin_packager/decoder"
@@ -83,8 +84,9 @@ func InitGlobalManager(oss oss.OSS, config *app.Config) *PluginManager {
 		config: config,
 	}
 
-	// mount logger to control panel
+	// mount control panel notifiers
 	manager.controlPanel.AddNotifier(&controlpanel.StandardLogger{})
+	manager.controlPanel.AddNotifier(&install_service.InstallListener{})
 
 	return manager
 }

--- a/internal/service/install_service/controlpanel.go
+++ b/internal/service/install_service/controlpanel.go
@@ -9,6 +9,30 @@ import (
 
 type InstallListener struct{}
 
+func (l *InstallListener) OnLocalRuntimeStarting(pluginUniqueIdentifier plugin_entities.PluginUniqueIdentifier) {
+}
+
+func (l *InstallListener) OnLocalRuntimeReady(runtime *local_runtime.LocalPluginRuntime) {
+}
+
+func (l *InstallListener) OnLocalRuntimeStartFailed(
+	pluginUniqueIdentifier plugin_entities.PluginUniqueIdentifier,
+	err error,
+) {
+}
+
+func (l *InstallListener) OnLocalRuntimeStop(runtime *local_runtime.LocalPluginRuntime) {
+}
+
+func (l *InstallListener) OnLocalRuntimeStopped(runtime *local_runtime.LocalPluginRuntime) {
+}
+
+func (l *InstallListener) OnLocalRuntimeScaleUp(runtime *local_runtime.LocalPluginRuntime, instanceNums int32) {
+}
+
+func (l *InstallListener) OnLocalRuntimeScaleDown(runtime *local_runtime.LocalPluginRuntime, instanceNums int32) {
+}
+
 func (l *InstallListener) OnDebuggingRuntimeConnected(runtime *debugging_runtime.RemotePluginRuntime) {
 	_, installation, err := InstallPlugin(
 		runtime.TenantId(),
@@ -40,12 +64,4 @@ func (l *InstallListener) OnDebuggingRuntimeDisconnected(runtime *debugging_runt
 	); err != nil {
 		log.Error("uninstall debugging plugin failed, error: %v", err)
 	}
-}
-
-func (l *InstallListener) OnLocalRuntimeReady(runtime *local_runtime.LocalPluginRuntime) {
-
-}
-
-func (l *InstallListener) OnLocalRuntimeStartFailed(runtime *local_runtime.LocalPluginRuntime) {
-
 }


### PR DESCRIPTION
## Description

Please provide a brief description of the changes made in this pull request.
Please also include the issue number if this is related to an issue using the format `Fixes #123` or `Closes #123`.

After the refactoring, when you remotely debug a plugin, it will not display on the plugin page.

It seems that the `/plugin/.../management/list` only reads plugins from the database, but the `InstallListener` is not mounted by the `ControlPanel`. As a result, it will not write plugin data to the database, so it will not function properly.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Other

## Essential Checklist

### Testing
- [x] I have tested the changes locally and confirmed they work as expected
- [ ] I have added unit tests where necessary and they pass successfully

### Bug Fix (if applicable)
- [ ] I have used GitHub syntax to close the related issue (e.g., `Fixes #123` or `Closes #123`)

## Additional Information

Please provide any additional context that would help reviewers understand the changes. 