### PR TITLE
Fix non-constant format string in backwards invocation permission check

### DIFF
--- a/internal/core/io_tunnel/backwards_invocation/task.go
+++ b/internal/core/io_tunnel/backwards_invocation/task.go
@@ -189,7 +189,7 @@ func checkPermission(runtime *plugin_entities.PluginDeclaration, requestHandle *
 	}
 
 	if !permissionFunc(runtime) {
-		return fmt.Errorf(permission["error"].(string))
+		return errors.New(permission["error"].(string))
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
- replace dynamic fmt.Errorf usage with errors.New in backwards invocation permission check
- maintain formatting with gofmt

## Testing
- go test ./internal/core/io_tunnel/backwards_invocation -run TestBackwardsInvocationAllPermittedPermission -v


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693a5723696c83269ed9b34ea258802b)