### PR TITLE
fix: support lowercase proxy environment variables fallback

### DIFF
--- a/internal/types/app/default.go
+++ b/internal/types/app/default.go
@@ -42,9 +42,9 @@ func (config *Config) SetDefault() {
 	setDefaultInt(&config.DifyInvocationReadTimeout, 240000)
 
 	// fallback to lowercase proxy environment variables if uppercase is empty
-	setDefaultStringFromEnv(&config.HttpProxy, "http_proxy")
-	setDefaultStringFromEnv(&config.HttpsProxy, "https_proxy")
-	setDefaultStringFromEnv(&config.NoProxy, "no_proxy")
+	setDefaultString(&config.HttpProxy, os.Getenv("http_proxy"))
+	setDefaultString(&config.HttpsProxy, os.Getenv("https_proxy"))
+	setDefaultString(&config.NoProxy, os.Getenv("no_proxy"))
 	if config.DBType == DB_TYPE_POSTGRESQL || config.DBType == DB_TYPE_PG_BOUNCER {
 		setDefaultString(&config.DBDefaultDatabase, "postgres")
 	} else if config.DBType == DB_TYPE_MYSQL {
@@ -61,11 +61,5 @@ func setDefaultInt[T constraints.Integer](value *T, defaultValue T) {
 func setDefaultString(value *string, defaultValue string) {
 	if *value == "" {
 		*value = defaultValue
-	}
-}
-
-func setDefaultStringFromEnv(value *string, envKey string) {
-	if *value == "" {
-		*value = os.Getenv(envKey)
 	}
 }


### PR DESCRIPTION
## Description
This PR adds support for lowercase proxy environment variables as a fallback when uppercase versions are not set.

## Changes
- Added fallback logic in `SetDefault()` method to check lowercase `http_proxy`, `https_proxy`, and `no_proxy` when uppercase versions (`HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`) are empty
- Added new helper function `setDefaultStringFromEnv()` to read from environment variables

## Fixes
Fixes langgenius/dify#18752

## Testing
- Code compiles successfully
- Follows the same pattern as other configuration defaults in the codebase

## Behavior
- If `HTTP_PROXY` is set, it will be used (backward compatible)
- If `HTTP_PROXY` is empty but `http_proxy` is set, `http_proxy` will be used
- Same logic applies to `HTTPS_PROXY`/`https_proxy` and `NO_PROXY`/`no_proxy`