### PR TITLE
fix: tool and trigger not response icon_dark

### DIFF
--- a/pkg/entities/plugin_entities/tool_declaration.go
+++ b/pkg/entities/plugin_entities/tool_declaration.go
@@ -179,7 +179,7 @@ type ToolProviderIdentity struct {
 	Name        string                        `json:"name" validate:"required,tool_provider_identity_name"`
 	Description I18nObject                    `json:"description"`
 	Icon        string                        `json:"icon" validate:"required"`
-	IconDark    string                        `json:"icon_dark" validate:"omitempty"`
+	IconDark    string                        `json:"icon_dark" yaml:"icon_dark" validate:"omitempty"`
 	Label       I18nObject                    `json:"label" validate:"required"`
 	Tags        []manifest_entities.PluginTag `json:"tags" validate:"omitempty,dive,plugin_tag"`
 }

--- a/pkg/entities/plugin_entities/trigger_declaration.go
+++ b/pkg/entities/plugin_entities/trigger_declaration.go
@@ -89,7 +89,7 @@ type TriggerProviderIdentity struct {
 	Name        string                        `json:"name" validate:"required,tool_provider_identity_name"`
 	Description I18nObject                    `json:"description"`
 	Icon        string                        `json:"icon" validate:"required"`
-	IconDark    string                        `json:"icon_dark" validate:"omitempty"`
+	IconDark    string                        `json:"icon_dark" yaml:"icon_dark" validate:"omitempty"`
 	Label       I18nObject                    `json:"label" validate:"required"`
 	Tags        []manifest_entities.PluginTag `json:"tags" validate:"omitempty,dive,plugin_tag"`
 }


### PR DESCRIPTION
## Description


to support https://github.com/langgenius/dify/pull/28858

When I remote debug a tool or trigger, the dark icon works fine. 
However, when I install it locally, it does not work. 
This issue is caused by `IconDark` being mapped to `iconDark` in the YAML file. 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Other

## Essential Checklist

### Testing
- [x] I have tested the changes locally and confirmed they work as expected
- [ ] I have added unit tests where necessary and they pass successfully

### Bug Fix (if applicable)
- [ ] I have used GitHub syntax to close the related issue (e.g., `Fixes #123` or `Closes #123`)

## Additional Information

Please provide any additional context that would help reviewers understand the changes. 