### PR TITLE
fix: fix panic error

### DIFF
--- a/internal/core/io_tunnel/agent_service.go
+++ b/internal/core/io_tunnel/agent_service.go
@@ -18,9 +18,8 @@ func InvokeAgentStrategy(
 	session *session_manager.Session,
 	r *requests.RequestInvokeAgentStrategy,
 ) (*stream.Stream[agent_entities.AgentStrategyResponseChunk], error) {
-	runtime := session.Runtime()
-	if runtime == nil {
-		return nil, errors.New("plugin not found")
+	if session == nil {
+		return nil, errors.New("session is nil")
 	}
 
 	response, err := GenericInvokePlugin[

--- a/internal/core/io_tunnel/generic.go
+++ b/internal/core/io_tunnel/generic.go
@@ -17,15 +17,19 @@ func GenericInvokePlugin[Req any, Rsp any](
 	request *Req,
 	response_buffer_size int,
 ) (*stream.Stream[Rsp], error) {
+	if session == nil {
+		return nil, errors.New("session is nil")
+	}
+
 	runtime := session.Runtime()
 	if runtime == nil {
-		return nil, errors.New("plugin runtime not found")
+		return nil, errors.New("plugin runtime not bound to session, session may not be properly initialized")
 	}
 
 	response := stream.NewStream[Rsp](response_buffer_size)
 	listener, err := runtime.Listen(session.ID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create listener for session %s: %w", session.ID, err)
 	}
 
 	listener.Listen(func(chunk plugin_entities.SessionMessage) {

--- a/internal/core/session_manager/session.go
+++ b/internal/core/session_manager/session.go
@@ -145,10 +145,20 @@ func (s *Session) Close(payload CloseSessionPayload) {
 }
 
 func (s *Session) BindRuntime(runtime plugin_entities.PluginRuntimeSessionIOInterface) {
+	if s == nil {
+		return
+	}
+	if runtime == nil {
+		log.Warn("attempting to bind nil runtime to session %s", s.ID)
+		return
+	}
 	s.runtime = runtime
 }
 
 func (s *Session) Runtime() plugin_entities.PluginRuntimeSessionIOInterface {
+	if s == nil {
+		return nil
+	}
 	return s.runtime
 }
 

--- a/internal/service/session.go
+++ b/internal/service/session.go
@@ -25,6 +25,9 @@ func createSession[T any](
 	if err != nil {
 		return nil, errors.New("failed to get plugin runtime")
 	}
+	if runtime == nil {
+		return nil, errors.New("plugin runtime is nil for identifier: " + string(r.UniqueIdentifier))
+	}
 
 	session := session_manager.NewSession(
 		session_manager.NewSessionPayload{


### PR DESCRIPTION
## Description

fix https://github.com/langgenius/dify/issues/29282

The nil pointer dereference happens when:
1. A session is created via NewSession() where runtime field remains nil
2. The session is used before BindRuntime() is called to attach a runtime instance
3. GenericInvokePlugin tries to access the runtime's Listen() method


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Other

## Essential Checklist

### Testing
- [x] I have tested the changes locally and confirmed they work as expected
- [ ] I have added unit tests where necessary and they pass successfully

### Bug Fix (if applicable)
- [x] I have used GitHub syntax to close the related issue (e.g., `Fixes #123` or `Closes #123`)

## Additional Information

Please provide any additional context that would help reviewers understand the changes. 