### PR TITLE
fix: monitor timeout task SQL

### DIFF
--- a/internal/types/models/task.go
+++ b/internal/types/models/task.go
@@ -23,7 +23,7 @@ type InstallTaskPluginStatus struct {
 
 type InstallTask struct {
 	Model
-	Status           InstallTaskStatus         `json:"status" gorm:"not null"`
+	Status           InstallTaskStatus         `json:"status" gorm:"size:50;not null;index:idx_install_tasks_status"`
 	TenantID         string                    `json:"tenant_id" gorm:"type:uuid;not null"`
 	TotalPlugins     int                       `json:"total_plugins" gorm:"not null"`
 	CompletedPlugins int                       `json:"completed_plugins" gorm:"not null"`


### PR DESCRIPTION
## Description

`internal/tasks/recycle.go:86` `func MonitorTimeoutTasks` executes such query:
`SELECT * FROM "install_tasks" WHERE status IN ($1,$2)` that produces significant performance issues on DB.

Dify SaaS fixes this by adding index `idx_install_tasks_status ON install_tasks (status)`

This PR adds this index to `internal/types/models/task.go`, allowing community instances to have this optimization.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Performance improvement
- [ ] Other

## Essential Checklist

### Testing
- [x] I have tested the changes locally and confirmed they work as expected
