### PR TITLE
feat(model-declaration): support per-field help on model provider credentials

### DIFF
--- a/pkg/entities/plugin_entities/model_declaration.go
+++ b/pkg/entities/plugin_entities/model_declaration.go
@@ -557,6 +557,8 @@ type ModelProviderCredentialFormSchema struct {
 	Required    bool                            `json:"required" yaml:"required"`
 	Default     *string                         `json:"default" yaml:"default" validate:"omitempty,lt=256"`
 	Options     []ModelProviderFormOption       `json:"options" yaml:"options" validate:"omitempty,lte=128,dive"`
+	Help        *I18nObject                     `json:"help" yaml:"help" validate:"omitempty"`
+	URL         *string                         `json:"url" yaml:"url" validate:"omitempty"`
 	Placeholder *I18nObject                     `json:"placeholder" yaml:"placeholder" validate:"omitempty"`
 	MaxLength   int                             `json:"max_length" yaml:"max_length"`
 	ShowOn      []ModelProviderFormShowOnObject `json:"show_on" yaml:"show_on" validate:"omitempty,lte=16,dive"`

--- a/pkg/entities/plugin_entities/model_declaration_test.go
+++ b/pkg/entities/plugin_entities/model_declaration_test.go
@@ -1,6 +1,7 @@
 package plugin_entities
 
 import (
+	"bytes"
 	"encoding/json"
 	"reflect"
 	"testing"
@@ -216,5 +217,66 @@ func TestModelParameterRule_UseTemplateJSON(t *testing.T) {
 
 	if model.Min == nil || model.Max == nil || model.Precision == nil {
 		t.Errorf("Missing default value")
+	}
+}
+
+func TestModelProviderCredentialFormSchema_HelpSurvivesRoundTrip(t *testing.T) {
+	const model_provider_template = `
+    provider: openai
+    label:
+      en_US: OpenAI
+    provider_credential_schema:
+      credential_form_schemas:
+        - variable: openai_api_base
+          label:
+            en_US: API Base
+          type: text-input
+          required: false
+          help:
+            en_US: Custom API base URL, e.g. a proxy or gateway
+            zh_Hans: 自定义 API 基础地址，例如代理或网关
+          url: https://platform.openai.com/docs/api-reference
+          placeholder:
+            en_US: Enter your API Base
+        `
+
+	jsonData, err := parse_yaml_to_json([]byte(model_provider_template))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	declaration, err := parser.UnmarshalYamlBytes[ModelProviderDeclaration](jsonData)
+	if err != nil {
+		t.Fatalf("UnmarshalYamlBytes() error = %v", err)
+	}
+
+	if declaration.ProviderCredentialSchema == nil {
+		t.Fatal("provider_credential_schema was not parsed")
+	}
+	schemas := declaration.ProviderCredentialSchema.CredentialFormSchemas
+	if len(schemas) != 1 {
+		t.Fatalf("expected 1 credential form schema, got %d", len(schemas))
+	}
+	field := schemas[0]
+
+	if field.Help == nil {
+		t.Fatal("Help was dropped during unmarshal; expected the manifest help to be retained")
+	}
+	if field.Help.EnUS != "Custom API base URL, e.g. a proxy or gateway" {
+		t.Errorf("Help.EnUS = %q, want the manifest help text", field.Help.EnUS)
+	}
+	if field.URL == nil || *field.URL != "https://platform.openai.com/docs/api-reference" {
+		t.Errorf("URL = %v, want the manifest url", field.URL)
+	}
+
+	roundTripped, err := json.Marshal(declaration)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(roundTripped, []byte(`"help":`)) {
+		t.Error("marshaled JSON does not contain a help key")
+	}
+	if !bytes.Contains(roundTripped, []byte("Custom API base URL, e.g. a proxy or gateway")) {
+		t.Error("marshaled JSON does not retain the help text")
 	}
 }


### PR DESCRIPTION
## Description

Model-provider credential form fields don't carry per-field `help`, so a plugin manifest's `help` on such a field is silently dropped during unmarshal and never reaches the provider declaration returned by the management API. **Tool** credential fields already model this — `ProviderConfig` (`pkg/entities/plugin_entities/config.go`) has `Help` and `URL` — which is why tool credential help renders in the Dify UI while model-provider credential help does not.

This brings model-provider credentials to parity by adding `Help` (and `URL`, matching `ProviderConfig`) to `ModelProviderCredentialFormSchema` (`pkg/entities/plugin_entities/model_declaration.go`). The `type Alias` unmarshalers handle the new fields automatically. The change is additive and optional — no behavior change for existing plugins.

For example, `models/bedrock` sets `help` on `bedrock_endpoint_url` / `bedrock_proxy_url` and `models/openai` on `api_protocol`; today those never reach the client. (Full trace: manifest → daemon struct → management-API JSON confirms the field is dropped at this struct.)

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Other

## Essential Checklist

### Testing
- [x] I have tested the changes locally and confirmed they work as expected
- [x] I have added unit tests where necessary and they pass successfully

### Bug Fix (if applicable)
- [ ] I have used GitHub syntax to close the related issue (e.g., `Fixes #123` or `Closes #123`)

## Additional Information

This is the first of three coordinated changes needed for a plugin's per-field help to reach the model-provider credential form in the Dify UI: **(1) this daemon change** so the declaration carries `help`; (2) the `graphon` `CredentialFormSchema` needs the field (it currently drops unknown keys via pydantic `extra="ignore"`); (3) the Dify frontend needs to map `help`→`tooltip` for model-provider credentials (tools/agents already do). Flagging so it's clear this is intentionally scoped to the daemon and is safe/inert on its own.

Note: `URL` is included for exact parity with `ProviderConfig`; happy to drop it to `Help`-only if you'd prefer the minimal change. Similarly, `json` `omitempty` was left off `help` to match `ProviderConfig` — glad to add it on both if you'd rather.

*Drafted with AI assistance (Claude) and reviewed by me before submitting.*