### PR TITLE
fix: align plugin manifest validation error messages with regex length limits

### DIFF
--- a/pkg/entities/plugin_entities/plugin_declaration.go
+++ b/pkg/entities/plugin_entities/plugin_declaration.go
@@ -271,7 +271,7 @@ func (p *PluginDeclaration) ManifestValidate() error {
 	}
 
 	if !PluginNameRegex.MatchString(p.Name) {
-		return fmt.Errorf("plugin name must be alphanumeric and less than 64 characters: ^[a-z0-9_-]{1,64}$")
+		return fmt.Errorf("plugin name must be alphanumeric and less than 128 characters: ^[a-z0-9_-]{1,128}$")
 	}
 
 	if p.Endpoint == nil && p.Model == nil && p.Tool == nil && p.AgentStrategy == nil && p.Datasource == nil && p.Trigger == nil {


### PR DESCRIPTION
## Description

Please provide a brief description of the changes made in this pull request.
Please also include the issue number if this is related to an issue using the format `Fixes #123` or `Closes #123`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Other

## Essential Checklist

### Testing
- [x] I have tested the changes locally and confirmed they work as expected
- [ ] I have added unit tests where necessary and they pass successfully

### Bug Fix (if applicable)
- [ ] I have used GitHub syntax to close the related issue (e.g., `Fixes #123` or `Closes #123`)

## Additional Information

Please provide any additional context that would help reviewers understand the changes. 