### PR TITLE
fix: support lowercase proxy environment variables as fallback

### DIFF
--- a/internal/types/app/default.go
+++ b/internal/types/app/default.go
@@ -9,15 +9,9 @@ import (
 
 func (config *Config) SetDefault() {
 	// Fallback to lowercase proxy env vars if uppercase are not set
-	if config.HttpProxy == "" {
-		config.HttpProxy = os.Getenv("http_proxy")
-	}
-	if config.HttpsProxy == "" {
-		config.HttpsProxy = os.Getenv("https_proxy")
-	}
-	if config.NoProxy == "" {
-		config.NoProxy = os.Getenv("no_proxy")
-	}
+	setDefaultString(&config.HttpProxy, os.Getenv("http_proxy"))
+	setDefaultString(&config.HttpsProxy, os.Getenv("https_proxy"))
+	setDefaultString(&config.NoProxy, os.Getenv("no_proxy"))
 
 	switch config.DBType {
 	case DB_TYPE_OCEANBASE, DB_TYPE_SEEKDB:

--- a/internal/types/app/default.go
+++ b/internal/types/app/default.go
@@ -1,11 +1,24 @@
 package app
 
 import (
+	"os"
+
 	"github.com/langgenius/dify-cloud-kit/oss"
 	"golang.org/x/exp/constraints"
 )
 
 func (config *Config) SetDefault() {
+	// Fallback to lowercase proxy env vars if uppercase are not set
+	if config.HttpProxy == "" {
+		config.HttpProxy = os.Getenv("http_proxy")
+	}
+	if config.HttpsProxy == "" {
+		config.HttpsProxy = os.Getenv("https_proxy")
+	}
+	if config.NoProxy == "" {
+		config.NoProxy = os.Getenv("no_proxy")
+	}
+
 	switch config.DBType {
 	case DB_TYPE_OCEANBASE, DB_TYPE_SEEKDB:
 		config.DBType = DB_TYPE_MYSQL


### PR DESCRIPTION
## Summary

The plugin_daemon config only reads uppercase `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` via envconfig tags. When only lowercase `http_proxy`, `https_proxy`, and `no_proxy` are set (common in many environments), the proxy settings are silently ignored, causing plugin installation failures behind HTTP proxies.

Add fallback in `SetDefault()` to check lowercase env vars when uppercase are not set, matching the behavior of other Dify containers (api, web).

## Fix

In `internal/types/app/default.go`, use the existing `setDefaultString` helper function for proxy environment variable fallback to maintain code consistency.

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/langgenius/dify-plugin-daemon/blob/main/CONTRIBUTING.md)
- [x] Fixes #18752