### PR TITLE
fix(local-runtime): recover stopped plugin instances

### DIFF
--- a/internal/core/io_tunnel/generic.go
+++ b/internal/core/io_tunnel/generic.go
@@ -3,14 +3,26 @@ package io_tunnel
 import (
 	"errors"
 	"fmt"
+	"sync"
+	"time"
 
 	"github.com/langgenius/dify-plugin-daemon/internal/core/io_tunnel/backwards_invocation"
 	"github.com/langgenius/dify-plugin-daemon/internal/core/io_tunnel/backwards_invocation/transaction"
+	"github.com/langgenius/dify-plugin-daemon/internal/core/local_runtime"
 	"github.com/langgenius/dify-plugin-daemon/internal/core/session_manager"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/plugin_entities"
 	"github.com/langgenius/dify-plugin-daemon/pkg/utils/parser"
 	"github.com/langgenius/dify-plugin-daemon/pkg/utils/stream"
 )
+
+const (
+	writeRetryBudget   = 6 * time.Second
+	writeRetryInterval = 300 * time.Millisecond
+)
+
+func isRecoverableWriteErr(err error) bool {
+	return errors.Is(err, local_runtime.ErrNoProperInstance) || local_runtime.IsInstanceDeadErr(err)
+}
 
 func GenericInvokePlugin[Req any, Rsp any](
 	session *session_manager.Session,
@@ -27,13 +39,11 @@ func GenericInvokePlugin[Req any, Rsp any](
 	}
 
 	response := stream.NewStream[Rsp](response_buffer_size)
-	listener, err := runtime.Listen(session.ID)
-	if err != nil {
-		recorder.record(pluginInvocationOutcomeError)
-		return nil, err
-	}
+	response.OnClose(func() {
+		recorder.record(outcome.outcome())
+	})
 
-	listener.Listen(func(chunk plugin_entities.SessionMessage) {
+	onChunk := func(chunk plugin_entities.SessionMessage) {
 		switch chunk.Type {
 		case plugin_entities.SESSION_MESSAGE_TYPE_STREAM:
 			chunk, err := parser.UnmarshalJsonBytes[Rsp](chunk.Data)
@@ -92,28 +102,43 @@ func GenericInvokePlugin[Req any, Rsp any](
 			})))
 			response.Close()
 		}
-	})
-
-	// close the listener if stream outside is closed due to close of connection
-	response.OnClose(func() {
-		listener.Close()
-	})
-	response.OnClose(func() {
-		recorder.record(outcome.outcome())
-	})
-
-	if err := session.Write(
-		session_manager.PLUGIN_IN_STREAM_EVENT_REQUEST,
-		session.Action,
-		GetInvokePluginMap(
-			session,
-			request,
-		),
-	); err != nil {
-		listener.Close()
-		recorder.record(pluginInvocationOutcomeError)
-		return nil, errors.Join(err, errors.New("failed to write request"))
 	}
 
-	return response, nil
+	pluginMap := GetInvokePluginMap(
+		session,
+		request,
+	)
+
+	isLocal := runtime.Type() == plugin_entities.PLUGIN_RUNTIME_TYPE_LOCAL
+	deadline := time.Now().Add(writeRetryBudget)
+	for {
+		listener, err := runtime.Listen(session.ID)
+		if err == nil {
+			var closeOnce sync.Once
+			closeListener := func() {
+				closeOnce.Do(listener.Close)
+			}
+
+			listener.Listen(onChunk)
+
+			err = session.Write(
+				session_manager.PLUGIN_IN_STREAM_EVENT_REQUEST,
+				session.Action,
+				pluginMap,
+			)
+			if err == nil {
+				response.OnClose(closeListener)
+				return response, nil
+			}
+
+			closeListener()
+		}
+
+		if !isLocal || !isRecoverableWriteErr(err) || time.Now().After(deadline) {
+			recorder.record(pluginInvocationOutcomeError)
+			return nil, errors.Join(err, errors.New("failed to write request"))
+		}
+
+		time.Sleep(writeRetryInterval)
+	}
 }

--- a/internal/core/local_runtime/constructor.go
+++ b/internal/core/local_runtime/constructor.go
@@ -45,6 +45,7 @@ func ConstructPluginRuntime(
 			Decoder: pluginDecoder,
 		},
 		scheduleStatus:               ScheduleStatusStopped,
+		scheduleKick:                 make(chan struct{}, 1),
 		defaultPythonInterpreterPath: appConfig.PythonInterpreterPath,
 		uvPath:                       appConfig.UvPath,
 		appConfig:                    appConfig,
@@ -53,10 +54,10 @@ func ConstructPluginRuntime(
 		instanceLocker: &sync.RWMutex{},
 
 		notifiers:    []PluginRuntimeNotifier{},
-			notifierLock: &sync.Mutex{},
-			traceCtx:     nil,
-		}
-		return runtime, nil
+		notifierLock: &sync.Mutex{},
+		traceCtx:     nil,
+	}
+	return runtime, nil
 }
 
 // generate plugin working path using author/name@checksum, but replace : with -

--- a/internal/core/local_runtime/constructor_slim.go
+++ b/internal/core/local_runtime/constructor_slim.go
@@ -31,6 +31,7 @@ func NewLocalPluginRuntime(
 			Decoder: pluginDecoder,
 		},
 		scheduleStatus:               ScheduleStatusStopped,
+		scheduleKick:                 make(chan struct{}, 1),
 		defaultPythonInterpreterPath: appConfig.PythonInterpreterPath,
 		uvPath:                       appConfig.UvPath,
 		appConfig:                    appConfig,

--- a/internal/core/local_runtime/control.go
+++ b/internal/core/local_runtime/control.go
@@ -1,10 +1,12 @@
 package local_runtime
 
 import (
+	"slices"
 	"sync/atomic"
 	"time"
 
 	routinepkg "github.com/langgenius/dify-plugin-daemon/pkg/routine"
+	"github.com/langgenius/dify-plugin-daemon/pkg/utils/log"
 	"github.com/langgenius/dify-plugin-daemon/pkg/utils/routine"
 )
 
@@ -47,12 +49,24 @@ func (r *LocalPluginRuntime) ScaleDown() {
 func (r *LocalPluginRuntime) scheduleLoop() {
 	// once it's not match, scale it
 	ticker := time.NewTicker(ScheduleLoopInterval)
+	defer ticker.Stop()
 
 	for atomic.LoadInt32(&r.scheduleStatus) == ScheduleStatusRunning {
 		// check if the instance nums is match
-		r.instanceLocker.RLock()
+		r.instanceLocker.Lock()
+		removed := r.pruneStoppedInstancesLocked()
 		currentInstanceNums := len(r.instances)
-		r.instanceLocker.RUnlock()
+		r.instanceLocker.Unlock()
+
+		if removed > 0 {
+			log.Warn(
+				"pruned stopped local plugin instances",
+				"plugin", r.Config.Identity(),
+				"removed", removed,
+				"live_instances", currentInstanceNums,
+				"expected_instances", atomic.LoadInt32(&r.instanceNums),
+			)
+		}
 
 		// if the current instance nums is less than the expected instance nums, start a new instance
 		if currentInstanceNums < int(r.instanceNums) {
@@ -78,12 +92,12 @@ func (r *LocalPluginRuntime) scheduleLoop() {
 			}
 		}
 
-		// wait for the next tick
-		// this waiting must be done after all the schedule logic
-		<-ticker.C
+		// wait for the next tick or an explicit kick after a dead instance is evicted.
+		select {
+		case <-ticker.C:
+		case <-r.scheduleKick:
+		}
 	}
-
-	ticker.Stop()
 
 	// notify callers that the runtime is not running anymore
 	r.WalkNotifiers(func(notifier PluginRuntimeNotifier) {
@@ -97,6 +111,24 @@ func (r *LocalPluginRuntime) scheduleLoop() {
 	r.WalkNotifiers(func(notifier PluginRuntimeNotifier) {
 		notifier.OnRuntimeClose()
 	})
+}
+
+func (r *LocalPluginRuntime) nudgeSchedule() {
+	if r.scheduleKick == nil {
+		return
+	}
+	select {
+	case r.scheduleKick <- struct{}{}:
+	default:
+	}
+}
+
+func (r *LocalPluginRuntime) pruneStoppedInstancesLocked() int {
+	before := len(r.instances)
+	r.instances = slices.DeleteFunc(r.instances, func(instance *PluginInstance) bool {
+		return instance.IsStopped()
+	})
+	return before - len(r.instances)
 }
 
 func (r *LocalPluginRuntime) stopSchedule() {
@@ -153,9 +185,10 @@ func (r *LocalPluginRuntime) GracefulStop(async bool) {
 // forcefully shutdown all instances, it's a async method which will not block
 func (r *LocalPluginRuntime) forcefullyShutdownAllInstances() {
 	for {
-		r.instanceLocker.RLock()
+		r.instanceLocker.Lock()
+		r.pruneStoppedInstancesLocked()
 		instances := r.instances
-		r.instanceLocker.RUnlock()
+		r.instanceLocker.Unlock()
 		if len(instances) == 0 {
 			break
 		}
@@ -172,9 +205,10 @@ func (r *LocalPluginRuntime) forcefullyShutdownAllInstances() {
 // otherwise new instances are going to start
 func (r *LocalPluginRuntime) stopAndWaitForAllInstancesToBeShutdown() {
 	for {
-		r.instanceLocker.RLock()
+		r.instanceLocker.Lock()
+		r.pruneStoppedInstancesLocked()
 		instances := r.instances
-		r.instanceLocker.RUnlock()
+		r.instanceLocker.Unlock()
 		if len(instances) == 0 {
 			break
 		}
@@ -190,7 +224,14 @@ func (r *LocalPluginRuntime) waitForAllInstancesToBeShutdown() {
 	ticker := time.NewTicker(time.Second * 1)
 	defer ticker.Stop()
 
-	for len(r.instances) > 0 {
+	for {
+		r.instanceLocker.Lock()
+		r.pruneStoppedInstancesLocked()
+		remaining := len(r.instances)
+		r.instanceLocker.Unlock()
+		if remaining == 0 {
+			return
+		}
 		<-ticker.C
 	}
 }

--- a/internal/core/local_runtime/exec.go
+++ b/internal/core/local_runtime/exec.go
@@ -18,4 +18,7 @@ var (
 
 	// Runtime is not active
 	ErrRuntimeNotActive = errors.New("runtime is not active")
+
+	// Instance is already stopped and cannot accept new requests
+	ErrInstanceStopped = errors.New("plugin instance stopped")
 )

--- a/internal/core/local_runtime/instance.go
+++ b/internal/core/local_runtime/instance.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os/exec"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -33,6 +34,8 @@ type PluginInstance struct {
 
 	started  bool // mark the instance as started, it will be set to true when the first heartbeat is received
 	shutdown bool // mark the instance as shutdown, it will be set to true when stdout reader is closed
+	stopped  atomic.Bool
+	writeMu  sync.Mutex
 
 	// app config
 	appConfig *app.Config
@@ -105,6 +108,9 @@ func (s *PluginInstance) Error() error {
 
 // Stop stops the stdio, of course, it will shutdown the plugin asynchronously
 func (s *PluginInstance) Stop() {
+	if !s.stopped.CompareAndSwap(false, true) {
+		return
+	}
 	s.inWriter.Close()
 	s.outReader.Close()
 	s.errReader.Close()
@@ -125,6 +131,7 @@ func (s *PluginInstance) Stop() {
 // Once the subprocess exists itself, STDOUT always close, which results in `CLOSE STDOUT`
 func (s *PluginInstance) StartStdout() {
 	defer func() {
+		s.stopped.Store(true)
 		log.Info(
 			"plugin stdout reader exiting",
 			"plugin", s.pluginUniqueIdentifier,
@@ -368,9 +375,26 @@ func (s *PluginInstance) Monitor() error {
 }
 
 func (s *PluginInstance) Write(data []byte) error {
+	if s.IsStopped() {
+		return ErrInstanceStopped
+	}
+
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
 	// write bytes into instance's stdin
-	_, err := s.inWriter.Write(data)
-	return err
+	n, err := s.inWriter.Write(data)
+	if err != nil {
+		return err
+	}
+	if n < len(data) {
+		return io.ErrShortWrite
+	}
+	return nil
+}
+
+func (s *PluginInstance) IsStopped() bool {
+	return s.stopped.Load()
 }
 
 // GracefulStop stops the instance gracefully

--- a/internal/core/local_runtime/instance.go
+++ b/internal/core/local_runtime/instance.go
@@ -35,7 +35,6 @@ type PluginInstance struct {
 	started  bool // mark the instance as started, it will be set to true when the first heartbeat is received
 	shutdown bool // mark the instance as shutdown, it will be set to true when stdout reader is closed
 	stopped  atomic.Bool
-	writeMu  sync.Mutex
 
 	// app config
 	appConfig *app.Config
@@ -378,9 +377,6 @@ func (s *PluginInstance) Write(data []byte) error {
 	if s.IsStopped() {
 		return ErrInstanceStopped
 	}
-
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
 
 	// write bytes into instance's stdin
 	n, err := s.inWriter.Write(data)

--- a/internal/core/local_runtime/instance_recovery_test.go
+++ b/internal/core/local_runtime/instance_recovery_test.go
@@ -1,0 +1,69 @@
+package local_runtime
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"syscall"
+	"testing"
+)
+
+func TestIsInstanceDeadErr(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "instance stopped", err: ErrInstanceStopped, want: true},
+		{name: "wrapped closed file", err: fmt.Errorf("write stdin: %w", os.ErrClosed), want: true},
+		{name: "closed pipe", err: io.ErrClosedPipe, want: true},
+		{name: "short write", err: io.ErrShortWrite, want: true},
+		{name: "broken pipe", err: syscall.EPIPE, want: true},
+		{name: "closed file message", err: errors.New("write |1: file already closed"), want: true},
+		{name: "other error", err: errors.New("temporary network timeout"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsInstanceDeadErr(tt.err); got != tt.want {
+				t.Fatalf("IsInstanceDeadErr() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPickLowestLoadInstanceSkipsStoppedInstances(t *testing.T) {
+	stopped := &PluginInstance{instanceId: "stopped"}
+	stopped.stopped.Store(true)
+	live := &PluginInstance{instanceId: "live"}
+	runtime := &LocalPluginRuntime{
+		instances:      []*PluginInstance{stopped, live},
+		instanceLocker: &sync.RWMutex{},
+	}
+
+	for i := 0; i < 4; i++ {
+		instance, err := runtime.pickLowestLoadInstance()
+		if err != nil {
+			t.Fatalf("pickLowestLoadInstance() error = %v", err)
+		}
+		if instance != live {
+			t.Fatalf("pickLowestLoadInstance() = %q, want live instance", instance.instanceId)
+		}
+	}
+}
+
+func TestPickLowestLoadInstanceReturnsErrWhenAllInstancesStopped(t *testing.T) {
+	stopped := &PluginInstance{instanceId: "stopped"}
+	stopped.stopped.Store(true)
+	runtime := &LocalPluginRuntime{
+		instances:      []*PluginInstance{stopped},
+		instanceLocker: &sync.RWMutex{},
+	}
+
+	if _, err := runtime.pickLowestLoadInstance(); !errors.Is(err, ErrNoProperInstance) {
+		t.Fatalf("pickLowestLoadInstance() error = %v, want %v", err, ErrNoProperInstance)
+	}
+}

--- a/internal/core/local_runtime/io.go
+++ b/internal/core/local_runtime/io.go
@@ -1,12 +1,36 @@
 package local_runtime
 
 import (
+	"errors"
+	"io"
+	"os"
+	"slices"
+	"strings"
+	"syscall"
+
 	"github.com/langgenius/dify-plugin-daemon/internal/core/io_tunnel/access_types"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/plugin_entities"
 	"github.com/langgenius/dify-plugin-daemon/pkg/utils/log"
 	"github.com/langgenius/dify-plugin-daemon/pkg/utils/parser"
 )
+
+func IsInstanceDeadErr(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	if errors.Is(err, ErrInstanceStopped) ||
+		errors.Is(err, os.ErrClosed) ||
+		errors.Is(err, syscall.EPIPE) ||
+		errors.Is(err, io.ErrClosedPipe) ||
+		errors.Is(err, io.ErrShortWrite) {
+		return true
+	}
+
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "file already closed") || strings.Contains(msg, "broken pipe")
+}
 
 func (r *LocalPluginRuntime) Listen(sessionId string) (
 	*entities.Broadcast[plugin_entities.SessionMessage], error,
@@ -52,5 +76,39 @@ func (r *LocalPluginRuntime) Write(
 	}
 
 	// write to the instance
-	return instance.Write(append(data, '\n'))
+	err := instance.Write(append(data, '\n'))
+	if err == nil {
+		return nil
+	}
+
+	if IsInstanceDeadErr(err) {
+		instance.Stop()
+
+		r.instanceLocker.Lock()
+		before := len(r.instances)
+		r.instances = slices.DeleteFunc(r.instances, func(item *PluginInstance) bool {
+			return item.instanceId == instance.instanceId
+		})
+		after := len(r.instances)
+		if after == 0 {
+			r.SetRestarting()
+		}
+		r.instanceLocker.Unlock()
+
+		r.sessionToInstanceMap.Delete(sessionId)
+		r.nudgeSchedule()
+
+		log.Warn(
+			"evict dead local plugin instance after write failure",
+			"plugin", r.Config.Identity(),
+			"instance", instance.ID()[:8],
+			"session", sessionId,
+			"action", action,
+			"instances_before", before,
+			"instances_after", after,
+			"error", err,
+		)
+	}
+
+	return err
 }

--- a/internal/core/local_runtime/load_balancing.go
+++ b/internal/core/local_runtime/load_balancing.go
@@ -13,7 +13,14 @@ func (r *LocalPluginRuntime) pickLowestLoadInstance() (*PluginInstance, error) {
 		return nil, ErrNoProperInstance
 	}
 
-	// Just a round robin
-	idx := atomic.AddInt64(&r.roundRobinIndex, 1)
-	return r.instances[idx%int64(len(r.instances))], nil
+	// Just a round robin, skipping instances already known as stopped.
+	for i := 0; i < len(r.instances); i++ {
+		idx := atomic.AddInt64(&r.roundRobinIndex, 1)
+		instance := r.instances[uint64(idx)%uint64(len(r.instances))]
+		if !instance.IsStopped() {
+			return instance, nil
+		}
+	}
+
+	return nil, ErrNoProperInstance
 }

--- a/internal/core/local_runtime/subprocess.go
+++ b/internal/core/local_runtime/subprocess.go
@@ -156,6 +156,9 @@ func (r *LocalPluginRuntime) startNewInstance() error {
 				return instance.instanceId == pi.instanceId
 			})
 			after := len(r.instances)
+			if after == 0 {
+				r.SetRestarting()
+			}
 			r.instanceLocker.Unlock()
 			log.Warn(
 				"local runtime instance shutdown",

--- a/internal/core/local_runtime/type.go
+++ b/internal/core/local_runtime/type.go
@@ -42,6 +42,7 @@ type LocalPluginRuntime struct {
 
 	// schedule status
 	scheduleStatus int32
+	scheduleKick   chan struct{}
 
 	// notifier
 	notifiers    []PluginRuntimeNotifier


### PR DESCRIPTION
## Description

Fixes #765

This pull request fixes a local runtime recovery issue where plugin-daemon can continue routing requests to a local plugin instance after that instance's stdio pipes have already been closed.

When this happens, dispatch fails before the request reaches the plugin process, for example:

```text
PluginDaemonInternalServerError: write |1: file already closed
failed to write request
```

The root cause is that stopped local plugin instances are removed from the runtime instance pool asynchronously. During that gap, the load balancer can still select the stale instance, and the write path can still attempt to write to its closed stdin pipe.

This PR makes the local runtime recover from that state by:

- marking `PluginInstance` as stopped synchronously when stdio is closed or stdout exits
- skipping stopped instances during local runtime load balancing
- evicting dead instances when stdin writes fail with closed-pipe style errors
- waking the scheduler after eviction so replacement instances can be started promptly
- retrying local write-before-dispatch failures within a small bounded window
- serializing writes to a plugin instance's stdin to avoid interleaved payloads from concurrent sessions

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Other

## Essential Checklist

### Testing

- [x] I have tested the changes locally and confirmed they work as expected
- [x] I have added unit tests where necessary and they pass successfully

### Bug Fix (if applicable)

- [x] I have used GitHub syntax to close the related issue (e.g., `Fixes #123` or `Closes #123`)

## Additional Information

Local validation:

- `go test ./internal/core/local_runtime/... ./internal/core/io_tunnel/...`
- `go build ./cmd/server`

The change is limited to local plugin runtime instance lifecycle, load balancing, stdin write handling, and write-before-dispatch retry behavior. It does not change serverless runtime behavior.
