### PR TITLE
feat : Add command line startup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Run the daemon with the following command. It uses `godotenv` to load environmen
 
 ```bash
 go run github.com/joho/godotenv/cmd/godotenv@latest -f .env go run cmd/server/main.go
+```
 
 If you were using a non-AWS S3 storage before version 0.1.2, you need to manually set the S3_USE_AWS environment variable to false in the .env file.
 


### PR DESCRIPTION
## Description

Since the method of loading environment variables has been removed before, 
<img width="1349" height="636" alt="图片" src="https://github.com/user-attachments/assets/7bfab301-5715-44b4-bb88-b28a37071a90" /> [https://github.com/langgenius/dify-plugin-daemon/pull/608](https://github.com/langgenius/dify-plugin-daemon/pull/608)
`go run cmd/server/main.go` cannot directly start the program, so you need to use `godotenv -f .env go run cmd/server/main.go`

Install `godotenv` to load the environment variables from `.env` file.

```bash
go install github.com/joho/godotenv/cmd/godotenv@latest
```

Run the daemon with the following command:

```bash
godotenv -f .env go run cmd/server/main.go
```

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [x] Other

## Essential Checklist

### Testing
- [x] I have tested the changes locally and confirmed they work as expected
- [x] I have added unit tests where necessary and they pass successfully

### Bug Fix (if applicable)
- [x] I have used GitHub syntax to close the related issue (e.g., `Fixes #123` or `Closes #123`)

## Additional Information

update readme