### PR TITLE
refactor!: Remove obsolete polling suspension fields from request protocol

### DIFF
--- a/pkg/entities/requests/model.go
+++ b/pkg/entities/requests/model.go
@@ -186,17 +186,12 @@ type RequestGetAIModelSchema struct {
 
 type RequestStartPolling struct {
 	RequestInvokeLLM
-
-	WorkflowRunID string `json:"workflow_run_id" validate:"required"`
-	NodeID        string `json:"node_id" validate:"required"`
 }
 
 type RequestCheckPolling struct {
 	BaseRequestInvokeModel
 	Credentials
 
-	ModelType     model_entities.ModelType `json:"model_type" validate:"required,model_type,eq=llm"`
-	WorkflowRunID string                   `json:"workflow_run_id" validate:"required"`
-	NodeID        string                   `json:"node_id" validate:"required"`
-	PluginState   map[string]any           `json:"plugin_state" validate:"required,min=1"`
+	ModelType   model_entities.ModelType `json:"model_type" validate:"required,model_type,eq=llm"`
+	PluginState map[string]any           `json:"plugin_state" validate:"required,min=1"`
 }

--- a/pkg/entities/requests/model_polling_test.go
+++ b/pkg/entities/requests/model_polling_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-playground/validator/v10"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/model_entities"
+	"github.com/langgenius/dify-plugin-daemon/pkg/utils/parser"
 	"github.com/langgenius/dify-plugin-daemon/pkg/validators"
 )
 
@@ -116,5 +117,86 @@ func TestRequestCheckPollingAcceptsPluginState(t *testing.T) {
 	}
 	if request.PluginState["task_id"] != "task-1" {
 		t.Fatalf("unexpected plugin_state: %#v", request.PluginState)
+	}
+}
+
+func TestPollingRequestMapExcludesSuspensionFields(t *testing.T) {
+	startPolling := RequestStartPolling{
+		RequestInvokeLLM: RequestInvokeLLM{
+			BaseRequestInvokeModel: BaseRequestInvokeModel{
+				Provider: "volcengine",
+				Model:    "doubao-seedance-2-0-260128",
+			},
+			Credentials: Credentials{
+				Credentials: map[string]any{"ark_api_key": "test"},
+			},
+			InvokeLLMSchema: InvokeLLMSchema{
+				Stream: true,
+			},
+			ModelType: model_entities.MODEL_TYPE_LLM,
+		},
+	}
+
+	assertPollingRequestMapShape(t, parser.StructToMap(startPolling), false)
+
+	checkPolling := RequestCheckPolling{
+		BaseRequestInvokeModel: BaseRequestInvokeModel{
+			Provider: "volcengine",
+			Model:    "doubao-seedance-2-0-260128",
+		},
+		Credentials: Credentials{
+			Credentials: map[string]any{"ark_api_key": "test"},
+		},
+		ModelType:   model_entities.MODEL_TYPE_LLM,
+		PluginState: map[string]any{"task_id": "task-1"},
+	}
+
+	assertPollingRequestMapShape(t, parser.StructToMap(checkPolling), true)
+}
+
+func assertPollingRequestMapShape(t *testing.T, result map[string]any, expectPluginState bool) {
+	t.Helper()
+
+	if _, ok := result["workflow_run_id"]; ok {
+		t.Fatal("workflow_run_id should not be present in polling request map")
+	}
+	if _, ok := result["node_id"]; ok {
+		t.Fatal("node_id should not be present in polling request map")
+	}
+
+	if result["provider"] != "volcengine" {
+		t.Fatalf("provider should be volcengine, got %#v", result["provider"])
+	}
+	if result["model"] != "doubao-seedance-2-0-260128" {
+		t.Fatalf("model should be present, got %#v", result["model"])
+	}
+	if result["model_type"] != model_entities.MODEL_TYPE_LLM {
+		t.Fatalf("model_type should be llm, got %#v", result["model_type"])
+	}
+
+	credentials, ok := result["credentials"].(map[string]any)
+	if !ok {
+		t.Fatalf("credentials should be a map, got %T", result["credentials"])
+	}
+	if credentials["ark_api_key"] != "test" {
+		t.Fatalf("credentials should contain ark_api_key, got %#v", credentials)
+	}
+
+	if expectPluginState {
+		pluginState, ok := result["plugin_state"].(map[string]any)
+		if !ok {
+			t.Fatalf("plugin_state should be a map, got %T", result["plugin_state"])
+		}
+		if pluginState["task_id"] != "task-1" {
+			t.Fatalf("plugin_state should contain task_id, got %#v", pluginState)
+		}
+		return
+	}
+
+	if _, ok := result["plugin_state"]; ok {
+		t.Fatal("plugin_state should not be present in start polling request map")
+	}
+	if stream, ok := result["stream"].(bool); !ok || !stream {
+		t.Fatalf("stream should be true, got %#v", result["stream"])
 	}
 }

--- a/pkg/entities/requests/model_polling_test.go
+++ b/pkg/entities/requests/model_polling_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/go-playground/validator/v10"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/model_entities"
 	"github.com/langgenius/dify-plugin-daemon/pkg/validators"
 )
@@ -39,9 +40,24 @@ func TestRequestCheckPollingRequiresPluginState(t *testing.T) {
 		t.Fatalf("unmarshal request: %v", err)
 	}
 
-	if err := validators.GlobalEntitiesValidator.Struct(request); err == nil {
-		t.Fatal("expected missing plugin_state validation error")
+	if err := validators.GlobalEntitiesValidator.Struct(request); err != nil {
+		validationErrors, ok := err.(validator.ValidationErrors)
+		if !ok {
+			t.Fatalf("unexpected validation error type: %T: %v", err, err)
+		}
+		if len(validationErrors) != 1 {
+			t.Fatalf("expected 1 validation error, got %d: %v", len(validationErrors), validationErrors)
+		}
+		validationError := validationErrors[0]
+		if validationError.Field() != "PluginState" {
+			t.Fatalf("unexpected field: %s", validationError.Field())
+		}
+		if validationError.Tag() != "required" {
+			t.Fatalf("unexpected tag: %s", validationError.Tag())
+		}
+		return
 	}
+	t.Fatal("expected missing plugin_state validation error")
 }
 
 func TestRequestCheckPollingRejectsEmptyPluginState(t *testing.T) {
@@ -58,9 +74,24 @@ func TestRequestCheckPollingRejectsEmptyPluginState(t *testing.T) {
 		t.Fatalf("unmarshal request: %v", err)
 	}
 
-	if err := validators.GlobalEntitiesValidator.Struct(request); err == nil {
-		t.Fatal("expected empty plugin_state validation error")
+	if err := validators.GlobalEntitiesValidator.Struct(request); err != nil {
+		validationErrors, ok := err.(validator.ValidationErrors)
+		if !ok {
+			t.Fatalf("unexpected validation error type: %T: %v", err, err)
+		}
+		if len(validationErrors) != 1 {
+			t.Fatalf("expected 1 validation error, got %d: %v", len(validationErrors), validationErrors)
+		}
+		validationError := validationErrors[0]
+		if validationError.Field() != "PluginState" {
+			t.Fatalf("unexpected field: %s", validationError.Field())
+		}
+		if validationError.Tag() != "min" {
+			t.Fatalf("unexpected tag: %s", validationError.Tag())
+		}
+		return
 	}
+	t.Fatal("expected empty plugin_state validation error")
 }
 
 func TestRequestCheckPollingAcceptsPluginState(t *testing.T) {

--- a/pkg/entities/requests/model_polling_test.go
+++ b/pkg/entities/requests/model_polling_test.go
@@ -8,14 +8,30 @@ import (
 	"github.com/langgenius/dify-plugin-daemon/pkg/validators"
 )
 
+func TestRequestStartPollingDoesNotRequireSuspensionFields(t *testing.T) {
+	payload := []byte(`{
+		"provider": "volcengine",
+		"model": "doubao-seedance-2-0-260128",
+		"model_type": "llm",
+		"credentials": {"ark_api_key": "test"}
+	}`)
+
+	var request RequestStartPolling
+	if err := json.Unmarshal(payload, &request); err != nil {
+		t.Fatalf("unmarshal request: %v", err)
+	}
+
+	if err := validators.GlobalEntitiesValidator.Struct(request); err != nil {
+		t.Fatalf("validate request: %v", err)
+	}
+}
+
 func TestRequestCheckPollingRequiresPluginState(t *testing.T) {
 	payload := []byte(`{
 		"provider": "volcengine",
 		"model": "doubao-seedance-2-0-260128",
 		"model_type": "llm",
-		"credentials": {"ark_api_key": "test"},
-		"workflow_run_id": "wr-1",
-		"node_id": "llm-1"
+		"credentials": {"ark_api_key": "test"}
 	}`)
 
 	var request RequestCheckPolling
@@ -34,8 +50,6 @@ func TestRequestCheckPollingRejectsEmptyPluginState(t *testing.T) {
 		"model": "doubao-seedance-2-0-260128",
 		"model_type": "llm",
 		"credentials": {"ark_api_key": "test"},
-		"workflow_run_id": "wr-1",
-		"node_id": "llm-1",
 		"plugin_state": {}
 	}`)
 
@@ -55,8 +69,6 @@ func TestRequestCheckPollingAcceptsPluginState(t *testing.T) {
 		"model": "doubao-seedance-2-0-260128",
 		"model_type": "llm",
 		"credentials": {"ark_api_key": "test"},
-		"workflow_run_id": "wr-1",
-		"node_id": "llm-1",
 		"plugin_state": {"task_id": "task-1"}
 	}`)
 


### PR DESCRIPTION
**AI disclosure**: This PR was primarily drafted with Codex using GPT-5.4.
I have reviewed and edited the final diff, and I am responsible for the content.

Closes #758

## Summary
- remove `workflow_run_id` and `node_id` from `RequestStartPolling` and `RequestCheckPolling`
- update polling request validation tests so those fields are no longer part of the expected contract
- add a regression test for the serialized polling request shape to ensure the obsolete fields are no longer sent to plugins

## Why
Graphon removed these fields in [langgenius/graphon#184](https://github.com/langgenius/graphon/pull/184), following [langgenius/graphon#183](https://github.com/langgenius/graphon/issues/183).

After [langgenius/graphon#151](https://github.com/langgenius/graphon/pull/151), the polling flow no longer depends on suspension context and runs to completion without `workflow_run_id` / `node_id`. Keeping these fields required in `plugin-daemon` leaves the daemon-side protocol stricter than the upstream caller.

## Notes
- `plugin-daemon` still keeps `plugin_state` required for check-polling
- older callers that still send the removed fields remain tolerated because unknown input fields are ignored at the binding boundary

## Validation
- `GOCACHE=/private/tmp/gocache go test ./pkg/entities/requests ./pkg/entities/model_entities ./pkg/utils/parser`
