### PR TITLE
fix: plugin install context canceled by detaching from HTTP request c…

### DIFF
--- a/internal/service/install_plugin.go
+++ b/internal/service/install_plugin.go
@@ -114,6 +114,7 @@ func InstallMultiplePluginsToTenant(
 	}
 	taskIDs := taskRegistry.IDs()
 
+	ctx = context.WithoutCancel(log.EnsureTrace(ctx))
 	for _, job := range jobs {
 		jobCopy := job
 		// start a new goroutine to install the plugin
@@ -286,6 +287,7 @@ func UpgradePlugin(
 	}
 
 	taskIDs := taskRegistry.IDs()
+	ctx = context.WithoutCancel(log.EnsureTrace(ctx))
 
 	routine.Submit(routinepkg.Labels{
 		routinepkg.RoutineLabelKeyModule: "service",


### PR DESCRIPTION
Fixes #603

## Description

#### Summary

Plugin installation/upgrade runs asynchronously after returning a task ID, but previously reused the HTTP request context (c.Request.Context()). When the handler returned, the context was canceled, causing uv sync (started via exec.CommandContext) to fail with context canceled.

#### Changes
- Detach background install/upgrade goroutines from request cancellation using context.WithoutCancel(ctx).
- Preserve tracing context via log.EnsureTrace(...) for downstream spans/logs.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Other

## Essential Checklist

### Testing
- [x] I have tested the changes locally and confirmed they work as expected
- [x] I have added unit tests where necessary and they pass successfully

### Bug Fix (if applicable)
- [x] I have used GitHub syntax to close the related issue (e.g., `Fixes #123` or `Closes #123`)

## Additional Information

Local plugin dependency installation (uv sync / uv pip install) no longer fails immediately due to premature context cancellation.
