### PR TITLE
fix: avoid persisting invalid plugin upload artifacts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -88,7 +88,9 @@ require (
 )
 
 require (
+	github.com/alicebob/miniredis/v2 v2.38.0
 	gorm.io/driver/mysql v1.6.0
+	gorm.io/driver/sqlite v1.5.0
 	gorm.io/gorm v1.30.0
 	gorm.io/plugin/opentelemetry v0.1.16
 )
@@ -183,6 +185,7 @@ require (
 	github.com/magiconair/properties v1.8.10 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
+	github.com/mattn/go-sqlite3 v1.14.15 // indirect
 	github.com/mozillazg/go-httpheader v0.2.1 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
@@ -214,6 +217,7 @@ require (
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/detectors/gcp v1.39.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.60.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -51,6 +51,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.51.0 h1:6/0iUd0xrnX7qt+mLNRwg5c0PGv8wpE8K90ryANQwMI=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.51.0/go.mod h1:otE2jQekW/PqXk1Awf5lmfokJx4uwuqcj1ab5SpGeW0=
 github.com/QcloudApi/qcloud_sign_golang v0.0.0-20141224014652-e4130a326409/go.mod h1:1pk82RBxDY/JZnPQrtqHlUFfCctgdorsd9M06fMynOM=
+github.com/alicebob/miniredis/v2 v2.38.0 h1:nZAzCR+Lj+Vxk4ZXzm2NuKq2O33RXj1XxJ2e2uP9jiw=
+github.com/alicebob/miniredis/v2 v2.38.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/aliyun/aliyun-oss-go-sdk v3.0.2+incompatible h1:8psS8a+wKfiLt1iVDX79F7Y6wUM49Lcha2FMXt4UM8g=
 github.com/aliyun/aliyun-oss-go-sdk v3.0.2+incompatible/go.mod h1:T/Aws4fEfogEE9v+HPhhw+CntffsBHJ8nXQCwKr0/g8=
 github.com/andybalholm/brotli v1.1.1 h1:PR2pgnyFznKEugtsUo0xLdDop5SKXd5Qf5ysW+7XdTA=
@@ -425,6 +427,8 @@ github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3i
 github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d/go.mod h1:rHwXgn7JulP+udvsHwJoVG1YGAP6VLg4y9I5dyZdqmA=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 go.mongodb.org/mongo-driver v1.11.4/go.mod h1:PTSz5yu21bkT/wXpkS7WR5f0ddqw5quethTUn9WM+2g=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
@@ -569,6 +573,7 @@ gorm.io/driver/postgres v1.5.11 h1:ubBVAfbKEUld/twyKZ0IYn9rSQh448EdelLYk9Mv314=
 gorm.io/driver/postgres v1.5.11/go.mod h1:DX3GReXH+3FPWGrrgffdvCk3DQ1dwDPdmbenSkweRGI=
 gorm.io/driver/sqlite v1.5.0 h1:zKYbzRCpBrT1bNijRnxLDJWPjVfImGEn0lSnUY5gZ+c=
 gorm.io/driver/sqlite v1.5.0/go.mod h1:kDMDfntV9u/vuMmz8APHtHF0b4nyBB7sfCieC6G8k8I=
+gorm.io/gorm v1.24.7-0.20230306060331-85eaf9eeda11/go.mod h1:L4uxeKpfBml98NYqVqwAdmV1a2nBtAec/cf3fpucW/k=
 gorm.io/gorm v1.30.0 h1:qbT5aPv1UH8gI99OsRlvDToLxW5zR7FzS9acZDOZcgs=
 gorm.io/gorm v1.30.0/go.mod h1:8Z33v652h4//uMA76KjeDH8mJXPm1QNCYrMeatR0DOE=
 gorm.io/plugin/opentelemetry v0.1.16 h1:Kypj2YYAliJqkIczDZDde6P6sFMhKSlG5IpngMFQGpc=

--- a/internal/core/plugin_manager/media_transport/assets.go
+++ b/internal/core/plugin_manager/media_transport/assets.go
@@ -64,7 +64,7 @@ func (m *MediaBucket) RemapAssets(declaration *plugin_entities.PluginDeclaration
 				if valPtr != nil && *valPtr != "" {
 					*valPtr, err = remap(*valPtr)
 					if err != nil {
-						return nil, errors.Join(err, fmt.Errorf("failed to remap %s %s", iconField.iconType, langField.suffix))
+						return assetsIds, errors.Join(err, fmt.Errorf("failed to remap %s %s", iconField.iconType, langField.suffix))
 					}
 				}
 			}
@@ -75,14 +75,14 @@ func (m *MediaBucket) RemapAssets(declaration *plugin_entities.PluginDeclaration
 		if declaration.Tool.Identity.Icon != "" {
 			declaration.Tool.Identity.Icon, err = remap(declaration.Tool.Identity.Icon)
 			if err != nil {
-				return nil, errors.Join(err, fmt.Errorf("failed to remap tool icon"))
+				return assetsIds, errors.Join(err, fmt.Errorf("failed to remap tool icon"))
 			}
 		}
 
 		if declaration.Tool.Identity.IconDark != "" {
 			declaration.Tool.Identity.IconDark, err = remap(declaration.Tool.Identity.IconDark)
 			if err != nil {
-				return nil, errors.Join(err, fmt.Errorf("failed to remap tool icon dark"))
+				return assetsIds, errors.Join(err, fmt.Errorf("failed to remap tool icon dark"))
 			}
 		}
 	}
@@ -91,14 +91,14 @@ func (m *MediaBucket) RemapAssets(declaration *plugin_entities.PluginDeclaration
 		if declaration.AgentStrategy.Identity.Icon != "" {
 			declaration.AgentStrategy.Identity.Icon, err = remap(declaration.AgentStrategy.Identity.Icon)
 			if err != nil {
-				return nil, errors.Join(err, fmt.Errorf("failed to remap agent icon"))
+				return assetsIds, errors.Join(err, fmt.Errorf("failed to remap agent icon"))
 			}
 		}
 
 		if declaration.AgentStrategy.Identity.IconDark != "" {
 			declaration.AgentStrategy.Identity.IconDark, err = remap(declaration.AgentStrategy.Identity.IconDark)
 			if err != nil {
-				return nil, errors.Join(err, fmt.Errorf("failed to remap agent icon dark"))
+				return assetsIds, errors.Join(err, fmt.Errorf("failed to remap agent icon dark"))
 			}
 		}
 	}
@@ -107,7 +107,7 @@ func (m *MediaBucket) RemapAssets(declaration *plugin_entities.PluginDeclaration
 		if declaration.Datasource.Identity.Icon != "" {
 			declaration.Datasource.Identity.Icon, err = remap(declaration.Datasource.Identity.Icon)
 			if err != nil {
-				return nil, errors.Join(err, fmt.Errorf("failed to remap datasource icon"))
+				return assetsIds, errors.Join(err, fmt.Errorf("failed to remap datasource icon"))
 			}
 		}
 
@@ -115,7 +115,7 @@ func (m *MediaBucket) RemapAssets(declaration *plugin_entities.PluginDeclaration
 			if datasource.Identity.Icon != "" {
 				remappedIcon, err := remap(datasource.Identity.Icon)
 				if err != nil {
-					return nil, errors.Join(err, fmt.Errorf("failed to remap datasource step icon"))
+					return assetsIds, errors.Join(err, fmt.Errorf("failed to remap datasource step icon"))
 				}
 
 				identityPointer := &declaration.Datasource.Datasources[i].Identity
@@ -128,14 +128,14 @@ func (m *MediaBucket) RemapAssets(declaration *plugin_entities.PluginDeclaration
 		if declaration.Trigger.Identity.Icon != "" {
 			declaration.Trigger.Identity.Icon, err = remap(declaration.Trigger.Identity.Icon)
 			if err != nil {
-				return nil, errors.Join(err, fmt.Errorf("failed to remap trigger icon"))
+				return assetsIds, errors.Join(err, fmt.Errorf("failed to remap trigger icon"))
 			}
 		}
 
 		if declaration.Trigger.Identity.IconDark != "" {
 			declaration.Trigger.Identity.IconDark, err = remap(declaration.Trigger.Identity.IconDark)
 			if err != nil {
-				return nil, errors.Join(err, fmt.Errorf("failed to remap trigger icon dark"))
+				return assetsIds, errors.Join(err, fmt.Errorf("failed to remap trigger icon dark"))
 			}
 		}
 	}
@@ -143,14 +143,14 @@ func (m *MediaBucket) RemapAssets(declaration *plugin_entities.PluginDeclaration
 	if declaration.Icon != "" {
 		declaration.Icon, err = remap(declaration.Icon)
 		if err != nil {
-			return nil, errors.Join(err, fmt.Errorf("failed to remap plugin icon"))
+			return assetsIds, errors.Join(err, fmt.Errorf("failed to remap plugin icon"))
 		}
 	}
 
 	if declaration.IconDark != "" {
 		declaration.IconDark, err = remap(declaration.IconDark)
 		if err != nil {
-			return nil, errors.Join(err, fmt.Errorf("failed to remap plugin dark icon"))
+			return assetsIds, errors.Join(err, fmt.Errorf("failed to remap plugin dark icon"))
 		}
 	}
 

--- a/internal/core/plugin_manager/media_transport/package_bucket.go
+++ b/internal/core/plugin_manager/media_transport/package_bucket.go
@@ -26,6 +26,10 @@ func (m *PackageBucket) Get(name string) ([]byte, error) {
 	return m.oss.Load(path.Join(m.packagePath, name))
 }
 
+func (m *PackageBucket) Exists(name string) (bool, error) {
+	return m.oss.Exists(path.Join(m.packagePath, name))
+}
+
 func (m *PackageBucket) Delete(name string) error {
 	// delete from storage
 	return m.oss.Delete(path.Join(m.packagePath, name))

--- a/internal/core/plugin_manager/packages.go
+++ b/internal/core/plugin_manager/packages.go
@@ -1,6 +1,7 @@
 package plugin_manager
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -13,16 +14,30 @@ import (
 	"github.com/langgenius/dify-plugin-daemon/pkg/utils/cache/helper"
 )
 
-func (p *PluginManager) SavePackage(
-	plugin_unique_identifier plugin_entities.PluginUniqueIdentifier,
+type PreparedPackage struct {
+	UniqueIdentifier plugin_entities.PluginUniqueIdentifier
+	Declaration      plugin_entities.PluginDeclaration
+	Verification     *decoder.Verification
+	Package          []byte
+	Assets           map[string][]byte
+	AssetIDs         []string
+
+	packageSaved       bool
+	packageExisted     bool
+	previousPackage    []byte
+	declarationCreated bool
+}
+
+func (p *PluginManager) PreparePackage(
 	pkg []byte,
 	thirdPartySignatureVerificationConfig *decoder.ThirdPartySignatureVerificationConfig,
-) (*plugin_entities.PluginDeclaration, error) {
+) (*PreparedPackage, error) {
 	// try to decode the package
 	packageDecoder, err := decoder.NewZipPluginDecoderWithThirdPartySignatureVerificationConfig(pkg, thirdPartySignatureVerificationConfig)
 	if err != nil {
 		return nil, err
 	}
+	defer packageDecoder.Close()
 
 	// get the declaration
 	declaration, err := packageDecoder.Manifest()
@@ -40,50 +55,144 @@ func (p *PluginManager) SavePackage(
 		return nil, err
 	}
 
-	// remap the assets
-	_, err = p.mediaBucket.RemapAssets(&declaration, assets)
-	if err != nil {
-		return nil, errors.Join(err, fmt.Errorf("failed to remap assets"))
-	}
-
 	uniqueIdentifier, err := packageDecoder.UniqueIdentity()
 	if err != nil {
 		return nil, err
 	}
 
-	// save to storage
-	err = p.packageBucket.Save(plugin_unique_identifier.String(), pkg)
+	verification, _ := packageDecoder.Verification()
+	if verification == nil && packageDecoder.Verified() {
+		verification = decoder.DefaultVerification()
+	}
+
+	return &PreparedPackage{
+		UniqueIdentifier: uniqueIdentifier,
+		Declaration:      declaration,
+		Verification:     verification,
+		Package:          pkg,
+		Assets:           assets,
+	}, nil
+}
+
+func (p *PluginManager) PersistPackage(
+	prepared *PreparedPackage,
+) (*plugin_entities.PluginDeclaration, error) {
+	declaration := prepared.Declaration
+	prepared.AssetIDs = nil
+	prepared.packageSaved = false
+	prepared.packageExisted = false
+	prepared.previousPackage = nil
+	prepared.declarationCreated = false
+
+	packageExists, err := p.packageBucket.Exists(prepared.UniqueIdentifier.String())
 	if err != nil {
 		return nil, err
 	}
+	if packageExists {
+		existingPackage, err := p.packageBucket.Get(prepared.UniqueIdentifier.String())
+		if err != nil {
+			return nil, err
+		}
+		prepared.packageExisted = true
+		prepared.previousPackage = existingPackage
+	}
+
+	// remap the assets
+	assetIDs, err := p.mediaBucket.RemapAssets(&declaration, prepared.Assets)
+	if err != nil {
+		prepared.AssetIDs = assetIDs
+		p.rollbackPreparedPackage(prepared)
+		return nil, errors.Join(err, fmt.Errorf("failed to remap assets"))
+	}
+	prepared.AssetIDs = assetIDs
+
+	// save to storage
+	err = p.packageBucket.Save(prepared.UniqueIdentifier.String(), prepared.Package)
+	if err != nil {
+		p.rollbackPreparedPackage(prepared)
+		return nil, err
+	}
+	prepared.packageSaved = true
 
 	// create plugin if not exists (idempotent under concurrency)
 	if _, err := db.GetOne[models.PluginDeclaration](
-		db.Equal("plugin_unique_identifier", uniqueIdentifier.String()),
+		db.Equal("plugin_unique_identifier", prepared.UniqueIdentifier.String()),
 	); err == db.ErrDatabaseNotFound {
 		createErr := db.Create(&models.PluginDeclaration{
-			PluginUniqueIdentifier: uniqueIdentifier.String(),
-			PluginID:               uniqueIdentifier.PluginID(),
+			PluginUniqueIdentifier: prepared.UniqueIdentifier.String(),
+			PluginID:               prepared.UniqueIdentifier.PluginID(),
 			Declaration:            declaration,
 		})
 		if createErr != nil {
 			// ignore Postgres unique-violation (23505) errors triggered by concurrent inserts
 			if isUniqueViolation(createErr) {
-				return &declaration, nil
+				prepared.Declaration = declaration
+				return &prepared.Declaration, nil
 			}
 			// fallback: if another goroutine has just inserted, read-after-write should succeed
 			if _, again := db.GetOne[models.PluginDeclaration](
-				db.Equal("plugin_unique_identifier", uniqueIdentifier.String()),
+				db.Equal("plugin_unique_identifier", prepared.UniqueIdentifier.String()),
 			); again == nil {
-				return &declaration, nil
+				prepared.Declaration = declaration
+				return &prepared.Declaration, nil
 			}
+			p.rollbackPreparedPackage(prepared)
 			return nil, createErr
 		}
+		prepared.declarationCreated = true
 	} else if err != nil {
+		p.rollbackPreparedPackage(prepared)
 		return nil, err
 	}
 
-	return &declaration, nil
+	prepared.Declaration = declaration
+	return &prepared.Declaration, nil
+}
+
+func (p *PluginManager) SavePackage(
+	plugin_unique_identifier plugin_entities.PluginUniqueIdentifier,
+	pkg []byte,
+	thirdPartySignatureVerificationConfig *decoder.ThirdPartySignatureVerificationConfig,
+) (*plugin_entities.PluginDeclaration, error) {
+	prepared, err := p.PreparePackage(pkg, thirdPartySignatureVerificationConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	if prepared.UniqueIdentifier != plugin_unique_identifier {
+		return nil, fmt.Errorf("plugin unique identifier mismatch")
+	}
+
+	return p.PersistPackage(prepared)
+}
+
+func (p *PluginManager) RollbackPackage(prepared *PreparedPackage) {
+	p.rollbackPreparedPackage(prepared)
+}
+
+func (p *PluginManager) rollbackPreparedPackage(prepared *PreparedPackage) {
+	for _, assetID := range prepared.AssetIDs {
+		_ = p.mediaBucket.Delete(assetID)
+	}
+	if prepared.declarationCreated {
+		_ = db.DeleteByCondition(models.PluginDeclaration{
+			PluginUniqueIdentifier: prepared.UniqueIdentifier.String(),
+		})
+	}
+	if prepared.packageSaved {
+		currentPackage, err := p.packageBucket.Get(prepared.UniqueIdentifier.String())
+		if err == nil && bytes.Equal(currentPackage, prepared.Package) {
+			if _, dbErr := db.GetOne[models.PluginDeclaration](
+				db.Equal("plugin_unique_identifier", prepared.UniqueIdentifier.String()),
+			); dbErr == db.ErrDatabaseNotFound {
+				if prepared.packageExisted {
+					_ = p.packageBucket.Save(prepared.UniqueIdentifier.String(), prepared.previousPackage)
+				} else {
+					_ = p.packageBucket.Delete(prepared.UniqueIdentifier.String())
+				}
+			}
+		}
+	}
 }
 
 // isUniqueViolation returns true if err indicates a PostgreSQL unique constraint violation (SQLSTATE 23505).

--- a/internal/service/plugin_decoder.go
+++ b/internal/service/plugin_decoder.go
@@ -33,6 +33,7 @@ func UploadPluginPkg(
 	if err != nil {
 		return exception.BadRequestError(err).ToResponse()
 	}
+	defer decoderInstance.Close()
 
 	pluginUniqueIdentifier, err := decoderInstance.UniqueIdentity()
 	if err != nil {
@@ -45,29 +46,29 @@ func UploadPluginPkg(
 	}
 
 	manager := plugin_manager.Manager()
-	declaration, err := manager.SavePackage(pluginUniqueIdentifier, pluginFile, &decoder.ThirdPartySignatureVerificationConfig{
+	preparedPackage, err := manager.PreparePackage(pluginFile, &decoder.ThirdPartySignatureVerificationConfig{
 		Enabled:        config.ThirdPartySignatureVerificationEnabled,
 		PublicKeyPaths: config.ThirdPartySignatureVerificationPublicKeys,
 	})
 	if err != nil {
-		return exception.BadRequestError(errors.Join(err, errors.New("failed to save package"))).ToResponse()
+		return exception.BadRequestError(errors.Join(err, errors.New("failed to decode package"))).ToResponse()
 	}
 
 	if config.ForceVerifyingSignature || verifySignature {
-		if !declaration.Verified {
+		if !preparedPackage.Declaration.Verified {
 			return exception.BadRequestError(errors.Join(err, errors.New(
 				"plugin verification has been enabled, and the plugin you want to install has a bad signature",
 			))).ToResponse()
 		}
 	}
 
-	verification, _ := decoderInstance.Verification()
-	if verification == nil && decoderInstance.Verified() {
-		verification = decoder.DefaultVerification()
+	declaration, err := manager.PersistPackage(preparedPackage)
+	if err != nil {
+		return exception.BadRequestError(errors.Join(err, errors.New("failed to save package"))).ToResponse()
 	}
 
 	// if config.EnforceLanggeniusSignatures {
-	// 	if isUnauthorizedLanggenius(declaration, verification) {
+	// 	if isUnauthorizedLanggenius(declaration, preparedPackage.Verification) {
 	// 		return exception.BadRequestError(ErrUnauthorizedLanggenius).ToResponse()
 	// 	}
 	// }
@@ -75,7 +76,7 @@ func UploadPluginPkg(
 	return entities.NewSuccessResponse(map[string]any{
 		"unique_identifier": pluginUniqueIdentifier,
 		"manifest":          declaration,
-		"verification":      verification,
+		"verification":      preparedPackage.Verification,
 	})
 }
 
@@ -105,6 +106,10 @@ func UploadPluginBundle(
 	manager := plugin_manager.Manager()
 
 	result := []map[string]any{}
+	preparedPackageDependencies := []struct {
+		resultIndex int
+		prepared    *plugin_manager.PreparedPackage
+	}{}
 
 	for _, dependency := range bundle.Dependencies {
 		if dependency.Type == bundle_entities.DEPENDENCY_TYPE_GITHUB {
@@ -144,46 +149,67 @@ func UploadPluginBundle(
 					}
 
 					pluginUniqueIdentifier, err := decoderInstance.UniqueIdentity()
+					_ = decoderInstance.Close()
 					if err != nil {
 						return exception.BadRequestError(errors.Join(errors.New("failed to get package unique identifier"), err)).ToResponse()
 					}
 
-					declaration, err := manager.SavePackage(pluginUniqueIdentifier, asset, &decoder.ThirdPartySignatureVerificationConfig{
+					preparedPackage, err := manager.PreparePackage(asset, &decoder.ThirdPartySignatureVerificationConfig{
 						Enabled:        config.ThirdPartySignatureVerificationEnabled,
 						PublicKeyPaths: config.ThirdPartySignatureVerificationPublicKeys,
 					})
 					if err != nil {
-						return exception.InternalServerError(errors.Join(errors.New("failed to save package"), err)).ToResponse()
+						return exception.InternalServerError(errors.Join(errors.New("failed to decode package"), err)).ToResponse()
 					}
 
 					if config.ForceVerifyingSignature || verify_signature {
-						if !declaration.Verified {
+						if !preparedPackage.Declaration.Verified {
 							return exception.BadRequestError(errors.Join(errors.New(
 								"plugin verification has been enabled, and the plugin you want to install has a bad signature",
 							), err)).ToResponse()
 						}
 					}
 
-					verification, _ := decoderInstance.Verification()
-					if verification == nil && decoderInstance.Verified() {
-						verification = decoder.DefaultVerification()
-					}
-
 					if config.EnforceLanggeniusSignatures {
-						if isUnauthorizedLanggenius(declaration, verification) {
+						if isUnauthorizedLanggenius(&preparedPackage.Declaration, preparedPackage.Verification) {
 							return exception.BadRequestError(ErrUnauthorizedLanggenius).ToResponse()
 						}
 					}
 
+					resultIndex := len(result)
 					result = append(result, map[string]any{
 						"type": "package",
 						"value": map[string]any{
 							"unique_identifier": pluginUniqueIdentifier,
-							"manifest":          declaration,
+							"manifest":          &preparedPackage.Declaration,
 						},
 					})
+					preparedPackageDependencies = append(preparedPackageDependencies, struct {
+						resultIndex int
+						prepared    *plugin_manager.PreparedPackage
+					}{resultIndex: resultIndex, prepared: preparedPackage})
 				}
 			}
+		}
+	}
+
+	persistedPackages := []*plugin_manager.PreparedPackage{}
+	for _, dependency := range preparedPackageDependencies {
+		declaration, err := manager.PersistPackage(dependency.prepared)
+		if err != nil {
+			for i := len(persistedPackages) - 1; i >= 0; i-- {
+				manager.RollbackPackage(persistedPackages[i])
+			}
+			return exception.InternalServerError(errors.Join(errors.New("failed to save package"), err)).ToResponse()
+		}
+
+		persistedPackages = append(persistedPackages, dependency.prepared)
+		result[dependency.resultIndex] = map[string]any{
+			"type": "package",
+			"value": map[string]any{
+				"unique_identifier": dependency.prepared.UniqueIdentifier,
+				"manifest":          declaration,
+			},
 		}
 	}
 

--- a/internal/service/plugin_decoder_test.go
+++ b/internal/service/plugin_decoder_test.go
@@ -1,0 +1,365 @@
+package service
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	miniredis "github.com/alicebob/miniredis/v2"
+	cloudoss "github.com/langgenius/dify-cloud-kit/oss"
+	"github.com/langgenius/dify-cloud-kit/oss/factory"
+	"github.com/langgenius/dify-plugin-daemon/internal/core/plugin_manager"
+	"github.com/langgenius/dify-plugin-daemon/internal/db"
+	"github.com/langgenius/dify-plugin-daemon/internal/types/app"
+	"github.com/langgenius/dify-plugin-daemon/internal/types/models"
+	"github.com/langgenius/dify-plugin-daemon/pkg/entities/plugin_entities"
+	"github.com/langgenius/dify-plugin-daemon/pkg/plugin_packager/decoder"
+	"github.com/langgenius/dify-plugin-daemon/pkg/plugin_packager/signer/withkey"
+	"github.com/langgenius/dify-plugin-daemon/pkg/utils/cache"
+	"github.com/langgenius/dify-plugin-daemon/pkg/utils/cache/helper"
+	"github.com/langgenius/dify-plugin-daemon/pkg/utils/encryption"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+type uploadTestEnv struct {
+	config     *app.Config
+	manager    *plugin_manager.PluginManager
+	storageDir string
+}
+
+type testMultipartFile struct {
+	*bytes.Reader
+}
+
+func (f testMultipartFile) Close() error {
+	return nil
+}
+
+func setupUploadTestEnv(t *testing.T, forceVerify bool) uploadTestEnv {
+	t.Helper()
+
+	redisServer := miniredis.RunT(t)
+	require.NoError(t, cache.InitRedisClient(redisServer.Addr(), "", "", false, 0, nil))
+	t.Cleanup(func() {
+		_ = cache.Close()
+	})
+
+	gormDB, err := gorm.Open(sqlite.Open("file:"+strings.ReplaceAll(t.Name(), "/", "_")+"?mode=memory&cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, gormDB.AutoMigrate(
+		&models.Plugin{},
+		&models.PluginDeclaration{},
+		&models.PluginInstallation{},
+	))
+	db.DifyPluginDB = gormDB
+	t.Cleanup(func() {
+		sqlDB, err := gormDB.DB()
+		if err == nil {
+			_ = sqlDB.Close()
+		}
+	})
+
+	storageDir := t.TempDir()
+	oss, err := factory.Load("local", cloudoss.OSSArgs{
+		Local: &cloudoss.Local{Path: storageDir},
+	})
+	require.NoError(t, err)
+
+	config := &app.Config{
+		PluginMediaCachePath:                   "assets",
+		PluginMediaCacheSize:                   32,
+		PluginAssetCacheSize:                   32,
+		PluginInstalledPath:                    "installed",
+		PluginPackageCachePath:                 "packages",
+		PluginLocalLaunchingConcurrent:         1,
+		PluginInstallTimeout:                   15,
+		PluginWorkingPath:                      filepath.Join(storageDir, "working"),
+		Platform:                               app.PLATFORM_LOCAL,
+		MaxPluginPackageSize:                   50 * 1024 * 1024,
+		MaxBundlePackageSize:                   50 * 1024 * 1024,
+		ForceVerifyingSignature:                forceVerify,
+		EnforceLanggeniusSignatures:            false,
+		ThirdPartySignatureVerificationEnabled: true,
+		ThirdPartySignatureVerificationPublicKeys: []string{
+			repoPath(t, "pkg/plugin_packager/testdata/keys/test_key_pair_1.public.pem"),
+		},
+	}
+
+	manager := plugin_manager.InitGlobalManager(oss, config)
+	return uploadTestEnv{config: config, manager: manager, storageDir: storageDir}
+}
+
+func TestUploadPluginPkgRejectsInvalidSignatureWithoutArtifacts(t *testing.T) {
+	env := setupUploadTestEnv(t, true)
+	pkgBytes := signedPluginPackage(t, "badpkgsingle")
+	pkgBytes[len(pkgBytes)-1] = 0
+	pkgBytes[len(pkgBytes)-2] = 0
+	identifier := packageIdentifier(t, pkgBytes)
+
+	resp := UploadPluginPkg(env.config, nil, "tenant-1", testMultipartFile{bytes.NewReader(pkgBytes)}, true)
+
+	require.Equal(t, -400, resp.Code)
+	requireNoUploadArtifacts(t, env, identifier)
+	require.Empty(t, storedFiles(t, filepath.Join(env.storageDir, "assets")))
+}
+
+func TestUploadPluginBundleRejectsInvalidPackageDependencyWithoutPartialArtifacts(t *testing.T) {
+	env := setupUploadTestEnv(t, true)
+	validDependency := signedPluginPackage(t, "bundlevaliddep")
+	invalidDependency := signedPluginPackage(t, "bundlebaddep")
+	invalidDependency[len(invalidDependency)-1] = 0
+	invalidDependency[len(invalidDependency)-2] = 0
+
+	validIdentifier := packageIdentifier(t, validDependency)
+	invalidIdentifier := packageIdentifier(t, invalidDependency)
+	bundleBytes := bundleWithPackageDependencies(t, []bundlePackage{
+		{name: "valid.difypkg", content: validDependency},
+		{name: "bad.difypkg", content: invalidDependency},
+	})
+
+	resp := UploadPluginBundle(env.config, nil, "tenant-1", testMultipartFile{bytes.NewReader(bundleBytes)}, true)
+
+	require.NotEqual(t, 0, resp.Code)
+	requireNoUploadArtifacts(t, env, validIdentifier, invalidIdentifier)
+	require.Empty(t, storedFiles(t, filepath.Join(env.storageDir, "assets")))
+}
+
+func TestUploadPluginPkgPersistsValidPackageAndSupportsInstallLookup(t *testing.T) {
+	env := setupUploadTestEnv(t, true)
+	pkgBytes := signedPluginPackage(t, "validpkgupload")
+	identifier := packageIdentifier(t, pkgBytes)
+
+	resp := UploadPluginPkg(env.config, nil, "tenant-1", testMultipartFile{bytes.NewReader(pkgBytes)}, true)
+
+	require.Equal(t, 0, resp.Code)
+	storedPackage, err := env.manager.GetPackage(identifier)
+	require.NoError(t, err)
+	require.Equal(t, pkgBytes, storedPackage)
+
+	manifestResp := FetchPluginManifest(identifier)
+	require.Equal(t, 0, manifestResp.Code)
+
+	declaration := manifestResp.Data.(*plugin_entities.PluginDeclaration)
+	require.True(t, declaration.Verified)
+	require.Equal(t, "validpkgupload", declaration.Name)
+
+	require.NoError(t, db.Create(&models.Plugin{
+		PluginUniqueIdentifier: identifier.String(),
+		PluginID:               identifier.PluginID(),
+		InstallType:            plugin_entities.PLUGIN_RUNTIME_TYPE_LOCAL,
+	}))
+	installResp := InstallMultiplePluginsToTenant(
+		context.Background(),
+		env.config,
+		"00000000-0000-0000-0000-000000000001",
+		[]plugin_entities.PluginUniqueIdentifier{identifier},
+		"test",
+		[]map[string]any{{}},
+	)
+	require.Equal(t, 0, installResp.Code)
+	installData := installResp.Data.(*InstallPluginResponse)
+	require.True(t, installData.AllInstalled)
+	require.Empty(t, installData.TaskID)
+}
+
+func TestUploadPluginPkgStillAllowsUnsignedPackageWhenVerificationNotRequired(t *testing.T) {
+	env := setupUploadTestEnv(t, false)
+	pkgBytes := unsignedPluginPackage(t, "unsignedallowed")
+	identifier := packageIdentifier(t, pkgBytes)
+
+	resp := UploadPluginPkg(env.config, nil, "tenant-1", testMultipartFile{bytes.NewReader(pkgBytes)}, false)
+
+	require.Equal(t, 0, resp.Code)
+	_, err := env.manager.GetPackage(identifier)
+	require.NoError(t, err)
+	manifestResp := FetchPluginManifest(identifier)
+	require.Equal(t, 0, manifestResp.Code)
+}
+
+func requireNoUploadArtifacts(t *testing.T, env uploadTestEnv, identifiers ...plugin_entities.PluginUniqueIdentifier) {
+	t.Helper()
+
+	for _, identifier := range identifiers {
+		_, err := env.manager.GetPackage(identifier)
+		require.Error(t, err)
+
+		_, err = db.GetOne[models.PluginDeclaration](
+			db.Equal("plugin_unique_identifier", identifier.String()),
+		)
+		require.ErrorIs(t, err, db.ErrDatabaseNotFound)
+
+		resp := FetchPluginManifest(identifier)
+		require.Equal(t, -400, resp.Code)
+		require.Contains(t, resp.Message, helper.ErrPluginNotFound.Error())
+	}
+}
+
+func signedPluginPackage(t *testing.T, name string) []byte {
+	t.Helper()
+
+	pkgBytes := unsignedPluginPackage(t, name)
+	privateKeyBytes, err := os.ReadFile(repoPath(t, "pkg/plugin_packager/testdata/keys/test_key_pair_1.private.pem"))
+	require.NoError(t, err)
+	privateKey, err := encryption.LoadPrivateKey(privateKeyBytes)
+	require.NoError(t, err)
+	signed, err := withkey.SignPluginWithPrivateKey(pkgBytes, &decoder.Verification{
+		AuthorizedCategory: decoder.AUTHORIZED_CATEGORY_LANGGENIUS,
+	}, privateKey)
+	require.NoError(t, err)
+	return signed
+}
+
+func unsignedPluginPackage(t *testing.T, name string) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	zipWriter := zip.NewWriter(&buf)
+	writeZipFile(t, zipWriter, "manifest.yaml", pluginManifest(name))
+	writeZipFile(t, zipWriter, "endpoint.yaml", endpointManifest())
+	writeZipFile(t, zipWriter, "_assets/test.svg", `<svg xmlns="http://www.w3.org/2000/svg"></svg>`)
+	require.NoError(t, zipWriter.Close())
+	return buf.Bytes()
+}
+
+type bundlePackage struct {
+	name    string
+	content []byte
+}
+
+func bundleWithPackageDependencies(t *testing.T, packages []bundlePackage) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	zipWriter := zip.NewWriter(&buf)
+	writeZipFile(t, zipWriter, "manifest.yaml", bundleManifest(packages))
+	for _, pkg := range packages {
+		writeZipFileBytes(t, zipWriter, filepath.Join("_assets", pkg.name), pkg.content)
+	}
+	require.NoError(t, zipWriter.Close())
+	return buf.Bytes()
+}
+
+func packageIdentifier(t *testing.T, pkgBytes []byte) plugin_entities.PluginUniqueIdentifier {
+	t.Helper()
+
+	zipDecoder, err := decoder.NewZipPluginDecoder(pkgBytes)
+	require.NoError(t, err)
+	identifier, err := zipDecoder.UniqueIdentity()
+	require.NoError(t, err)
+	return identifier
+}
+
+func writeZipFile(t *testing.T, zipWriter *zip.Writer, name string, content string) {
+	t.Helper()
+	writeZipFileBytes(t, zipWriter, name, []byte(content))
+}
+
+func writeZipFileBytes(t *testing.T, zipWriter *zip.Writer, name string, content []byte) {
+	t.Helper()
+	file, err := zipWriter.Create(name)
+	require.NoError(t, err)
+	_, err = io.Copy(file, bytes.NewReader(content))
+	require.NoError(t, err)
+}
+
+func storedFiles(t *testing.T, root string) []string {
+	t.Helper()
+
+	files := []string{}
+	if _, err := os.Stat(root); errors.Is(err, os.ErrNotExist) {
+		return files
+	}
+	require.NoError(t, filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		files = append(files, rel)
+		return nil
+	}))
+	return files
+}
+
+func pluginManifest(name string) string {
+	return fmt.Sprintf(`version: 0.0.1
+type: plugin
+author: testauthor
+name: %s
+icon: test.svg
+description:
+  en_US: "test"
+label:
+  en_US: "Test"
+created_at: "2024-07-12T08:03:44Z"
+resource:
+  memory: 1048576
+  permission:
+    endpoint:
+      enabled: true
+plugins:
+  endpoints:
+    - "endpoint.yaml"
+meta:
+  version: 0.0.1
+  arch:
+    - "amd64"
+  runner:
+    language: "python"
+    version: "3.12"
+    entrypoint: "main.py"
+`, name)
+}
+
+func endpointManifest() string {
+	return `settings: []
+endpoints:
+  - path: "/test"
+    method: "GET"
+`
+}
+
+func bundleManifest(packages []bundlePackage) string {
+	var builder strings.Builder
+	builder.WriteString(`version: 0.0.1
+name: test-bundle
+labels:
+  en_US: "Test Bundle"
+description:
+  en_US: "Test bundle"
+icon: test.svg
+author: testauthor
+type: bundle
+dependencies:
+`)
+	for _, pkg := range packages {
+		builder.WriteString("  - type: package\n")
+		builder.WriteString("    value:\n")
+		builder.WriteString("      path: " + pkg.name + "\n")
+	}
+	return builder.String()
+}
+
+func repoPath(t *testing.T, parts ...string) string {
+	t.Helper()
+
+	_, file, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	root := filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+	return filepath.Join(append([]string{root}, parts...)...)
+}


### PR DESCRIPTION
## Description

Adjust plugin upload validation order so failed validations do not leave stale upload artifacts.
Keep bundle package uploads atomic when dependency validation fails.

## Type of Change

- [x] Bug fix

## Additional Information

No additional context.