### PR TITLE
chore(ci): add macos runner benchmark

### DIFF
--- a/.github/workflows/runner-benchmark.yml
+++ b/.github/workflows/runner-benchmark.yml
@@ -1,0 +1,52 @@
+name: Runner Benchmark
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: runner-benchmark-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  benchmark:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-latest
+            name: github-macos
+          - runner: depot-macos-latest
+            name: depot-macos
+    runs-on: ${{ matrix.runner }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+
+      - name: Benchmark CLI build
+        id: bench
+        shell: bash
+        run: |
+          start=$(date +%s)
+          go mod download
+          CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -o /tmp/dify-plugin-darwin-amd64 ./cmd/commandline
+          CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -o /tmp/dify-plugin-darwin-arm64 ./cmd/commandline
+          end=$(date +%s)
+          echo "elapsed=$((end - start))" >> "$GITHUB_OUTPUT"
+
+      - name: Summarize
+        shell: bash
+        run: |
+          {
+            echo "### Runner Benchmark"
+            echo ""
+            echo "- Runner: ${{ matrix.name }}"
+            echo "- Elapsed seconds: ${{ steps.bench.outputs.elapsed }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/runner-benchmark.yml
+++ b/.github/workflows/runner-benchmark.yml
@@ -12,8 +12,6 @@ concurrency:
 
 jobs:
   benchmark:
-    env:
-      BENCH_CACHE_BASE: ${{ runner.temp }}/runner-benchmark
     strategy:
       fail-fast: false
       matrix:
@@ -35,11 +33,11 @@ jobs:
       - name: Benchmark CLI build
         id: bench_cold
         shell: bash
-        env:
-          GOMODCACHE: ${{ runner.temp }}/runner-benchmark/cold/gomod
-          GOCACHE: ${{ runner.temp }}/runner-benchmark/cold/gocache
         run: |
-          rm -rf "$BENCH_CACHE_BASE/cold"
+          cache_base="$RUNNER_TEMP/runner-benchmark/cold"
+          export GOMODCACHE="$cache_base/gomod"
+          export GOCACHE="$cache_base/gocache"
+          rm -rf "$cache_base"
           mkdir -p "$GOMODCACHE" "$GOCACHE"
 
           start=$(date +%s)
@@ -52,10 +50,10 @@ jobs:
       - name: Benchmark CLI build warm cache
         id: bench_warm
         shell: bash
-        env:
-          GOMODCACHE: ${{ runner.temp }}/runner-benchmark/cold/gomod
-          GOCACHE: ${{ runner.temp }}/runner-benchmark/cold/gocache
         run: |
+          cache_base="$RUNNER_TEMP/runner-benchmark/cold"
+          export GOMODCACHE="$cache_base/gomod"
+          export GOCACHE="$cache_base/gocache"
           start=$(date +%s)
           go mod download
           CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -o /tmp/dify-plugin-darwin-amd64 ./cmd/commandline

--- a/.github/workflows/runner-benchmark.yml
+++ b/.github/workflows/runner-benchmark.yml
@@ -12,6 +12,8 @@ concurrency:
 
 jobs:
   benchmark:
+    env:
+      BENCH_CACHE_BASE: ${{ runner.temp }}/runner-benchmark
     strategy:
       fail-fast: false
       matrix:
@@ -33,11 +35,12 @@ jobs:
       - name: Benchmark CLI build
         id: bench_cold
         shell: bash
+        env:
+          GOMODCACHE: ${{ runner.temp }}/runner-benchmark/cold/gomod
+          GOCACHE: ${{ runner.temp }}/runner-benchmark/cold/gocache
         run: |
-          gomodcache=$(go env GOMODCACHE)
-          gocache=$(go env GOCACHE)
-          rm -rf "$gomodcache" "$gocache"
-          mkdir -p "$gomodcache" "$gocache"
+          rm -rf "$BENCH_CACHE_BASE/cold"
+          mkdir -p "$GOMODCACHE" "$GOCACHE"
 
           start=$(date +%s)
           go mod download
@@ -49,6 +52,9 @@ jobs:
       - name: Benchmark CLI build warm cache
         id: bench_warm
         shell: bash
+        env:
+          GOMODCACHE: ${{ runner.temp }}/runner-benchmark/cold/gomod
+          GOCACHE: ${{ runner.temp }}/runner-benchmark/cold/gocache
         run: |
           start=$(date +%s)
           go mod download

--- a/.github/workflows/runner-benchmark.yml
+++ b/.github/workflows/runner-benchmark.yml
@@ -31,7 +31,21 @@ jobs:
           go-version: "1.23"
 
       - name: Benchmark CLI build
-        id: bench
+        id: bench_cold
+        shell: bash
+        run: |
+          rm -rf "$GOMODCACHE" "$GOCACHE"
+          mkdir -p "$GOMODCACHE" "$GOCACHE"
+
+          start=$(date +%s)
+          go mod download
+          CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -o /tmp/dify-plugin-darwin-amd64 ./cmd/commandline
+          CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -o /tmp/dify-plugin-darwin-arm64 ./cmd/commandline
+          end=$(date +%s)
+          echo "elapsed=$((end - start))" >> "$GITHUB_OUTPUT"
+
+      - name: Benchmark CLI build warm cache
+        id: bench_warm
         shell: bash
         run: |
           start=$(date +%s)
@@ -48,5 +62,6 @@ jobs:
             echo "### Runner Benchmark"
             echo ""
             echo "- Runner: ${{ matrix.name }}"
-            echo "- Elapsed seconds: ${{ steps.bench.outputs.elapsed }}"
+            echo "- Cold cache seconds: ${{ steps.bench_cold.outputs.elapsed }}"
+            echo "- Warm cache seconds: ${{ steps.bench_warm.outputs.elapsed }}"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/runner-benchmark.yml
+++ b/.github/workflows/runner-benchmark.yml
@@ -34,8 +34,10 @@ jobs:
         id: bench_cold
         shell: bash
         run: |
-          rm -rf "$GOMODCACHE" "$GOCACHE"
-          mkdir -p "$GOMODCACHE" "$GOCACHE"
+          gomodcache=$(go env GOMODCACHE)
+          gocache=$(go env GOCACHE)
+          rm -rf "$gomodcache" "$gocache"
+          mkdir -p "$gomodcache" "$gocache"
 
           start=$(date +%s)
           go mod download


### PR DESCRIPTION
Temporary benchmark PR to compare `macos-latest` and `depot-macos-latest` on the same commit.

This PR is only for measuring runner-time differences and should not be merged.

## What it runs
- macOS GitHub-hosted runner
- Depot macOS runner

## Measurement
- Same repository commit
- Same build command
- Elapsed time reported in the workflow summary

## Cleanup
- Close this PR after collecting results.
