### PR TITLE
feat: support configurable redis key prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,18 @@ uses docker volume to share the directory with the host machine, it's better for
 
 For now, Daemon community edition does not support smoothly scale out with the number of replicas, If you are interested in this feature, please contact us. we have a more production-ready version for enterprise users.
 
+### Redis namespacing
+
+Enterprise deployments often share Redis across multiple systems or subsystems. The
+daemon supports a global Redis prefix via `REDIS_KEY_PREFIX`.
+
+- Default value: `plugin_daemon`
+- Applies to Redis keys and pub/sub channels used by the daemon
+- Safe for Redis Cluster logical keys that already use hash tags such as
+  `{remote:key:manager}`
+- Changing the prefix changes the active namespace; existing cache and coordination
+  data under the old prefix is not migrated automatically
+
 ## Documentation
 
 ### Development Guide

--- a/docs/claude/cache.md
+++ b/docs/claude/cache.md
@@ -9,6 +9,10 @@ Redis-based caching system (`internal/utils/cache/`).
 
 ## Basic Operations
 
+All cache helpers accept logical names and apply the configured Redis prefix internally.
+By default the daemon uses `plugin_daemon`, and operators can override it with
+`REDIS_KEY_PREFIX`.
+
 ```go
 // Store and retrieve
 cache.Store("key", value, time.Minute*30)
@@ -38,6 +42,9 @@ cache.DelMapField(CLUSTER_STATUS_KEY, nodeId)
 ```
 
 ## Pub/Sub Pattern
+
+Pub/sub channels are prefixed with the same `REDIS_KEY_PREFIX` value as keys, so
+callers should always pass logical channel names.
 
 ```go
 // Publish event
@@ -104,3 +111,11 @@ cache.InitRedisClient(
     db,        // database number
 )
 ```
+
+Redis naming behavior:
+
+- `REDIS_KEY_PREFIX` defaults to `plugin_daemon`
+- applies to keys and pub/sub channels managed by this package
+- changing the prefix switches the active Redis namespace and does not migrate old data
+- logical keys that contain Redis Cluster hash tags such as `{remote:key:manager}` keep
+  those tags intact because the prefix is prepended to the full logical key

--- a/internal/core/plugin_manager/manager.go
+++ b/internal/core/plugin_manager/manager.go
@@ -123,6 +123,8 @@ func (p *PluginManager) Launch(configuration *app.Config) {
 		log.Panic("invalid Redis TLS config: %s", err.Error())
 	}
 
+	cache.SetKeyPrefix(configuration.RedisKeyPrefix)
+
 	// init redis client
 	if configuration.RedisUseSentinel {
 		// use Redis Sentinel

--- a/internal/types/app/config.go
+++ b/internal/types/app/config.go
@@ -130,6 +130,7 @@ type Config struct {
 	RedisPass        string `envconfig:"REDIS_PASSWORD"`
 	RedisUser        string `envconfig:"REDIS_USERNAME"`
 	RedisDB          int    `envconfig:"REDIS_DB"`
+	RedisKeyPrefix   string `envconfig:"REDIS_KEY_PREFIX" default:"plugin_daemon"`
 	RedisUseSsl      bool   `envconfig:"REDIS_USE_SSL"`
 	RedisSSLCertReqs string `envconfig:"REDIS_SSL_CERT_REQS"`
 	RedisSSLCACerts  string `envconfig:"REDIS_SSL_CA_CERTS"`

--- a/internal/types/app/config_test.go
+++ b/internal/types/app/config_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/kelseyhightower/envconfig"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -75,6 +76,14 @@ func TestValidateLogLevel(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+func TestConfigRedisKeyPrefixField(t *testing.T) {
+	t.Setenv("REDIS_KEY_PREFIX", "enterprise-a")
+
+	cfg := Config{}
+	require.NoError(t, envconfig.Process("", &cfg))
+	assert.Equal(t, "enterprise-a", cfg.RedisKeyPrefix)
 }
 
 func TestRedisTLSConfig(t *testing.T) {

--- a/pkg/utils/cache/redis.go
+++ b/pkg/utils/cache/redis.go
@@ -21,6 +21,9 @@ var (
 
 	ErrDBNotInit = errors.New("redis client not init")
 	ErrNotFound  = errors.New("key not found")
+
+	keyPrefix     = "plugin_daemon"
+	keyPrefixLock sync.RWMutex
 )
 
 func getRedisOptions(addr, username, password string, useSsl bool, db int, tlsConf *tls.Config) *redis.Options {
@@ -116,11 +119,52 @@ func getCmdable(context ...redis.Cmdable) redis.Cmdable {
 	return client
 }
 
+func SetKeyPrefix(prefix string) {
+	prefix = strings.TrimSpace(prefix)
+	if prefix == "" {
+		prefix = "plugin_daemon"
+	}
+
+	keyPrefixLock.Lock()
+	keyPrefix = prefix
+	keyPrefixLock.Unlock()
+}
+
+func currentKeyPrefix() string {
+	keyPrefixLock.RLock()
+	defer keyPrefixLock.RUnlock()
+
+	return keyPrefix
+}
+
 func serialKey(keys ...string) string {
-	return strings.Join(append(
-		[]string{"plugin_daemon"},
-		keys...,
-	), ":")
+	prefix := currentKeyPrefix()
+	if len(keys) == 0 {
+		return prefix
+	}
+
+	totalLen := len(prefix)
+	for _, key := range keys {
+		totalLen += 1 + len(key)
+	}
+
+	var builder strings.Builder
+	builder.Grow(totalLen)
+	builder.WriteString(prefix)
+	for _, key := range keys {
+		builder.WriteByte(':')
+		builder.WriteString(key)
+	}
+
+	return builder.String()
+}
+
+func serialChannel(channel string) string {
+	return serialKey(channel)
+}
+
+func serialKeyMatch(match string) string {
+	return serialKey(match)
 }
 
 // Store the key-value pair
@@ -362,6 +406,8 @@ func ScanKeysAsync(match string, fn func([]string) error, context ...redis.Cmdab
 		return ErrDBNotInit
 	}
 
+	match = serialKeyMatch(match)
+
 	cursor := uint64(0)
 
 	for {
@@ -561,11 +607,11 @@ func Publish(channel string, message any, context ...redis.Cmdable) error {
 		message = parser.MarshalJson(message)
 	}
 
-	return getCmdable(context...).Publish(ctx, channel, message).Err()
+	return getCmdable(context...).Publish(ctx, serialChannel(channel), message).Err()
 }
 
 func Subscribe[T any](channel string) (<-chan T, func()) {
-	pubsub := client.Subscribe(ctx, channel)
+	pubsub := client.Subscribe(ctx, serialChannel(channel))
 	ch := make(chan T)
 	connectionEstablished := make(chan bool)
 

--- a/pkg/utils/cache/redis_auto_type_test.go
+++ b/pkg/utils/cache/redis_auto_type_test.go
@@ -2,7 +2,11 @@ package cache
 
 import (
 	"errors"
+	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type TestAutoTypeStruct struct {
@@ -61,4 +65,39 @@ func TestAutoTypeWithGetter(t *testing.T) {
 	if result.ID != "123" {
 		t.Fatal("result not correct")
 	}
+}
+
+func TestAutoTypeUsesConfiguredPrefix(t *testing.T) {
+	if err := InitRedisClient("127.0.0.1:6379", "", "difyai123456", false, 0, nil); err != nil {
+		t.Fatal(err)
+	}
+	defer Close()
+
+	SetKeyPrefix("enterprise-a")
+	t.Cleanup(func() { SetKeyPrefix("plugin_daemon") })
+
+	require.NoError(t, AutoSet("typed:key", TestAutoTypeStruct{ID: "123"}))
+
+	fullTypeInfo := reflect.TypeOf(TestAutoTypeStruct{})
+	fullTypeName := fullTypeInfo.PkgPath() + "." + fullTypeInfo.Name()
+	physicalKey := "enterprise-a:auto_type:" + fullTypeName + ":typed:key"
+	t.Cleanup(func() {
+		_ = client.Del(ctx, physicalKey).Err()
+	})
+
+	result, err := client.Get(ctx, physicalKey).Bytes()
+	require.NoError(t, err)
+	assert.NotEmpty(t, result)
+
+	value, err := AutoGetWithGetter("typed:key", func() (*TestAutoTypeStruct, error) {
+		return nil, errors.New("must hit cache")
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "123", value.ID)
+
+	_, err = AutoDelete[TestAutoTypeStruct]("typed:key")
+	require.NoError(t, err)
+
+	_, err = client.Get(ctx, physicalKey).Result()
+	assert.Error(t, err)
 }

--- a/pkg/utils/cache/redis_test.go
+++ b/pkg/utils/cache/redis_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -19,6 +20,117 @@ const (
 
 func getRedisConnection() error {
 	return InitRedisClient("0.0.0.0:6379", "", "difyai123456", false, 0, nil)
+}
+
+func TestStoreUsesDefaultPrefix(t *testing.T) {
+	require.NoError(t, getRedisConnection())
+	defer Close()
+
+	SetKeyPrefix("")
+	t.Cleanup(func() { SetKeyPrefix("plugin_daemon") })
+
+	require.NoError(t, client.Del(ctx, "plugin_daemon:test:key").Err())
+	t.Cleanup(func() {
+		_ = client.Del(ctx, "plugin_daemon:test:key").Err()
+	})
+	require.NoError(t, Store("test:key", "value", time.Minute))
+
+	val, err := client.Get(ctx, "plugin_daemon:test:key").Result()
+	require.NoError(t, err)
+	assert.Equal(t, "value", val)
+}
+
+func TestStoreUsesCustomPrefix(t *testing.T) {
+	require.NoError(t, getRedisConnection())
+	defer Close()
+
+	SetKeyPrefix("enterprise-a")
+	t.Cleanup(func() { SetKeyPrefix("plugin_daemon") })
+
+	require.NoError(t, client.Del(ctx, "enterprise-a:test:key").Err())
+	t.Cleanup(func() {
+		_ = client.Del(ctx, "enterprise-a:test:key").Err()
+	})
+	require.NoError(t, Store("test:key", "value", time.Minute))
+
+	val, err := client.Get(ctx, "enterprise-a:test:key").Result()
+	require.NoError(t, err)
+	assert.Equal(t, "value", val)
+}
+
+func TestRedisPubSubUsesConfiguredPrefix(t *testing.T) {
+	require.NoError(t, getRedisConnection())
+	defer Close()
+
+	SetKeyPrefix("enterprise-a")
+	t.Cleanup(func() { SetKeyPrefix("plugin_daemon") })
+
+	type testEvent struct{}
+
+	sub, cancel := Subscribe[testEvent]("cluster-events")
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		<-sub
+		close(done)
+	}()
+
+	require.NoError(t, Publish("cluster-events", testEvent{}))
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for prefixed pubsub event")
+	}
+}
+
+func TestScanKeysUsesConfiguredPrefix(t *testing.T) {
+	require.NoError(t, getRedisConnection())
+	defer Close()
+
+	SetKeyPrefix("enterprise-a")
+	t.Cleanup(func() { SetKeyPrefix("plugin_daemon") })
+
+	require.NoError(t, client.Set(ctx, "enterprise-a:scan:key1", "1", time.Minute).Err())
+	require.NoError(t, client.Set(ctx, "other:scan:key1", "1", time.Minute).Err())
+	t.Cleanup(func() {
+		_ = client.Del(ctx, "enterprise-a:scan:key1", "other:scan:key1").Err()
+	})
+
+	keys, err := ScanKeys("scan:*")
+	require.NoError(t, err)
+	assert.Contains(t, keys, "enterprise-a:scan:key1")
+	assert.NotContains(t, keys, "other:scan:key1")
+}
+
+func TestKeyPrefixPreservesRedisClusterHashTag(t *testing.T) {
+	require.NoError(t, getRedisConnection())
+	defer Close()
+
+	SetKeyPrefix("enterprise-a")
+	t.Cleanup(func() { SetKeyPrefix("plugin_daemon") })
+
+	logicalKey := "{remote:key:manager}:id2key:tenant-a"
+	physicalKey := "enterprise-a:{remote:key:manager}:id2key:tenant-a"
+	t.Cleanup(func() {
+		_ = client.Del(ctx, physicalKey).Err()
+	})
+
+	require.NoError(t, Store(logicalKey, "value", time.Minute))
+
+	val, err := client.Get(ctx, physicalKey).Result()
+	require.NoError(t, err)
+	assert.Equal(t, "value", val)
+}
+
+func TestSerialKey(t *testing.T) {
+	t.Cleanup(func() { SetKeyPrefix("plugin_daemon") })
+
+	SetKeyPrefix("enterprise-a")
+	assert.Equal(t, "enterprise-a", serialKey())
+	assert.Equal(t, "enterprise-a:test:key", serialKey("test:key"))
+	assert.Equal(t, "enterprise-a:auto_type:full.Type:test:key", serialKey("auto_type", "full.Type", "test:key"))
 }
 
 func TestRedisConnection(t *testing.T) {
@@ -43,11 +155,16 @@ func TestRedisTransaction(t *testing.T) {
 	}
 	defer Close()
 
+	SetKeyPrefix("plugin_daemon")
+
+	transactionKey := strings.Join([]string{TEST_PREFIX, "key"}, ":")
+	_, _ = Del(transactionKey)
+
 	// test transaction
 	err := Transaction(func(p redis.Pipeliner) error {
 		// set key
 		if err := Store(
-			strings.Join([]string{TEST_PREFIX, "key"}, ":"),
+			transactionKey,
 			"value",
 			time.Second,
 			p,
@@ -66,7 +183,7 @@ func TestRedisTransaction(t *testing.T) {
 
 	// get key
 	value, err := GetString(
-		strings.Join([]string{TEST_PREFIX, "key"}, ":"),
+		transactionKey,
 	)
 
 	if err != ErrNotFound {
@@ -83,7 +200,7 @@ func TestRedisTransaction(t *testing.T) {
 	err = Transaction(func(p redis.Pipeliner) error {
 		// set key
 		if err := Store(
-			strings.Join([]string{TEST_PREFIX, "key"}, ":"),
+			transactionKey,
 			"value",
 			time.Second,
 			p,
@@ -100,11 +217,11 @@ func TestRedisTransaction(t *testing.T) {
 		return
 	}
 
-	defer Del(strings.Join([]string{TEST_PREFIX, "key"}, ":"))
+	defer Del(transactionKey)
 
 	// get key
 	value, err = GetString(
-		strings.Join([]string{TEST_PREFIX, "key"}, ":"),
+		transactionKey,
 	)
 
 	if err != nil {


### PR DESCRIPTION
## Description

This PR adds support for a configurable global Redis namespace through `REDIS_KEY_PREFIX`.
Fixes: #691 
Parent PR: https://github.com/langgenius/dify/pull/35139

The daemon now:

- reads `REDIS_KEY_PREFIX` from config with a default value of `plugin_daemon`
- applies the prefix consistently to Redis keys, scan patterns, distributed locks, and pub/sub channels
- preserves Redis Cluster hash tags in logical keys such as `{remote:key:manager}`
- documents the new namespacing behavior in the README and cache documentation

If you create a matching issue for this feature, add `Closes #<issue-number>` here before opening the PR.
This PR is intended to be tracked as a sub-PR under `langgenius/dify#35139`.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Other

## Essential Checklist

### Testing
- [x] I have tested the changes locally and confirmed they work as expected
- [x] I have added unit tests where necessary and they pass successfully

### Bug Fix (if applicable)
- [ ] I have used GitHub syntax to close the related issue (e.g., `Fixes #123` or `Closes #123`)

## Additional Information

Local verification completed with:

```bash
go test ./internal/types/app ./pkg/utils/cache
```

Key implementation notes for reviewers:

- `internal/types/app/config.go` adds `REDIS_KEY_PREFIX`
- `internal/core/plugin_manager/manager.go` sets the prefix during startup
- `pkg/utils/cache/redis.go` routes key serialization, key scanning, and pub/sub through the configured prefix
- tests cover default prefix behavior, custom prefix behavior, pub/sub namespacing, scan behavior, auto-type cache paths, and Redis Cluster hash tag preservation

Operational note:

Changing `REDIS_KEY_PREFIX` switches the daemon to a different Redis namespace. Existing cache or coordination data under the previous prefix is not migrated automatically.
