### PR TITLE
fix: use context.Background() for trace context in LaunchLocalPlugin

### DIFF
--- a/internal/core/control_panel/launcher_local.go
+++ b/internal/core/control_panel/launcher_local.go
@@ -64,7 +64,7 @@ func (c *ControlPanel) LaunchLocalPlugin(
 		return nil, nil, err
 	}
 	// attach trace context for env initialization spans
-	runtime.SetTraceContext(ctx)
+	runtime.SetTraceContext(context.WithoutCancel(ctx))
 
 	// init environment
 	// whatever it's a user request to launch a plugin or a new plugin was found


### PR DESCRIPTION
## Description

Bug was introduced in #[583](https://github.com/langgenius/dify-plugin-daemon/pull/583). Bug reported in #603.

When plugins are installed via HTTP API, the request context passed to `LaunchLocalPlugin` gets stored via `runtime.SetTraceContext(ctx)`. This context is cancelled when the HTTP response is sent, but environment initialization continues asynchronously. This causes `exec.CommandContext` to fail immediately with "context canceled" during dependency installation.

This fix changes `SetTraceContext(ctx)` to `SetTraceContext(context.WithoutCancel(ctx))`.

**Before**
<img width="562" height="344" alt="Screenshot 2026-02-04 at 1 07 45 PM" src="https://github.com/user-attachments/assets/b0e5335e-d95b-4c7b-9c3e-00e234dededa" />

**After**
<img width="562" height="327" alt="Screenshot 2026-02-04 at 1 08 10 PM (2)" src="https://github.com/user-attachments/assets/cdc33d5c-a741-4b39-8141-d40f0ee30998" />

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Other

### Testing
- [x] I have tested the changes locally and confirmed they work as expected
- [x] I have added unit tests where necessary and they pass successfully