### PR TITLE
fix: clean up ServerlessRuntime record and cache on plugin uninstall

### DIFF
--- a/internal/core/plugin_manager/installer.go
+++ b/internal/core/plugin_manager/installer.go
@@ -50,7 +50,7 @@ func (p *PluginManager) SwitchServerlessEndpoint(
 	if err != nil {
 		return err
 	}
-	return p.clearServerlessRuntimeCache(pluginUniqueIdentifier)
+	return p.ClearServerlessRuntimeCache(pluginUniqueIdentifier)
 }
 
 // serverless runtime uses a strategy that firstly compile the plugin into a docker image
@@ -109,7 +109,7 @@ func (p *PluginManager) Reinstall(
 
 				// cleanup system cache for serverless runtime model
 				// cleanup must be done after updating the model, otherwise race condition may occur
-				if err := p.clearServerlessRuntimeCache(pluginUniqueIdentifier); err != nil {
+				if err := p.ClearServerlessRuntimeCache(pluginUniqueIdentifier); err != nil {
 					log.Error("failed to cleanup system cache for serverless runtime model", "error", err)
 					responseStream.Write(installation_entities.PluginInstallResponse{
 						Event: installation_entities.PluginInstallEventError,

--- a/internal/core/plugin_manager/serverless.go
+++ b/internal/core/plugin_manager/serverless.go
@@ -87,7 +87,7 @@ func (p *PluginManager) getServerlessPluginRuntimeModel(
 	return runtime, nil
 }
 
-func (p *PluginManager) clearServerlessRuntimeCache(
+func (p *PluginManager) ClearServerlessRuntimeCache(
 	identity plugin_entities.PluginUniqueIdentifier,
 ) error {
 	_, err := cache.Del(p.getServerlessRuntimeCacheKey(identity))

--- a/internal/service/install_plugin.go
+++ b/internal/service/install_plugin.go
@@ -364,6 +364,14 @@ func UninstallPlugin(
 
 	if deleteResponse != nil && deleteResponse.IsPluginDeleted {
 		helper.DeletePluginDeclarationCache(pluginUniqueIdentifier, plugin_entities.PluginRuntimeType(installation.RuntimeType))
+
+		if plugin_entities.PluginRuntimeType(installation.RuntimeType) == plugin_entities.PLUGIN_RUNTIME_TYPE_SERVERLESS {
+			if manager := plugin_manager.Manager(); manager != nil {
+				if err := manager.ClearServerlessRuntimeCache(pluginUniqueIdentifier); err != nil {
+					log.Error("failed to clear serverless runtime cache on uninstall", "error", err)
+				}
+			}
+		}
 	}
 
 	if deleteResponse != nil && deleteResponse.IsPluginDeleted && deleteResponse.Plugin != nil && deleteResponse.Plugin.InstallType == plugin_entities.PLUGIN_RUNTIME_TYPE_LOCAL {

--- a/internal/tasks/install_plugin_utils.go
+++ b/internal/tasks/install_plugin_utils.go
@@ -174,5 +174,12 @@ func RemovePluginIfNeeded(
 			return errors.Join(err, errors.New("failed to shutdown plugin gracefully"))
 		}
 	}
+
+	if shouldCleanup && response.DeletedPlugin != nil && response.DeletedPlugin.InstallType == plugin_entities.PLUGIN_RUNTIME_TYPE_SERVERLESS {
+		if err := manager.ClearServerlessRuntimeCache(originalPluginUniqueIdentifier); err != nil {
+			log.Error("failed to clear serverless runtime cache on upgrade", "error", err)
+		}
+	}
+
 	return nil
 }

--- a/internal/types/models/curd/atomic.go
+++ b/internal/types/models/curd/atomic.go
@@ -372,6 +372,14 @@ func UninstallPlugin(
 			}, tx); err != nil {
 				return err
 			}
+
+			if pluginToBeReturns.InstallType == plugin_entities.PLUGIN_RUNTIME_TYPE_SERVERLESS {
+				if err := db.DeleteByCondition(&models.ServerlessRuntime{
+					PluginUniqueIdentifier: pluginUniqueIdentifier.String(),
+				}, tx); err != nil {
+					return err
+				}
+			}
 		}
 
 		return nil

--- a/internal/types/models/curd/atomic.go
+++ b/internal/types/models/curd/atomic.go
@@ -506,6 +506,14 @@ func UpgradePlugin(
 			}, tx); err != nil {
 				return err
 			}
+
+			if originalPlugin.InstallType == plugin_entities.PLUGIN_RUNTIME_TYPE_SERVERLESS {
+				if err := db.DeleteByCondition(&models.ServerlessRuntime{
+					PluginUniqueIdentifier: originalPluginUniqueIdentifier.String(),
+				}, tx); err != nil {
+					return err
+				}
+			}
 		} else if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary

- Delete `ServerlessRuntime` DB record when the last tenant uninstalls a serverless plugin (`Refs==0`), inside the existing transaction — guarded by `InstallType == SERVERLESS`
- Expose `ClearServerlessRuntimeCache` as a public method on `PluginManager` (renamed from private)
- Clear Redis serverless runtime cache on full plugin deletion — best-effort (logged, not returned), guarded by `RuntimeType == SERVERLESS`

Fixes ENG-474: after uninstall + reinstall, the stale `ServerlessRuntime` record and cached hostname caused credential requests to route to the deleted serverless endpoint (`no such host`). Required a Pod restart to recover.

## Test Plan

- [ ] Install serverless plugin (single tenant) → uninstall → confirm `serverless_runtimes` row deleted and `redis-cli GET "serverless:runtime:<id>"` returns `(nil)`
- [ ] Reinstall same plugin → confirm fresh record created → add model credentials → no `no such host` error, no Pod restart needed
- [ ] Multi-tenant: install on Tenant A + B → Tenant A uninstalls (`Refers` → 1) → confirm record and cache NOT cleared (Tenant B still active)