### PR TITLE
feat: support STORAGE_PATH_PREFIX for global storage key namespacing

### DIFF
--- a/internal/core/persistence/init.go
+++ b/internal/core/persistence/init.go
@@ -1,6 +1,9 @@
 package persistence
 
 import (
+	"path"
+	"strings"
+
 	"github.com/langgenius/dify-cloud-kit/oss"
 
 	"github.com/langgenius/dify-plugin-daemon/internal/types/app"
@@ -12,8 +15,18 @@ var (
 )
 
 func InitPersistence(oss oss.OSS, config *app.Config) {
+	storagePath := config.PersistenceStoragePath
+	if prefix := strings.Trim(config.StoragePathPrefix, "/"); prefix != "" {
+		for _, seg := range strings.Split(prefix, "/") {
+			if seg == ".." {
+				log.Panic("STORAGE_PATH_PREFIX must not contain '..'")
+			}
+		}
+		storagePath = path.Join(prefix, storagePath)
+	}
+
 	persistence = &Persistence{
-		storage:        NewWrapper(oss, config.PersistenceStoragePath),
+		storage:        NewWrapper(oss, storagePath),
 		maxStorageSize: config.PersistenceStorageMaxSize,
 	}
 

--- a/internal/core/plugin_manager/manager.go
+++ b/internal/core/plugin_manager/manager.go
@@ -2,6 +2,7 @@ package plugin_manager
 
 import (
 	"fmt"
+	"path"
 	"strings"
 
 	lru "github.com/hashicorp/golang-lru/v2"
@@ -58,20 +59,36 @@ var (
 )
 
 func InitGlobalManager(oss oss.OSS, config *app.Config) *PluginManager {
+	prefix := strings.Trim(config.StoragePathPrefix, "/")
+	if prefix != "" {
+		for _, seg := range strings.Split(prefix, "/") {
+			if seg == ".." {
+				log.Panic("STORAGE_PATH_PREFIX must not contain '..'")
+			}
+		}
+	}
+
+	joinPrefix := func(p string) string {
+		if prefix == "" {
+			return p
+		}
+		return path.Join(prefix, p)
+	}
+
 	mediaBucket := media_transport.NewAssetsBucket(
 		oss,
-		config.PluginMediaCachePath,
+		joinPrefix(config.PluginMediaCachePath),
 		config.PluginMediaCacheSize,
 	)
 
 	installedBucket := media_transport.NewInstalledBucket(
 		oss,
-		config.PluginInstalledPath,
+		joinPrefix(config.PluginInstalledPath),
 	)
 
 	packageBucket := media_transport.NewPackageBucket(
 		oss,
-		config.PluginPackageCachePath,
+		joinPrefix(config.PluginPackageCachePath),
 	)
 
 	pluginAssetCache, err := lru.New[string, []byte](int(config.PluginAssetCacheSize))

--- a/internal/types/app/config.go
+++ b/internal/types/app/config.go
@@ -159,6 +159,9 @@ type Config struct {
 	DBReadTimeout     time.Duration `envconfig:"DB_READ_TIMEOUT" default:"30s"`
 	DBWriteTimeout    time.Duration `envconfig:"DB_WRITE_TIMEOUT" default:"30s"`
 
+	// global storage path prefix
+	StoragePathPrefix string `envconfig:"STORAGE_PATH_PREFIX"`
+
 	// persistence storage
 	PersistenceStoragePath    string `envconfig:"PERSISTENCE_STORAGE_PATH"`
 	PersistenceStorageMaxSize int64  `envconfig:"PERSISTENCE_STORAGE_MAX_SIZE"`


### PR DESCRIPTION
## Description

Add global `STORAGE_PATH_PREFIX` support to namespace all object storage keys under a configurable path prefix, enabling multi-tenant or environment-separated deployments sharing a single bucket.

resolve ENG-44

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Other

## Essential Checklist

### Testing
- [x] I have tested the changes locally and confirmed they work as expected
- [ ] I have added unit tests where necessary and they pass successfully

### Bug Fix (if applicable)
- [ ] I have used GitHub syntax to close the related issue (e.g., `Fixes #123` or `Closes #123`)

## Additional Information

- Adds `StoragePathPrefix` config field (`STORAGE_PATH_PREFIX` env var)
- Prepends prefix to media, installed, package, and persistence storage paths via `path.Join`
- Segment-based path traversal validation rejecting `..` segments
- Companion PRs: langgenius/dify-helm#192, langgenius/dify#35320