### PR TITLE
chore: init listener first avoid panic error

### DIFF
--- a/internal/core/local_runtime/instance.go
+++ b/internal/core/local_runtime/instance.go
@@ -71,9 +71,9 @@ func newPluginInstance(
 		errReader:              errReader,
 		l:                      &sync.Mutex{},
 		appConfig:              appConfig,
-
-		notifiers:    []PluginInstanceNotifier{},
-		notifierLock: &sync.Mutex{},
+		listener:               make(map[string]func([]byte)),
+		notifiers:              []PluginInstanceNotifier{},
+		notifierLock:           &sync.Mutex{},
 	}
 
 	return instance
@@ -82,9 +82,6 @@ func newPluginInstance(
 func (s *PluginInstance) setupStdioEventListener(session_id string, listener func([]byte)) {
 	s.l.Lock()
 	defer s.l.Unlock()
-	if s.listener == nil {
-		s.listener = map[string]func([]byte){}
-	}
 
 	s.listener[session_id] = listener
 }


### PR DESCRIPTION
## Description

fix #29959, init listener first to avoid panic error

```go
func(sessionId string, data []byte) {
    // FIX: avoid deadlock to plugin invoke
    s.l.Lock()
    listener := s.listener[sessionId]
    s.l.Unlock()
    if listener != nil {
        listener(data)
    }
}
```

if the listener is nil, it will panic, so init listener first

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Other

## Essential Checklist

### Testing
- [x] I have tested the changes locally and confirmed they work as expected
- [ ] I have added unit tests where necessary and they pass successfully

### Bug Fix (if applicable)
- [x] I have used GitHub syntax to close the related issue (e.g., `Fixes #123` or `Closes #123`)

## Additional Information

Please provide any additional context that would help reviewers understand the changes. 