### PR TITLE
fix: prefer debug runtime in serverless mode

### DIFF
--- a/internal/core/plugin_manager/runtime.go
+++ b/internal/core/plugin_manager/runtime.go
@@ -1,6 +1,9 @@
 package plugin_manager
 
 import (
+	"errors"
+
+	controlpanel "github.com/langgenius/dify-plugin-daemon/internal/core/control_panel"
 	"github.com/langgenius/dify-plugin-daemon/internal/types/app"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/plugin_entities"
 )
@@ -9,11 +12,19 @@ import (
 func (p *PluginManager) GetPluginRuntime(
 	pluginUniqueIdentifier plugin_entities.PluginUniqueIdentifier,
 ) (plugin_entities.PluginRuntimeSessionIOInterface, error) {
+	runtime, err := p.controlPanel.GetPluginRuntime(pluginUniqueIdentifier)
+	if err == nil {
+		return runtime, nil
+	}
+	if !errors.Is(err, controlpanel.ErrPluginRuntimeNotFound) {
+		return nil, err
+	}
+
 	if p.config.Platform == app.PLATFORM_SERVERLESS {
 		return p.getServerlessPluginRuntime(pluginUniqueIdentifier)
 	}
 
-	return p.controlPanel.GetPluginRuntime(pluginUniqueIdentifier)
+	return nil, err
 }
 
 func (p *PluginManager) RemoveLocalPlugin(

--- a/internal/core/plugin_manager/runtime_test.go
+++ b/internal/core/plugin_manager/runtime_test.go
@@ -1,0 +1,58 @@
+package plugin_manager
+
+import (
+	"reflect"
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/require"
+
+	controlpanel "github.com/langgenius/dify-plugin-daemon/internal/core/control_panel"
+	"github.com/langgenius/dify-plugin-daemon/internal/core/debugging_runtime"
+	"github.com/langgenius/dify-plugin-daemon/internal/types/app"
+	"github.com/langgenius/dify-plugin-daemon/pkg/entities/plugin_entities"
+	"github.com/langgenius/dify-plugin-daemon/pkg/utils/mapping"
+)
+
+func TestGetPluginRuntimePrefersConnectedDebugRuntimeInServerlessMode(t *testing.T) {
+	identifier := plugin_entities.PluginUniqueIdentifier(
+		"langgenius/test_debug_plugin:0.0.1@0123456789abcdef0123456789abcdef",
+	)
+	debugRuntime := &debugging_runtime.RemotePluginRuntime{}
+	controlPanel := controlpanel.NewControlPanel(
+		&app.Config{PluginLocalLaunchingConcurrent: 1},
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+	storeDebuggingPluginRuntime(t, controlPanel, identifier, debugRuntime)
+
+	manager := &PluginManager{
+		config:       &app.Config{Platform: app.PLATFORM_SERVERLESS},
+		controlPanel: controlPanel,
+	}
+
+	runtime, err := manager.GetPluginRuntime(identifier)
+
+	require.NoError(t, err)
+	require.Same(t, debugRuntime, runtime)
+}
+
+func storeDebuggingPluginRuntime(
+	t *testing.T,
+	controlPanel *controlpanel.ControlPanel,
+	identifier plugin_entities.PluginUniqueIdentifier,
+	runtime *debugging_runtime.RemotePluginRuntime,
+) {
+	t.Helper()
+
+	field := reflect.ValueOf(controlPanel).Elem().FieldByName("debuggingPluginRuntime")
+	require.True(t, field.IsValid())
+
+	runtimes := (*mapping.Map[
+		plugin_entities.PluginUniqueIdentifier,
+		*debugging_runtime.RemotePluginRuntime,
+	])(unsafe.Pointer(field.UnsafeAddr()))
+	runtimes.Store(identifier, runtime)
+}


### PR DESCRIPTION
## Bug

When plugin-daemon runs with `PLATFORM=serverless`, debugging a newly created plugin fails with `500 Internal Server Error`.

The remote debug runtime is successfully connected and registered in the control panel. However, `PluginManager.GetPluginRuntime` selects the runtime solely based on the global platform setting and directly calls `getServerlessPluginRuntime`.

Remote debug plugins do not have a corresponding `serverless_runtimes` record by design. As a result, plugin-daemon fails to resolve the runtime and returns `failed to get plugin runtime`.

This issue is less visible when a plugin with the same ID is already installed because the existing serverless installation is reused. In that case, requests may continue running the installed serverless package instead of the connected debug runtime.

## Fix

Check the control panel for an active debug or local runtime first.

Only fall back to the serverless runtime when the control panel explicitly returns `ErrPluginRuntimeNotFound`. Other errors are propagated unchanged.

This preserves the existing behavior for normal serverless plugins while allowing newly connected debug plugins to run correctly.


## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Other

## Essential Checklist

### Testing
- [ ] I have tested the changes locally and confirmed they work as expected
- [ ] I have added unit tests where necessary and they pass successfully

### Bug Fix (if applicable)
- [ ] I have used GitHub syntax to close the related issue (e.g., `Fixes #123` or `Closes #123`)

## Additional Information

Please provide any additional context that would help reviewers understand the changes. 