### PR TITLE
fix: fallback to lowercase proxy env vars (http_proxy, https_proxy, no_proxy)

### DIFF
--- a/internal/types/app/default.go
+++ b/internal/types/app/default.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"os"
+
 	"github.com/langgenius/dify-cloud-kit/oss"
 	"golang.org/x/exp/constraints"
 )
@@ -47,6 +49,18 @@ func (config *Config) SetDefault() {
 		setDefaultString(&config.DBDefaultDatabase, "postgres")
 	case DB_TYPE_MYSQL:
 		setDefaultString(&config.DBDefaultDatabase, "mysql")
+	}
+
+	// Fallback to lowercase proxy env vars if uppercase ones are not set.
+	// Many Linux environments use lowercase http_proxy/https_proxy/no_proxy.
+	if config.HttpProxy == "" {
+		config.HttpProxy = os.Getenv("http_proxy")
+	}
+	if config.HttpsProxy == "" {
+		config.HttpsProxy = os.Getenv("https_proxy")
+	}
+	if config.NoProxy == "" {
+		config.NoProxy = os.Getenv("no_proxy")
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes [#18752](https://github.com/langgenius/dify-plugin-daemon/issues/18752)

## Problem

`plugin_daemon` only reads proxy environment variables in uppercase (`HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`) via `envconfig`. In many Linux environments, these are conventionally set in lowercase (`http_proxy`, `https_proxy`, `no_proxy`). When users set only the lowercase variants, `plugin_daemon` ignores them, leading to nil pointer dereference when trying to use the empty proxy values.

## Fix

Added fallback logic in `Config.SetDefault()` that reads lowercase environment variables when the uppercase ones are empty:

- `HttpProxy` → falls back to `os.Getenv("http_proxy")`
- `HttpsProxy` → falls back to `os.Getenv("https_proxy")`  
- `NoProxy` → falls back to `os.Getenv("no_proxy")`

The uppercase `envconfig` binding takes priority; lowercase is only used as a fallback when uppercase is empty. This maintains backward compatibility while supporting the common lowercase convention.

## Changes

- `internal/types/app/default.go`: Added `"os"` import and fallback logic in `SetDefault()`