### PR TITLE
fix PluginDaemonInternalServerError: no available node, plugin runtime not found

### DIFF
--- a/internal/types/models/curd/atomic.go
+++ b/internal/types/models/curd/atomic.go
@@ -604,8 +604,10 @@ func UpgradePlugin(
 	if err != nil {
 		return nil, err
 	}
-    pluginId := strings.Split(newPluginUniqueIdentifier.String(), ":")[0]  // get the pluginId
+    pluginId := newPluginUniqueIdentifier.PluginID()  // get the pluginId
 	pluginInstallationCacheKey := helper.PluginInstallationCacheKey(pluginId, tenantId) // make cache key
-	_, _ = cache.AutoDelete[models.PluginInstallation](pluginInstallationCacheKey) // delete the old data
+	if _, err = cache.AutoDelete[models.PluginInstallation](pluginInstallationCacheKey); err != nil {
+		return nil, err
+	}
 	return &response, nil
 }


### PR DESCRIPTION

Fix the bug where after a plugin is successfully upgraded, new requests result in the plugin daemon service responding with "no available node, plugin runtime not found".

The root cause is that when the plugin is upgraded successfully, the corresponding value in Redis is not updated. Consequently, when a new request arrives, it reads the outdated plugin version from Redis and fails to locate the correct runtime.

## Description

Please provide a brief description of the changes made in this pull request.
Please also include the issue number if this is related to an issue using the format `Fixes #123` or `Closes #123`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Other

## Essential Checklist

### Testing
- [x] I have tested the changes locally and confirmed they work as expected
- [x] I have added unit tests where necessary and they pass successfully

### Bug Fix (if applicable)
- [x] I have used GitHub syntax to close the related issue (e.g., `Fixes #123` or `Closes #123`)

## Additional Information

Please provide any additional context that would help reviewers understand the changes. 