### PR TITLE
fix: handle connection close on the connector side

### DIFF
--- a/pkg/utils/parser/chunking.go
+++ b/pkg/utils/parser/chunking.go
@@ -24,7 +24,7 @@ func LineBasedChunking(reader io.Reader, maxChunkSize int, processor func([]byte
 			return err
 		}
 	}
-	return nil
+	return scanner.Err()
 }
 
 // We uses following format:


### PR DESCRIPTION
## Description

If serverless connector crashes while launching plugin, the install task gets stuck at Installing

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Other

## Essential Checklist

### Testing
- [ ] I have tested the changes locally and confirmed they work as expected
- [ ] I have added unit tests where necessary and they pass successfully

### Bug Fix (if applicable)
- [ ] I have used GitHub syntax to close the related issue (e.g., `Fixes #123` or `Closes #123`)

## Additional Information

Please provide any additional context that would help reviewers understand the changes. 