### PR TITLE
fix: remove leading slash from path after TrimPrefix in GCS storage

### DIFF
--- a/internal/core/plugin_manager/media_transport/installed_bucket.go
+++ b/internal/core/plugin_manager/media_transport/installed_bucket.go
@@ -73,9 +73,11 @@ func (b *InstalledBucket) List() ([]plugin_entities.PluginUniqueIdentifier, erro
 		if strings.HasPrefix(path.Path, ".") {
 			continue
 		}
-		// remove prefix
+		// remove prefix and leading slash
+		// GCS returns path like "plugins/org/plugin:1.0@hash", after TrimPrefix("plugins")
+		// it becomes "/org/plugin:1.0@hash" with a leading slash that needs to be removed
 		identifier, err := plugin_entities.NewPluginUniqueIdentifier(
-			strings.TrimPrefix(path.Path, b.installedPath),
+			strings.TrimPrefix(strings.TrimPrefix(path.Path, b.installedPath), "/"),
 		)
 		if err != nil {
 			log.Error("failed to create PluginUniqueIdentifier from path", "path", path.Path, "error", err)


### PR DESCRIPTION
## Summary

When using GCS storage, the `List()` method in `installed_bucket.go` returns paths like `plugins/org/plugin:1.0@hash`. After `TrimPrefix("plugins")`, the result is `/org/plugin:1.0@hash` with a leading slash, which causes `PluginUniqueIdentifier` validation to fail.

This fix adds an additional `TrimPrefix("/")` to remove the leading slash.

## Error Log

```
plugin_unique_identifier is not valid: /org/plugin:0.0.1@c6091c925eb5180de7a0ce0c94aea7329e7b3f7ed390f5e5a7a5d2991b85fc72
```

## Root Cause

In `installed_bucket.go:78`, when GCS storage returns a path like:
- `path.Path = "plugins/org/plugin:0.0.1@hash"`
- `b.installedPath = "plugins"`

The `strings.TrimPrefix(path.Path, b.installedPath)` produces:
- `/org/plugin:0.0.1@hash` (note the leading slash)

This leading slash causes the identifier validation to fail.

## Changes

- Added `strings.TrimPrefix(..., "/")` to remove the leading slash after removing the installed path prefix

Related issue: https://github.com/langgenius/dify/issues/22741