### PR TITLE
fix: prevent path traversal during plugin extraction

### DIFF
--- a/pkg/plugin_packager/decoder/zip.go
+++ b/pkg/plugin_packager/decoder/zip.go
@@ -18,6 +18,8 @@ import (
 	"github.com/langgenius/dify-plugin-daemon/pkg/utils/parser"
 )
 
+var errUnsafeZipPath = errors.New("unsafe path in plugin package")
+
 type ZipPluginDecoder struct {
 	PluginDecoder
 	PluginDecoderHelper
@@ -297,33 +299,98 @@ func (z *ZipPluginDecoder) UniqueIdentity() (plugin_entities.PluginUniqueIdentif
 
 func (z *ZipPluginDecoder) ExtractTo(dst string) error {
 	// copy to working directory
-	if err := z.Walk(func(filename, dir string) error {
-		workingPath := path.Join(dst, dir)
-		// check if directory exists
-		if err := os.MkdirAll(workingPath, 0755); err != nil {
-			return err
-		}
+	if z.reader == nil {
+		return z.err
+	}
 
-		bytes, err := z.ReadFile(filepath.Join(dir, filename))
-		if err != nil {
-			return err
-		}
+	if err := func() error {
+		for _, file := range z.reader.File {
+			targetPath, err := safeExtractPath(dst, file.Name)
+			if err != nil {
+				return err
+			}
 
-		filename = filepath.Join(workingPath, filename)
+			if file.FileInfo().IsDir() {
+				if err := os.MkdirAll(targetPath, 0755); err != nil {
+					return err
+				}
+				continue
+			}
 
-		// copy file
-		if err := os.WriteFile(filename, bytes, 0644); err != nil {
-			return err
+			workingPath := filepath.Dir(targetPath)
+			// check if directory exists
+			if err := os.MkdirAll(workingPath, 0755); err != nil {
+				return err
+			}
+
+			reader, err := file.Open()
+			if err != nil {
+				return err
+			}
+
+			writer, err := os.OpenFile(targetPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+			if err != nil {
+				reader.Close()
+				return err
+			}
+
+			if _, err := io.Copy(writer, reader); err != nil {
+				reader.Close()
+				writer.Close()
+				return err
+			}
+			if err := reader.Close(); err != nil {
+				writer.Close()
+				return err
+			}
+			if err := writer.Close(); err != nil {
+				return err
+			}
 		}
 
 		return nil
-	}); err != nil {
+	}(); err != nil {
 		// if error, delete the working directory
 		os.RemoveAll(dst)
 		return errors.Join(fmt.Errorf("copy plugin to working directory error: %v", err), err)
 	}
 
 	return nil
+}
+
+func safeExtractPath(dst, entryName string) (string, error) {
+	entryPath := path.Clean(entryName)
+	if entryPath == "." ||
+		path.IsAbs(entryPath) ||
+		strings.HasPrefix(entryPath, "../") ||
+		strings.Contains(entryPath, "/../") ||
+		strings.Contains(entryPath, `\`) ||
+		filepath.IsAbs(filepath.FromSlash(entryPath)) {
+		return "", fmt.Errorf("%w: %s", errUnsafeZipPath, entryName)
+	}
+
+	targetPath := filepath.Join(dst, filepath.FromSlash(entryPath))
+	if !pathIsInside(dst, targetPath) {
+		return "", fmt.Errorf("%w: %s", errUnsafeZipPath, entryName)
+	}
+
+	return targetPath, nil
+}
+
+func pathIsInside(root, target string) bool {
+	rootAbs, err := filepath.Abs(root)
+	if err != nil {
+		return false
+	}
+	targetAbs, err := filepath.Abs(target)
+	if err != nil {
+		return false
+	}
+	rel, err := filepath.Rel(rootAbs, targetAbs)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
 }
 
 func (z *ZipPluginDecoder) CheckAssetsValid() error {

--- a/pkg/plugin_packager/decoder/zip.go
+++ b/pkg/plugin_packager/decoder/zip.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"math"
 	"os"
 	"path"
 	"path/filepath"
@@ -334,7 +335,7 @@ func (z *ZipPluginDecoder) ExtractTo(dst string) error {
 				return err
 			}
 
-			if _, err := io.Copy(writer, reader); err != nil {
+			if err := copyZipFile(writer, reader, file.UncompressedSize64); err != nil {
 				reader.Close()
 				writer.Close()
 				return err
@@ -361,6 +362,7 @@ func (z *ZipPluginDecoder) ExtractTo(dst string) error {
 func safeExtractPath(dst, entryName string) (string, error) {
 	entryPath := path.Clean(entryName)
 	if entryPath == "." ||
+		entryPath == ".." ||
 		path.IsAbs(entryPath) ||
 		strings.HasPrefix(entryPath, "../") ||
 		strings.Contains(entryPath, "/../") ||
@@ -375,6 +377,22 @@ func safeExtractPath(dst, entryName string) (string, error) {
 	}
 
 	return targetPath, nil
+}
+
+func copyZipFile(writer io.Writer, reader io.Reader, uncompressedSize uint64) error {
+	if uncompressedSize > math.MaxInt64-1 {
+		return fmt.Errorf("zip entry is too large: %d bytes", uncompressedSize)
+	}
+
+	limit := int64(uncompressedSize) + 1
+	written, err := io.Copy(writer, io.LimitReader(reader, limit))
+	if err != nil {
+		return err
+	}
+	if written > int64(uncompressedSize) {
+		return fmt.Errorf("zip entry exceeds declared uncompressed size: %d bytes", uncompressedSize)
+	}
+	return nil
 }
 
 func pathIsInside(root, target string) bool {

--- a/pkg/plugin_packager/decoder/zip.go
+++ b/pkg/plugin_packager/decoder/zip.go
@@ -126,6 +126,9 @@ func (z *ZipPluginDecoder) Walk(fn func(filename string, dir string) error) erro
 	}
 
 	for _, file := range z.reader.File {
+		if file.FileInfo().IsDir() {
+			continue
+		}
 		// split the path into directory and filename
 		dir, filename := path.Split(file.Name)
 		if err := fn(filename, dir); err != nil {
@@ -169,7 +172,7 @@ func (z *ZipPluginDecoder) ReadDir(dirname string) ([]string, error) {
 	dirNameWithSlash := strings.TrimSuffix(dirname, "/") + "/"
 
 	for _, file := range z.reader.File {
-		if strings.HasPrefix(file.Name, dirNameWithSlash) {
+		if strings.HasPrefix(file.Name, dirNameWithSlash) && !file.FileInfo().IsDir() {
 			files = append(files, file.Name)
 		}
 	}
@@ -394,6 +397,13 @@ func copyZipFile(writer io.Writer, reader io.Reader, uncompressedSize uint64) er
 	}
 	if written > int64(uncompressedSize) {
 		return fmt.Errorf("zip entry exceeds declared uncompressed size: %d bytes", uncompressedSize)
+	}
+	if written != int64(uncompressedSize) {
+		return fmt.Errorf(
+			"zip entry ended before declared uncompressed size: expected %d bytes, got %d",
+			uncompressedSize,
+			written,
+		)
 	}
 	return nil
 }

--- a/pkg/plugin_packager/decoder/zip.go
+++ b/pkg/plugin_packager/decoder/zip.go
@@ -10,7 +10,6 @@ import (
 	"math"
 	"os"
 	"path"
-	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -305,46 +304,35 @@ func (z *ZipPluginDecoder) ExtractTo(dst string) error {
 	}
 
 	if err := func() error {
+		if err := os.MkdirAll(dst, 0755); err != nil {
+			return err
+		}
+
+		root, err := os.OpenRoot(dst)
+		if err != nil {
+			return err
+		}
+		defer root.Close()
+
 		for _, file := range z.reader.File {
-			targetPath, err := safeExtractPath(dst, file.Name)
+			entryPath, err := safeEntryPath(file.Name)
 			if err != nil {
 				return err
 			}
 
 			if file.FileInfo().IsDir() {
-				if err := os.MkdirAll(targetPath, 0755); err != nil {
+				if err := root.MkdirAll(entryPath, 0755); err != nil {
 					return err
 				}
 				continue
 			}
 
-			workingPath := filepath.Dir(targetPath)
 			// check if directory exists
-			if err := os.MkdirAll(workingPath, 0755); err != nil {
+			if err := root.MkdirAll(path.Dir(entryPath), 0755); err != nil {
 				return err
 			}
 
-			reader, err := file.Open()
-			if err != nil {
-				return err
-			}
-
-			writer, err := os.OpenFile(targetPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
-			if err != nil {
-				reader.Close()
-				return err
-			}
-
-			if err := copyZipFile(writer, reader, file.UncompressedSize64); err != nil {
-				reader.Close()
-				writer.Close()
-				return err
-			}
-			if err := reader.Close(); err != nil {
-				writer.Close()
-				return err
-			}
-			if err := writer.Close(); err != nil {
+			if err := extractZipFile(root, entryPath, file); err != nil {
 				return err
 			}
 		}
@@ -359,24 +347,39 @@ func (z *ZipPluginDecoder) ExtractTo(dst string) error {
 	return nil
 }
 
-func safeExtractPath(dst, entryName string) (string, error) {
+func safeEntryPath(entryName string) (string, error) {
+	if entryName == "" || strings.Contains(entryName, `\`) {
+		return "", fmt.Errorf("%w: %q", errUnsafeZipPath, entryName)
+	}
+
+	for _, part := range strings.Split(entryName, "/") {
+		if part == ".." {
+			return "", fmt.Errorf("%w: %q", errUnsafeZipPath, entryName)
+		}
+	}
+
 	entryPath := path.Clean(entryName)
-	if entryPath == "." ||
-		entryPath == ".." ||
-		path.IsAbs(entryPath) ||
-		strings.HasPrefix(entryPath, "../") ||
-		strings.Contains(entryPath, "/../") ||
-		strings.Contains(entryPath, `\`) ||
-		filepath.IsAbs(filepath.FromSlash(entryPath)) {
-		return "", fmt.Errorf("%w: %s", errUnsafeZipPath, entryName)
+	if entryPath == "." || path.IsAbs(entryPath) {
+		return "", fmt.Errorf("%w: %q", errUnsafeZipPath, entryName)
 	}
 
-	targetPath := filepath.Join(dst, filepath.FromSlash(entryPath))
-	if !pathIsInside(dst, targetPath) {
-		return "", fmt.Errorf("%w: %s", errUnsafeZipPath, entryName)
-	}
+	return entryPath, nil
+}
 
-	return targetPath, nil
+func extractZipFile(root *os.Root, entryPath string, file *zip.File) error {
+	reader, err := file.Open()
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+
+	writer, err := root.OpenFile(entryPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+	defer writer.Close()
+
+	return copyZipFile(writer, reader, file.UncompressedSize64)
 }
 
 func copyZipFile(writer io.Writer, reader io.Reader, uncompressedSize uint64) error {
@@ -393,22 +396,6 @@ func copyZipFile(writer io.Writer, reader io.Reader, uncompressedSize uint64) er
 		return fmt.Errorf("zip entry exceeds declared uncompressed size: %d bytes", uncompressedSize)
 	}
 	return nil
-}
-
-func pathIsInside(root, target string) bool {
-	rootAbs, err := filepath.Abs(root)
-	if err != nil {
-		return false
-	}
-	targetAbs, err := filepath.Abs(target)
-	if err != nil {
-		return false
-	}
-	rel, err := filepath.Rel(rootAbs, targetAbs)
-	if err != nil {
-		return false
-	}
-	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
 }
 
 func (z *ZipPluginDecoder) CheckAssetsValid() error {

--- a/pkg/plugin_packager/decoder/zip_extract_test.go
+++ b/pkg/plugin_packager/decoder/zip_extract_test.go
@@ -100,8 +100,8 @@ func TestZipPluginDecoderExtractToAllowsNestedPath(t *testing.T) {
 	assert.Equal(t, []byte("ok"), extracted)
 }
 
-func TestSafeExtractPathRejectsParentDirectoryEntry(t *testing.T) {
-	_, err := safeExtractPath(t.TempDir(), "..")
+func TestSafeEntryPathRejectsParentDirectoryEntry(t *testing.T) {
+	_, err := safeEntryPath("..")
 
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, errUnsafeZipPath))

--- a/pkg/plugin_packager/decoder/zip_extract_test.go
+++ b/pkg/plugin_packager/decoder/zip_extract_test.go
@@ -125,3 +125,33 @@ func TestCopyZipFileAllowsDeclaredSize(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "ok", out.String())
 }
+
+func TestZipPluginDecoderReadDirSkipsDirectoryEntries(t *testing.T) {
+	files := minimalPluginFiles(t)
+	files["nested/"] = nil
+	files["nested/file.txt"] = []byte("ok")
+
+	zipDecoder, err := NewZipPluginDecoder(buildZipPlugin(t, files))
+	require.NoError(t, err)
+
+	entries, err := zipDecoder.ReadDir("nested")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"nested/file.txt"}, entries)
+}
+
+func TestZipPluginDecoderWalkSkipsDirectoryEntries(t *testing.T) {
+	files := minimalPluginFiles(t)
+	files["nested/"] = nil
+	files["nested/file.txt"] = []byte("ok")
+
+	zipDecoder, err := NewZipPluginDecoder(buildZipPlugin(t, files))
+	require.NoError(t, err)
+
+	visited := make([]string, 0, 2)
+	err = zipDecoder.Walk(func(filename, dir string) error {
+		visited = append(visited, filepath.Join(dir, filename))
+		return nil
+	})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"manifest.yaml", "neko.yaml", filepath.Join("nested", "file.txt")}, visited)
+}

--- a/pkg/plugin_packager/decoder/zip_extract_test.go
+++ b/pkg/plugin_packager/decoder/zip_extract_test.go
@@ -1,0 +1,100 @@
+package decoder
+
+import (
+	"archive/zip"
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func buildZipPlugin(t *testing.T, files map[string][]byte) []byte {
+	t.Helper()
+
+	var buffer bytes.Buffer
+	zipWriter := zip.NewWriter(&buffer)
+	for name, content := range files {
+		if len(content) == 0 && strings.HasSuffix(name, "/") {
+			_, err := zipWriter.Create(name)
+			require.NoError(t, err)
+			continue
+		}
+
+		writer, err := zipWriter.Create(name)
+		require.NoError(t, err)
+		_, err = writer.Write(content)
+		require.NoError(t, err)
+	}
+	require.NoError(t, zipWriter.Close())
+
+	return buffer.Bytes()
+}
+
+func minimalPluginFiles(t *testing.T) map[string][]byte {
+	t.Helper()
+
+	manifest, err := os.ReadFile(filepath.Join("..", "testdata", "manifest.yaml"))
+	require.NoError(t, err)
+	endpoint, err := os.ReadFile(filepath.Join("..", "testdata", "neko.yaml"))
+	require.NoError(t, err)
+
+	return map[string][]byte{
+		"manifest.yaml": manifest,
+		"neko.yaml":     endpoint,
+	}
+}
+
+func TestZipPluginDecoderExtractToRejectsParentPath(t *testing.T) {
+	files := minimalPluginFiles(t)
+	files["../escaped.txt"] = []byte("escaped")
+
+	zipDecoder, err := NewZipPluginDecoder(buildZipPlugin(t, files))
+	require.NoError(t, err)
+
+	parent := t.TempDir()
+	dst := filepath.Join(parent, "plugin")
+	err = zipDecoder.ExtractTo(dst)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, errUnsafeZipPath))
+	assert.NoFileExists(t, filepath.Join(parent, "escaped.txt"))
+	assert.NoDirExists(t, dst)
+}
+
+func TestZipPluginDecoderExtractToRejectsBackslashPath(t *testing.T) {
+	files := minimalPluginFiles(t)
+	files[`..\escaped.txt`] = []byte("escaped")
+
+	zipDecoder, err := NewZipPluginDecoder(buildZipPlugin(t, files))
+	require.NoError(t, err)
+
+	parent := t.TempDir()
+	dst := filepath.Join(parent, "plugin")
+	err = zipDecoder.ExtractTo(dst)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, errUnsafeZipPath))
+	assert.NoFileExists(t, filepath.Join(parent, "escaped.txt"))
+	assert.NoDirExists(t, dst)
+}
+
+func TestZipPluginDecoderExtractToAllowsNestedPath(t *testing.T) {
+	files := minimalPluginFiles(t)
+	files["nested/"] = nil
+	files["nested/file.txt"] = []byte("ok")
+
+	zipDecoder, err := NewZipPluginDecoder(buildZipPlugin(t, files))
+	require.NoError(t, err)
+
+	dst := filepath.Join(t.TempDir(), "plugin")
+	require.NoError(t, zipDecoder.ExtractTo(dst))
+
+	extracted, err := os.ReadFile(filepath.Join(dst, "nested", "file.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, []byte("ok"), extracted)
+}

--- a/pkg/plugin_packager/decoder/zip_extract_test.go
+++ b/pkg/plugin_packager/decoder/zip_extract_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -97,4 +98,30 @@ func TestZipPluginDecoderExtractToAllowsNestedPath(t *testing.T) {
 	extracted, err := os.ReadFile(filepath.Join(dst, "nested", "file.txt"))
 	require.NoError(t, err)
 	assert.Equal(t, []byte("ok"), extracted)
+}
+
+func TestSafeExtractPathRejectsParentDirectoryEntry(t *testing.T) {
+	_, err := safeExtractPath(t.TempDir(), "..")
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, errUnsafeZipPath))
+}
+
+func TestCopyZipFileRejectsContentBeyondDeclaredSize(t *testing.T) {
+	var out bytes.Buffer
+
+	err := copyZipFile(&out, strings.NewReader("toolarge"), 3)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds declared uncompressed size")
+	assert.Equal(t, "tool", out.String())
+}
+
+func TestCopyZipFileAllowsDeclaredSize(t *testing.T) {
+	var out bytes.Buffer
+
+	err := copyZipFile(&out, io.NopCloser(strings.NewReader("ok")), 2)
+
+	require.NoError(t, err)
+	assert.Equal(t, "ok", out.String())
 }


### PR DESCRIPTION
## Summary
- validate zip entry paths before extracting plugin packages
- reject parent-directory and backslash paths so entries cannot escape the target working directory
- preserve normal nested file extraction, including packages with explicit directory entries

## Tests
- `go test ./pkg/plugin_packager/decoder ./pkg/plugin_packager/packager`

Notes:
- `go test ./pkg/plugin_packager` is blocked locally because `pkg/license/private_key/PRIVATE_KEY.pem` is not present in the checkout.
- `go test -race ./pkg/plugin_packager/decoder` is blocked locally because the current Go environment has cgo disabled.