### PR TITLE
fix: accept plugin_unique_identifier from query params for DecodePluginFromIdentifier

### DIFF
--- a/internal/server/controllers/plugins.go
+++ b/internal/server/controllers/plugins.go
@@ -164,7 +164,7 @@ func ReinstallPluginFromIdentifier(app *app.Config) gin.HandlerFunc {
 func DecodePluginFromIdentifier(app *app.Config) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		BindRequest(c, func(request struct {
-			PluginUniqueIdentifier plugin_entities.PluginUniqueIdentifier `json:"plugin_unique_identifier" validate:"required,plugin_unique_identifier"`
+			PluginUniqueIdentifier plugin_entities.PluginUniqueIdentifier `form:"plugin_unique_identifier" validate:"required,plugin_unique_identifier"`
 		}) {
 			c.JSON(http.StatusOK, service.DecodePluginFromIdentifier(app, request.PluginUniqueIdentifier))
 		})


### PR DESCRIPTION
## Summary

- Changed struct tag from `json:"plugin_unique_identifier"` to `form:"plugin_unique_identifier"` for DecodePluginFromIdentifier handler

## Problem

The `DecodePluginFromIdentifier` endpoint was expecting `plugin_unique_identifier` in the JSON request body. However, this is a GET endpoint, and sending a body with GET requests causes issues with HTTP intermediaries like **Google Cloud Run's frontend**, which rejects such requests as malformed.

## Solution

Changed from `json:` tag to `form:` tag, which binds the parameter from query string instead of JSON body. This is:
- Consistent with similar GET endpoints (`FetchPluginManifest`, `FetchPluginFromIdentifier`) which already use `form:` tags
- Compliant with HTTP standards (GET requests should not have semantic body content)
- Compatible with Cloud Run and other HTTP proxies/load balancers

## Related PR

This change requires a corresponding change in dify: 
- https://github.com/langgenius/dify/pull/31697