### PR TITLE
fix(persistence): correctly calculate storage size delta during save operations

### DIFF
--- a/internal/core/persistence/persistence.go
+++ b/internal/core/persistence/persistence.go
@@ -47,18 +47,26 @@ func (c *Persistence) Save(tenantId string, pluginId string, maxSize int64, key 
 		maxSize = c.maxStorageSize
 	}
 
+	oldSize := int64(0)
+	if exists, err := c.storage.Exists(tenantId, pluginId, key); err == nil && exists {
+		if size, err := c.storage.StateSize(tenantId, pluginId, key); err == nil {
+			oldSize = size
+		}
+	}
+
 	if err := c.storage.Save(tenantId, pluginId, key, data); err != nil {
 		return err
 	}
 
 	allocatedSize := int64(len(data))
+	sizeDiff := allocatedSize - oldSize
 
 	storage, err := db.GetOne[models.TenantStorage](
 		db.Equal("tenant_id", tenantId),
 		db.Equal("plugin_id", pluginId),
 	)
 	if err != nil {
-		if allocatedSize > c.maxStorageSize || allocatedSize > maxSize {
+		if sizeDiff > c.maxStorageSize || sizeDiff > maxSize {
 			return fmt.Errorf("allocated size is greater than max storage size")
 		}
 
@@ -66,7 +74,7 @@ func (c *Persistence) Save(tenantId string, pluginId string, maxSize int64, key 
 			storage = models.TenantStorage{
 				TenantID: tenantId,
 				PluginID: pluginId,
-				Size:     allocatedSize,
+				Size:     sizeDiff,
 			}
 			if err := db.Create(&storage); err != nil {
 				return err
@@ -75,7 +83,7 @@ func (c *Persistence) Save(tenantId string, pluginId string, maxSize int64, key 
 			return err
 		}
 	} else {
-		if allocatedSize+storage.Size > maxSize || allocatedSize+storage.Size > c.maxStorageSize {
+		if sizeDiff+storage.Size > maxSize || sizeDiff+storage.Size > c.maxStorageSize {
 			return fmt.Errorf("allocated size is greater than max storage size")
 		}
 
@@ -83,7 +91,7 @@ func (c *Persistence) Save(tenantId string, pluginId string, maxSize int64, key 
 			db.Model(&models.TenantStorage{}),
 			db.Equal("tenant_id", tenantId),
 			db.Equal("plugin_id", pluginId),
-			db.Inc(map[string]int64{"size": allocatedSize}),
+			db.Inc(map[string]int64{"size": sizeDiff}),
 		)
 		if err != nil {
 			return err


### PR DESCRIPTION
## Description

Please provide a brief description of the changes made in this pull request.
Please also include the issue number if this is related to an issue using the format `Fixes #123` or `Closes #123`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Other

## Essential Checklist

### Testing
- [x] I have tested the changes locally and confirmed they work as expected
- [ ] I have added unit tests where necessary and they pass successfully

### Bug Fix (if applicable)
- [ ] I have used GitHub syntax to close the related issue (e.g., `Fixes #123` or `Closes #123`)

## Additional Information

Please provide any additional context that would help reviewers understand the changes. 

📝 Background
Previously, the Save method in the persistence layer incorrectly updated the tenant's total storage size by always incrementing it with the full length of the new data. This resulted in over-reporting storage usage whenever an existing key was updated, leading to premature quota exhaustion.

🛠️ Changes
This PR refines the storage accounting logic to use a "delta-based" approach:

Existing Size Retrieval: Before saving, the system now checks if the key already exists and retrieves its current size.
Delta Calculation: It calculates the actual size difference (sizeDiff = new_size - old_size).
Optimized Update:
Storage quota checks are now performed against the sizeDiff rather than the total allocatedSize.
The database's aggregate Size field is updated using this calculated difference, ensuring accurately tracked usage for both new entries and overwrites.
✅ Impact
Accuracy: Tenant storage statistics will now accurately reflect the net change in data volume.
Reliability: Prevents "storage leaks" where the recorded size continually grows even if files are being replaced with smaller versions.