### PR TITLE
fix(cache): pass watch keys to Transaction so optimistic lock actually works

### DIFF
--- a/internal/core/plugin_manager/manager.go
+++ b/internal/core/plugin_manager/manager.go
@@ -126,31 +126,7 @@ func (p *PluginManager) Launch(configuration *app.Config) {
 	cache.SetKeyPrefix(configuration.RedisKeyPrefix)
 
 	// init redis client
-	if configuration.RedisUseClusters && configuration.RedisUseSentinel {
-		log.Panic("REDIS_USE_CLUSTERS and REDIS_USE_SENTINEL cannot both be true")
-	}
-	if configuration.RedisUseClusters {
-		if configuration.RedisDB != 0 {
-			log.Panic("REDIS_DB must be 0 when REDIS_USE_CLUSTERS is true (Redis Cluster does not support SELECT DB)")
-		}
-		addrs := parser.SplitAndTrimCSV(configuration.RedisClusters)
-		if len(addrs) == 0 {
-			log.Panic("REDIS_USE_CLUSTERS is true but REDIS_CLUSTERS is empty")
-		}
-		password := configuration.RedisClustersPassword
-		if password == "" {
-			password = configuration.RedisPass
-		}
-		if err := cache.InitRedisClusterClient(
-			addrs,
-			configuration.RedisUser,
-			password,
-			configuration.RedisUseSsl,
-			tlsConf,
-		); err != nil {
-			log.Panic("init redis cluster client failed", "error", err)
-		}
-	} else if configuration.RedisUseSentinel {
+	if configuration.RedisUseSentinel {
 		// use Redis Sentinel
 		sentinels := parser.SplitAndTrimCSV(configuration.RedisSentinels)
 		if err := cache.InitRedisSentinelClient(

--- a/internal/core/plugin_manager/manager.go
+++ b/internal/core/plugin_manager/manager.go
@@ -128,6 +128,9 @@ func (p *PluginManager) Launch(configuration *app.Config) {
 	// init redis client
 	if configuration.RedisUseClusters {
 		addrs := splitAndTrimCSV(configuration.RedisClusters)
+		if len(addrs) == 0 {
+			log.Panic("REDIS_USE_CLUSTERS is true but REDIS_CLUSTERS is empty")
+		}
 		password := configuration.RedisClustersPassword
 		if password == "" {
 			password = configuration.RedisPass

--- a/internal/core/plugin_manager/manager.go
+++ b/internal/core/plugin_manager/manager.go
@@ -126,7 +126,22 @@ func (p *PluginManager) Launch(configuration *app.Config) {
 	cache.SetKeyPrefix(configuration.RedisKeyPrefix)
 
 	// init redis client
-	if configuration.RedisUseSentinel {
+	if configuration.RedisUseClusters {
+		addrs := splitAndTrimCSV(configuration.RedisClusters)
+		password := configuration.RedisClustersPassword
+		if password == "" {
+			password = configuration.RedisPass
+		}
+		if err := cache.InitRedisClusterClient(
+			addrs,
+			configuration.RedisUser,
+			password,
+			configuration.RedisUseSsl,
+			tlsConf,
+		); err != nil {
+			log.Panic("init redis cluster client failed", "error", err)
+		}
+	} else if configuration.RedisUseSentinel {
 		// use Redis Sentinel
 		sentinels := strings.Split(configuration.RedisSentinels, ",")
 		if err := cache.InitRedisSentinelClient(
@@ -248,4 +263,18 @@ func (p *PluginManager) ExtractPluginAsset(
 	}
 	p.pluginAssetCache.Add(key, assets[path])
 	return assets[path], nil
+}
+
+func splitAndTrimCSV(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if trimmed := strings.TrimSpace(p); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
 }

--- a/internal/core/plugin_manager/manager.go
+++ b/internal/core/plugin_manager/manager.go
@@ -2,7 +2,6 @@ package plugin_manager
 
 import (
 	"fmt"
-	"strings"
 
 	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/langgenius/dify-cloud-kit/oss"
@@ -18,6 +17,7 @@ import (
 	"github.com/langgenius/dify-plugin-daemon/pkg/plugin_packager/decoder"
 	"github.com/langgenius/dify-plugin-daemon/pkg/utils/cache"
 	"github.com/langgenius/dify-plugin-daemon/pkg/utils/log"
+	"github.com/langgenius/dify-plugin-daemon/pkg/utils/parser"
 )
 
 type PluginManager struct {
@@ -126,8 +126,14 @@ func (p *PluginManager) Launch(configuration *app.Config) {
 	cache.SetKeyPrefix(configuration.RedisKeyPrefix)
 
 	// init redis client
+	if configuration.RedisUseClusters && configuration.RedisUseSentinel {
+		log.Panic("REDIS_USE_CLUSTERS and REDIS_USE_SENTINEL cannot both be true")
+	}
 	if configuration.RedisUseClusters {
-		addrs := splitAndTrimCSV(configuration.RedisClusters)
+		if configuration.RedisDB != 0 {
+			log.Panic("REDIS_DB must be 0 when REDIS_USE_CLUSTERS is true (Redis Cluster does not support SELECT DB)")
+		}
+		addrs := parser.SplitAndTrimCSV(configuration.RedisClusters)
 		if len(addrs) == 0 {
 			log.Panic("REDIS_USE_CLUSTERS is true but REDIS_CLUSTERS is empty")
 		}
@@ -146,7 +152,7 @@ func (p *PluginManager) Launch(configuration *app.Config) {
 		}
 	} else if configuration.RedisUseSentinel {
 		// use Redis Sentinel
-		sentinels := strings.Split(configuration.RedisSentinels, ",")
+		sentinels := parser.SplitAndTrimCSV(configuration.RedisSentinels)
 		if err := cache.InitRedisSentinelClient(
 			sentinels,
 			configuration.RedisSentinelServiceName,
@@ -266,18 +272,4 @@ func (p *PluginManager) ExtractPluginAsset(
 	}
 	p.pluginAssetCache.Add(key, assets[path])
 	return assets[path], nil
-}
-
-func splitAndTrimCSV(s string) []string {
-	if s == "" {
-		return nil
-	}
-	parts := strings.Split(s, ",")
-	out := make([]string, 0, len(parts))
-	for _, p := range parts {
-		if trimmed := strings.TrimSpace(p); trimmed != "" {
-			out = append(out, trimmed)
-		}
-	}
-	return out
 }

--- a/internal/service/debugging_service/connection_key.go
+++ b/internal/service/debugging_service/connection_key.go
@@ -45,10 +45,11 @@ func GetConnectionKey(info ConnectionInfo) (string, error) {
 	)
 
 	if err == cache.ErrNotFound {
+		id2key := strings.Join([]string{CONNECTION_KEY_MANAGER_ID2KEY_PREFIX, info.TenantId}, ":")
 		err := cache.Transaction(func(p redis.Pipeliner) error {
 			k := uuid.New().String()
 			_, err = cache.SetNX(
-				strings.Join([]string{CONNECTION_KEY_MANAGER_ID2KEY_PREFIX, info.TenantId}, ":"),
+				id2key,
 				Key{Key: k},
 				CONNECTION_KEY_EXPIRE_TIME,
 				p,
@@ -70,7 +71,7 @@ func GetConnectionKey(info ConnectionInfo) (string, error) {
 			key = &Key{Key: k}
 
 			return nil
-		})
+		}, id2key)
 
 		if err != nil {
 			return "", err

--- a/internal/types/app/config.go
+++ b/internal/types/app/config.go
@@ -135,11 +135,6 @@ type Config struct {
 	RedisSSLCertReqs string `envconfig:"REDIS_SSL_CERT_REQS"`
 	RedisSSLCACerts  string `envconfig:"REDIS_SSL_CA_CERTS"`
 
-	// redis cluster
-	RedisUseClusters      bool   `envconfig:"REDIS_USE_CLUSTERS" default:"false"`
-	RedisClusters         string `envconfig:"REDIS_CLUSTERS"`
-	RedisClustersPassword string `envconfig:"REDIS_CLUSTERS_PASSWORD"`
-
 	// redis sentinel
 	RedisUseSentinel           bool    `envconfig:"REDIS_USE_SENTINEL"`
 	RedisSentinels             string  `envconfig:"REDIS_SENTINELS"`

--- a/internal/types/app/config.go
+++ b/internal/types/app/config.go
@@ -135,6 +135,11 @@ type Config struct {
 	RedisSSLCertReqs string `envconfig:"REDIS_SSL_CERT_REQS"`
 	RedisSSLCACerts  string `envconfig:"REDIS_SSL_CA_CERTS"`
 
+	// redis cluster
+	RedisUseClusters      bool   `envconfig:"REDIS_USE_CLUSTERS" default:"false"`
+	RedisClusters         string `envconfig:"REDIS_CLUSTERS"`
+	RedisClustersPassword string `envconfig:"REDIS_CLUSTERS_PASSWORD"`
+
 	// redis sentinel
 	RedisUseSentinel           bool    `envconfig:"REDIS_USE_SENTINEL"`
 	RedisSentinels             string  `envconfig:"REDIS_SENTINELS"`

--- a/pkg/utils/cache/redis.go
+++ b/pkg/utils/cache/redis.go
@@ -616,14 +616,14 @@ func Expire(key string, time time.Duration, context ...redis.Cmdable) (bool, err
 	return getCmdable(context...).Expire(ctx, serialKey(key), time).Result()
 }
 
-func Transaction(fn func(redis.Pipeliner) error, keys ...string) error {
+func Transaction(fn func(redis.Pipeliner) error, watchKeys ...string) error {
 	if client == nil {
 		return ErrDBNotInit
 	}
 
-	watchKeys := make([]string, len(keys))
-	for i, k := range keys {
-		watchKeys[i] = serialKey(k)
+	serialized := make([]string, len(watchKeys))
+	for i, k := range watchKeys {
+		serialized[i] = serialKey(k)
 	}
 
 	return client.Watch(ctx, func(tx *redis.Tx) error {
@@ -634,7 +634,7 @@ func Transaction(fn func(redis.Pipeliner) error, keys ...string) error {
 			return nil
 		}
 		return err
-	}, watchKeys...)
+	}, serialized...)
 }
 
 func Publish(channel string, message any, context ...redis.Cmdable) error {

--- a/pkg/utils/cache/redis.go
+++ b/pkg/utils/cache/redis.go
@@ -102,6 +102,40 @@ func InitRedisSentinelClient(
 	return nil
 }
 
+func InitRedisClusterClient(
+	addrs []string,
+	username, password string,
+	useSsl bool,
+	tlsConf *tls.Config,
+) error {
+	if len(addrs) == 0 {
+		return errors.New("REDIS_CLUSTERS is empty but REDIS_USE_CLUSTERS is true")
+	}
+	opts := &redis.ClusterOptions{
+		Addrs:    addrs,
+		Username: username,
+		Password: password,
+	}
+	if useSsl {
+		if tlsConf != nil {
+			opts.TLSConfig = tlsConf
+		} else {
+			opts.TLSConfig = &tls.Config{
+				MinVersion: tls.VersionTLS12,
+			}
+		}
+	}
+
+	client = redis.NewClusterClient(opts)
+	_ = redisotel.InstrumentTracing(client, redisotel.WithTracerProvider(gootel.GetTracerProvider()))
+
+	if _, err := client.Ping(ctx).Result(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // Close the redis client
 func Close() error {
 	if client == nil {

--- a/pkg/utils/cache/redis.go
+++ b/pkg/utils/cache/redis.go
@@ -102,40 +102,6 @@ func InitRedisSentinelClient(
 	return nil
 }
 
-func InitRedisClusterClient(
-	addrs []string,
-	username, password string,
-	useSsl bool,
-	tlsConf *tls.Config,
-) error {
-	if len(addrs) == 0 {
-		return errors.New("redis cluster addresses are empty")
-	}
-	opts := &redis.ClusterOptions{
-		Addrs:    addrs,
-		Username: username,
-		Password: password,
-	}
-	if useSsl {
-		if tlsConf != nil {
-			opts.TLSConfig = tlsConf
-		} else {
-			opts.TLSConfig = &tls.Config{
-				MinVersion: tls.VersionTLS12,
-			}
-		}
-	}
-
-	client = redis.NewClusterClient(opts)
-	_ = redisotel.InstrumentTracing(client, redisotel.WithTracerProvider(gootel.GetTracerProvider()))
-
-	if _, err := client.Ping(ctx).Result(); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // Close the redis client
 func Close() error {
 	if client == nil {

--- a/pkg/utils/cache/redis.go
+++ b/pkg/utils/cache/redis.go
@@ -109,7 +109,7 @@ func InitRedisClusterClient(
 	tlsConf *tls.Config,
 ) error {
 	if len(addrs) == 0 {
-		return errors.New("REDIS_CLUSTERS is empty but REDIS_USE_CLUSTERS is true")
+		return errors.New("redis cluster addresses are empty")
 	}
 	opts := &redis.ClusterOptions{
 		Addrs:    addrs,
@@ -616,9 +616,14 @@ func Expire(key string, time time.Duration, context ...redis.Cmdable) (bool, err
 	return getCmdable(context...).Expire(ctx, serialKey(key), time).Result()
 }
 
-func Transaction(fn func(redis.Pipeliner) error) error {
+func Transaction(fn func(redis.Pipeliner) error, keys ...string) error {
 	if client == nil {
 		return ErrDBNotInit
+	}
+
+	watchKeys := make([]string, len(keys))
+	for i, k := range keys {
+		watchKeys[i] = serialKey(k)
 	}
 
 	return client.Watch(ctx, func(tx *redis.Tx) error {
@@ -629,7 +634,7 @@ func Transaction(fn func(redis.Pipeliner) error) error {
 			return nil
 		}
 		return err
-	})
+	}, watchKeys...)
 }
 
 func Publish(channel string, message any, context ...redis.Cmdable) error {

--- a/pkg/utils/parser/csv.go
+++ b/pkg/utils/parser/csv.go
@@ -1,0 +1,17 @@
+package parser
+
+import "strings"
+
+func SplitAndTrimCSV(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if trimmed := strings.TrimSpace(p); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}

--- a/pkg/utils/parser/csv_test.go
+++ b/pkg/utils/parser/csv_test.go
@@ -1,0 +1,37 @@
+package parser
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSplitAndTrimCSV(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{"empty string", "", nil},
+		{"only separators", ",,,", []string{}},
+		{"only whitespace between separators", " , , ,", []string{}},
+		{"single value", "a", []string{"a"}},
+		{"trims surrounding whitespace", " a , b ", []string{"a", "b"}},
+		{"drops empty segments", "a, ,b", []string{"a", "b"}},
+		{"preserves inner colons", "host1:6379, host2:6379", []string{"host1:6379", "host2:6379"}},
+		{"trailing comma", "a,b,", []string{"a", "b"}},
+		{"leading comma", ",a,b", []string{"a", "b"}},
+		{"tabs and mixed whitespace", "\ta\t,\nb\n", []string{"a", "b"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SplitAndTrimCSV(tt.input)
+			if len(got) == 0 && len(tt.want) == 0 {
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SplitAndTrimCSV(%q) = %#v, want %#v", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description                                                                                                                                                                                                                                                                
                                         
  `cache.Transaction(fn)` used to call `client.Watch(ctx, fn)` without passing any keys, so it ran a "MULTI/EXEC without optimistic lock" — the double-write of `id2key` / `key2id` in `debugging_service` didn't actually guard against concurrent races.                      
                                                                                                                                                                                                                                                                                
  - Added variadic signature: `Transaction(fn, watchKeys ...string)`. The varargs default to `nil`, so existing `Transaction(fn)` call sites are byte-level backward compatible.                                                                                                
  - Keys are passed through `serialKey()` to apply the prefix before handing off to go-redis, matching other helpers.
  - Migrated `debugging_service/connection_key.go` to the new signature and WATCH on `id2key`: concurrent creation of a connection key for the same tenant now relies on WATCH retry for correctness instead of leaning on the inner `SetNX`'s NX semantics.                    
                                                                                                                                                                                                                                                                                
  Bundled helper extraction:                                                                                                                                                                                                                                                    
  - New `pkg/utils/parser/csv.go` `SplitAndTrimCSV` (`"a, b , ,c"` → `["a", "b", "c"]`, empty string returns `nil`), with `csv_test.go` covering the edge cases.                                                                                                                
  - The sentinel branch in `plugin_manager/manager.go` switched from `strings.Split(configuration.RedisSentinels, ",")` to this helper, so accidental whitespace in `REDIS_SENTINELS` is parsed correctly.                                                                      
                                                                                                                                                                                                                                                                                
  ## Type of Change                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                
  - [x] Bug fix (fake-transaction semantics in `Transaction`)                                                                                                                                                                                                                   
  - [x] Refactor (CSV parsing extraction)
  - [ ] New feature                                                                                                                                                                                                                                                             
  - [ ] Performance improvement                             
  - [ ] Other
                                                                                                                                                                                                                                                                                
  ## Essential Checklist
                                                                                                                                                                                                                                                                                
  ### Testing                                               
  - [x] `go build ./internal/... ./pkg/...` passes; new unit tests in `parser/csv_test.go` are green; existing `cache` / `debugging_service` tests did not regress.
  - [ ] `debugging_service` integration smoke test (local Redis Sentinel) is pending.                                                                                                                                                                                           
   
  ### Bug Fix (if applicable)                                                                                                                                                                                                                                                   
  - N/A (no external issue tracking, self-discovered).      
                                                                                                                                                                                                                                                                                
  ## Additional Information                                 

  The variadic change is source-compatible — no existing `Transaction(fn)` call site needs to change. The new `watchKeys` parameter is optional; callers that want WATCH just pass keys positionally.       