### PR TITLE
feat: support plugin-specific database credentials with fallback

### DIFF
--- a/internal/types/app/config.go
+++ b/internal/types/app/config.go
@@ -150,6 +150,10 @@ type Config struct {
 	DBDefaultDatabase string `envconfig:"DB_DEFAULT_DATABASE" validate:"required"`
 	DBSslMode         string `envconfig:"DB_SSL_MODE" validate:"required,oneof=disable require"`
 
+	// plugin-specific database credentials, fallback to DB_USERNAME/DB_PASSWORD if not set
+	PluginDBUsername string `envconfig:"PLUGIN_DB_USER"`
+	PluginDBPassword string `envconfig:"PLUGIN_DB_PASS"`
+
 	// database connection pool settings
 	DBMaxIdleConns    int           `envconfig:"DB_MAX_IDLE_CONNS" default:"10"`
 	DBMaxOpenConns    int           `envconfig:"DB_MAX_OPEN_CONNS" default:"30"`

--- a/internal/types/app/default.go
+++ b/internal/types/app/default.go
@@ -46,6 +46,13 @@ func (config *Config) SetDefault() {
 	case DB_TYPE_MYSQL:
 		setDefaultString(&config.DBDefaultDatabase, "mysql")
 	}
+
+	if config.PluginDBUsername != "" {
+		config.DBUsername = config.PluginDBUsername
+	}
+	if config.PluginDBPassword != "" {
+		config.DBPassword = config.PluginDBPassword
+	}
 }
 
 func setDefaultInt[T constraints.Integer](value *T, defaultValue T) {


### PR DESCRIPTION
Adds `PLUGIN_DB_USER` and `PLUGIN_DB_PASS` env vars to configure separate database credentials for the plugin daemon, falling back to `DB_USERNAME`/`DB_PASSWORD` when not set.

Docker Compose doesn't support variable substitution with fallback to another variable (e.g. `${PLUGIN_DB_USER:-$DB_USERNAME}`), so fallback logic is handled at the application level in `Config.SetDefault()`.

## Description

- **`internal/types/app/config.go`**: Added `PluginDBUsername` (`PLUGIN_DB_USER`) and `PluginDBPassword` (`PLUGIN_DB_PASS`) optional fields to `Config`.
- **`internal/types/app/default.go`**: In `SetDefault()`, overwrite `DBUsername`/`DBPassword` with plugin-specific values when present — all downstream consumers require no changes.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Other

## Essential Checklist

### Testing
- [x] I have tested the changes locally and confirmed they work as expected
- [ ] I have added unit tests where necessary and they pass successfully

### Bug Fix (if applicable)
- [ ] I have used GitHub syntax to close the related issue (e.g., `Fixes #123` or `Closes #123`)

## Additional Information

No breaking changes. When `PLUGIN_DB_USER`/`PLUGIN_DB_PASS` are not set, behavior is identical to before.