### PR TITLE
feat: split oversized serverless requests to avoid lambda payload limit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -166,6 +166,8 @@ MAX_PLUGIN_PACKAGE_SIZE=52428800
 # dify serverless connector
 DIFY_PLUGIN_SERVERLESS_CONNECTOR_URL=http://127.0.0.1:5004
 DIFY_PLUGIN_SERVERLESS_CONNECTOR_API_KEY=HeRFb6yrzAy5vUSlJWK2lUl36mpkaRycv4witbQpucXacgXg7G9a8gVL
+# maximum serialized request payload sent to a serverless plugin runtime
+MAX_SERVERLESS_REQUEST_BYTES=5242880
 
 # python interpreter, if you are using local runtime, you should set this path to your python interpreter path
 # otherwise, it should be /usr/bin/python3

--- a/docs/runtime/sri.md
+++ b/docs/runtime/sri.md
@@ -16,6 +16,22 @@ The daemon is configured using the following environment variables:
 |----------|-------------|
 | `DIFY_PLUGIN_SERVERLESS_CONNECTOR_URL` | Base URL of the remote runtime environment, e.g., `https://example.com` |
 | `DIFY_PLUGIN_SERVERLESS_CONNECTOR_API_KEY` | Authentication token for accessing SRI, passed in the `Authorization` request header |
+| `MAX_SERVERLESS_REQUEST_BYTES` | Maximum serialized request payload size sent to a serverless plugin runtime (in bytes). Default is 5242880 (5 MB). This limit accounts for Lambda Function URL's 6 MB request size limit, with a safety margin for headers and metadata. |
+
+---
+
+## 📦 Request Size Limits and Batch Processing
+
+Serverless platforms like AWS Lambda Function URLs have strict payload size limits (6 MB for Lambda Function URLs). To handle large requests that would exceed these limits, the daemon automatically splits text embedding and token counting requests into multiple batches when they would exceed `MAX_SERVERLESS_REQUEST_BYTES`.
+
+**Key behaviors:**
+
+- **Transparent batching**: The daemon handles splitting and merging automatically — plugin developers don't need to implement any special logic
+- **Serial processing**: Each batch is processed serially to ensure consistent results
+- **Automatic merging**: Results from all batches are merged into a single response
+- **Error handling**: If a single text item exceeds the limit, the request will fail with a `ServerlessPayloadTooLargeError`
+
+This feature prevents opaque errors when large embedding requests fail due to payload size limits.
 
 ---
 

--- a/docs/runtime/sri_cn.md
+++ b/docs/runtime/sri_cn.md
@@ -16,6 +16,22 @@ daemon 通过如下环境变量进行配置：
 |--------|------|
 | `DIFY_PLUGIN_SERVERLESS_CONNECTOR_URL` | 指定远程运行环境的 Base URL，例如 `https://example.com` |
 | `DIFY_PLUGIN_SERVERLESS_CONNECTOR_API_KEY` | 用于访问 SRI 的鉴权 token，将被加入请求 Header 中的 `Authorization` 字段 |
+| `MAX_SERVERLESS_REQUEST_BYTES` | 发送到 serverless 插件运行时的最大序列化请求负载大小（以字节为单位）。默认值为 5242880（5 MB）。此限制考虑了 Lambda Function URL 的 6 MB 请求大小限制，并为 headers 和元数据留有安全余量。 |
+
+---
+
+## 📏 请求大小限制与批处理
+
+像 AWS Lambda Function URL 这样的 serverless 平台有严格的负载大小限制（Lambda Function URL 为 6 MB）。
+
+当文本嵌入和 token 计数请求超过 `MAX_SERVERLESS_REQUEST_BYTES` 时，daemon 会自动将其拆分为多个批次：
+
+- **透明处理**：批处理对插件开发者是透明的 - daemon 自动处理拆分和合并
+- **顺序处理**：每个批次按顺序处理以确保结果一致
+- **自动合并**：来自所有批次的结果会自动合并为单个响应
+- **错误处理**：如果单个文本项超过限制，请求将失败并返回 `ServerlessPayloadTooLargeError` 错误
+
+此功能可防止大型嵌入请求因负载大小限制而失败时出现不明确的错误。
 
 ---
 

--- a/internal/core/io_tunnel/datasource.gen.go
+++ b/internal/core/io_tunnel/datasource.gen.go
@@ -4,9 +4,9 @@ package io_tunnel
 
 import (
 	"github.com/langgenius/dify-plugin-daemon/internal/core/session_manager"
-	"github.com/langgenius/dify-plugin-daemon/pkg/utils/stream"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/datasource_entities"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/requests"
+	"github.com/langgenius/dify-plugin-daemon/pkg/utils/stream"
 )
 
 func DatasourceValidateCredentials(

--- a/internal/core/io_tunnel/dynamic_parameter.gen.go
+++ b/internal/core/io_tunnel/dynamic_parameter.gen.go
@@ -4,9 +4,9 @@ package io_tunnel
 
 import (
 	"github.com/langgenius/dify-plugin-daemon/internal/core/session_manager"
-	"github.com/langgenius/dify-plugin-daemon/pkg/utils/stream"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/dynamic_select_entities"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/requests"
+	"github.com/langgenius/dify-plugin-daemon/pkg/utils/stream"
 )
 
 func FetchDynamicParameterOptions(

--- a/internal/core/io_tunnel/generic.go
+++ b/internal/core/io_tunnel/generic.go
@@ -1,6 +1,7 @@
 package io_tunnel
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sync"
@@ -32,15 +33,47 @@ func GenericInvokePlugin[Req any, Rsp any](
 	recorder := newPluginInvocationRecorder(session)
 	outcome := &pluginInvocationOutcomeTracker{}
 
+	response, err := invokePluginOnce[Req, Rsp](
+		session.RequestContext(),
+		session,
+		request,
+		response_buffer_size,
+		outcome,
+		func() {
+			recorder.record(outcome.outcome())
+		},
+	)
+	if err != nil {
+		recorder.record(pluginInvocationOutcomeError)
+		return nil, err
+	}
+	return response, nil
+}
+
+func invokePluginOnce[Req any, Rsp any](
+	ctx context.Context,
+	session *session_manager.Session,
+	request *Req,
+	responseBufferSize int,
+	outcome *pluginInvocationOutcomeTracker,
+	onClose func(),
+) (*stream.Stream[Rsp], error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	runtime := session.Runtime()
 	if runtime == nil {
-		recorder.record(pluginInvocationOutcomeError)
 		return nil, errors.New("plugin runtime not found")
 	}
 
-	response := stream.NewStream[Rsp](response_buffer_size)
+	response := stream.NewStream[Rsp](responseBufferSize)
+	if onClose != nil {
+		response.OnClose(onClose)
+	}
+	stopCloseOnCancel := context.AfterFunc(ctx, response.Close)
 	response.OnClose(func() {
-		recorder.record(outcome.outcome())
+		stopCloseOnCancel()
 	})
 
 	onChunk := func(chunk plugin_entities.SessionMessage) {
@@ -49,11 +82,10 @@ func GenericInvokePlugin[Req any, Rsp any](
 			chunk, err := parser.UnmarshalJsonBytes[Rsp](chunk.Data)
 			if err != nil {
 				outcome.markError()
-				response.WriteError(errors.New(parser.MarshalJson(map[string]string{
+				response.CloseWithError(errors.New(parser.MarshalJson(map[string]string{
 					"error_type": "unmarshal_error",
 					"message":    fmt.Sprintf("unmarshal json failed: %s", err.Error()),
 				})))
-				response.Close()
 				return
 			} else {
 				response.WriteBlocking(chunk)
@@ -61,11 +93,10 @@ func GenericInvokePlugin[Req any, Rsp any](
 		case plugin_entities.SESSION_MESSAGE_TYPE_INVOKE:
 			if runtime.Type() == plugin_entities.PLUGIN_RUNTIME_TYPE_SERVERLESS {
 				outcome.markError()
-				response.WriteError(errors.New(parser.MarshalJson(map[string]string{
+				response.CloseWithError(errors.New(parser.MarshalJson(map[string]string{
 					"error_type": "serverless_event_not_supported",
 					"message":    "serverless event is not supported by full duplex",
 				})))
-				response.Close()
 				return
 			}
 			if err := backwards_invocation.InvokeDify(
@@ -76,11 +107,10 @@ func GenericInvokePlugin[Req any, Rsp any](
 				chunk.Data,
 			); err != nil {
 				outcome.markError()
-				response.WriteError(errors.New(parser.MarshalJson(map[string]string{
+				response.CloseWithError(errors.New(parser.MarshalJson(map[string]string{
 					"error_type": "invoke_dify_error",
 					"message":    fmt.Sprintf("invoke dify failed: %s", err.Error()),
 				})))
-				response.Close()
 				return
 			}
 		case plugin_entities.SESSION_MESSAGE_TYPE_END:
@@ -92,15 +122,13 @@ func GenericInvokePlugin[Req any, Rsp any](
 			if err != nil {
 				break
 			}
-			response.WriteError(errors.New(e.Error()))
-			response.Close()
+			response.CloseWithError(errors.New(e.Error()))
 		default:
 			outcome.markError()
-			response.WriteError(errors.New(parser.MarshalJson(map[string]string{
+			response.CloseWithError(errors.New(parser.MarshalJson(map[string]string{
 				"error_type": "unknown_stream_message_type",
 				"message":    "unknown stream message type: " + string(chunk.Type),
 			})))
-			response.Close()
 		}
 	}
 
@@ -120,8 +148,14 @@ func GenericInvokePlugin[Req any, Rsp any](
 			}
 
 			listener.Listen(onChunk)
+			if err := ctx.Err(); err != nil {
+				closeListener()
+				stopCloseOnCancel()
+				return nil, err
+			}
 
-			err = session.Write(
+			err = session.WriteContext(
+				ctx,
 				session_manager.PLUGIN_IN_STREAM_EVENT_REQUEST,
 				session.Action,
 				pluginMap,
@@ -135,10 +169,17 @@ func GenericInvokePlugin[Req any, Rsp any](
 		}
 
 		if !isLocal || !isRecoverableWriteErr(err) || time.Now().After(deadline) {
-			recorder.record(pluginInvocationOutcomeError)
+			stopCloseOnCancel()
 			return nil, errors.Join(err, errors.New("failed to write request"))
 		}
 
-		time.Sleep(writeRetryInterval)
+		retryTimer := time.NewTimer(writeRetryInterval)
+		select {
+		case <-ctx.Done():
+			retryTimer.Stop()
+			stopCloseOnCancel()
+			return nil, ctx.Err()
+		case <-retryTimer.C:
+		}
 	}
 }

--- a/internal/core/io_tunnel/model.gen.go
+++ b/internal/core/io_tunnel/model.gen.go
@@ -4,9 +4,9 @@ package io_tunnel
 
 import (
 	"github.com/langgenius/dify-plugin-daemon/internal/core/session_manager"
-	"github.com/langgenius/dify-plugin-daemon/pkg/utils/stream"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/model_entities"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/requests"
+	"github.com/langgenius/dify-plugin-daemon/pkg/utils/stream"
 )
 
 func InvokeLLM(
@@ -41,10 +41,9 @@ func InvokeTextEmbedding(
 ) (
 	*stream.Stream[model_entities.TextEmbeddingResult], error,
 ) {
-	return GenericInvokePlugin[requests.RequestInvokeTextEmbedding, model_entities.TextEmbeddingResult](
+	return invokeTextEmbeddingServerlessAware(
 		session,
 		request,
-		1,
 	)
 }
 
@@ -67,10 +66,9 @@ func GetTextEmbeddingNumTokens(
 ) (
 	*stream.Stream[model_entities.GetTextEmbeddingNumTokensResponse], error,
 ) {
-	return GenericInvokePlugin[requests.RequestGetTextEmbeddingNumTokens, model_entities.GetTextEmbeddingNumTokensResponse](
+	return getTextEmbeddingNumTokensServerlessAware(
 		session,
 		request,
-		1,
 	)
 }
 

--- a/internal/core/io_tunnel/model_serverless_batch.go
+++ b/internal/core/io_tunnel/model_serverless_batch.go
@@ -1,0 +1,686 @@
+package io_tunnel
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/langgenius/dify-plugin-daemon/internal/core/serverless_runtime"
+	"github.com/langgenius/dify-plugin-daemon/internal/core/session_manager"
+	"github.com/langgenius/dify-plugin-daemon/pkg/entities/model_entities"
+	"github.com/langgenius/dify-plugin-daemon/pkg/entities/plugin_entities"
+	"github.com/langgenius/dify-plugin-daemon/pkg/entities/requests"
+	"github.com/langgenius/dify-plugin-daemon/pkg/utils/log"
+	"github.com/langgenius/dify-plugin-daemon/pkg/utils/stream"
+)
+
+type serverlessRequestBytesLimiter interface {
+	MaxServerlessRequestBytes() int
+}
+
+type textRequestBatch[Request any] struct {
+	request         Request
+	payloadBytes    int
+	maxRequestBytes int
+	itemOffset      int
+	itemCount       int
+}
+
+type serverlessBatchResultLog struct {
+	batchIndex      int
+	batchCount      int
+	itemOffset      int
+	itemCount       int
+	payloadBytes    int
+	maxRequestBytes int
+	startedAt       time.Time
+	outcome         string
+	errorType       string
+}
+
+type serverlessBatchResultMismatchError struct {
+	Action        string
+	BatchIndex    int
+	ExpectedItems int
+	ActualItems   int
+	ResponseCount int
+	Reason        string
+}
+
+func (e *serverlessBatchResultMismatchError) Error() string {
+	message := fmt.Sprintf(
+		"ServerlessBatchResultMismatch: action=%s batch_index=%d expected_items=%d actual_items=%d response_count=%d",
+		e.Action,
+		e.BatchIndex,
+		e.ExpectedItems,
+		e.ActualItems,
+		e.ResponseCount,
+	)
+	if e.Reason != "" {
+		message += " reason=" + e.Reason
+	}
+	return message
+}
+
+func invokeTextEmbeddingServerlessAware(
+	session *session_manager.Session,
+	request *requests.RequestInvokeTextEmbedding,
+) (*stream.Stream[model_entities.TextEmbeddingResult], error) {
+	runtime := session.Runtime()
+	if runtime == nil || runtime.Type() != plugin_entities.PLUGIN_RUNTIME_TYPE_SERVERLESS {
+		return GenericInvokePlugin[requests.RequestInvokeTextEmbedding, model_entities.TextEmbeddingResult](
+			session,
+			request,
+			1,
+		)
+	}
+
+	limiter, ok := runtime.(serverlessRequestBytesLimiter)
+	if !ok || limiter.MaxServerlessRequestBytes() <= 0 {
+		return nil, errors.New("serverless runtime request byte limit is unavailable")
+	}
+	maxRequestBytes := limiter.MaxServerlessRequestBytes()
+	batches, err := splitTextRequest(
+		session,
+		request.Texts,
+		maxRequestBytes,
+		func(start, end int) requests.RequestInvokeTextEmbedding {
+			candidate := *request
+			candidate.Texts = request.Texts[start:end]
+			return candidate
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	if len(batches) <= 1 {
+		return GenericInvokePlugin[requests.RequestInvokeTextEmbedding, model_entities.TextEmbeddingResult](
+			session,
+			request,
+			1,
+		)
+	}
+	observeServerlessBatchPlan(session, len(request.Texts), maxRequestBytes, batches)
+
+	response := stream.NewStream[model_entities.TextEmbeddingResult](1)
+	recorder := newPluginInvocationRecorder(session)
+	outcome := &pluginInvocationOutcomeTracker{}
+	ctx, cancel := context.WithCancel(session.RequestContext())
+	response.OnClose(cancel)
+	response.OnClose(func() {
+		recorder.record(outcome.outcome())
+	})
+
+	go coordinateTextEmbeddingBatches(ctx, session, request, batches, response, outcome)
+	return response, nil
+}
+
+func getTextEmbeddingNumTokensServerlessAware(
+	session *session_manager.Session,
+	request *requests.RequestGetTextEmbeddingNumTokens,
+) (*stream.Stream[model_entities.GetTextEmbeddingNumTokensResponse], error) {
+	runtime := session.Runtime()
+	if runtime == nil || runtime.Type() != plugin_entities.PLUGIN_RUNTIME_TYPE_SERVERLESS {
+		return GenericInvokePlugin[requests.RequestGetTextEmbeddingNumTokens, model_entities.GetTextEmbeddingNumTokensResponse](
+			session,
+			request,
+			1,
+		)
+	}
+
+	limiter, ok := runtime.(serverlessRequestBytesLimiter)
+	if !ok || limiter.MaxServerlessRequestBytes() <= 0 {
+		return nil, errors.New("serverless runtime request byte limit is unavailable")
+	}
+	maxRequestBytes := limiter.MaxServerlessRequestBytes()
+	batches, err := splitTokenCountRequest(session, request, maxRequestBytes)
+	if err != nil {
+		return nil, err
+	}
+	if len(batches) <= 1 {
+		return GenericInvokePlugin[requests.RequestGetTextEmbeddingNumTokens, model_entities.GetTextEmbeddingNumTokensResponse](
+			session,
+			request,
+			1,
+		)
+	}
+	observeServerlessBatchPlan(session, len(request.Texts), maxRequestBytes, batches)
+
+	response := stream.NewStream[model_entities.GetTextEmbeddingNumTokensResponse](1)
+	recorder := newPluginInvocationRecorder(session)
+	outcome := &pluginInvocationOutcomeTracker{}
+	ctx, cancel := context.WithCancel(session.RequestContext())
+	response.OnClose(cancel)
+	response.OnClose(func() {
+		recorder.record(outcome.outcome())
+	})
+
+	go coordinateTokenCountBatches(ctx, session, request, batches, response, outcome)
+	return response, nil
+}
+
+func splitTokenCountRequest(
+	session *session_manager.Session,
+	request *requests.RequestGetTextEmbeddingNumTokens,
+	maxRequestBytes int,
+) ([]textRequestBatch[requests.RequestGetTextEmbeddingNumTokens], error) {
+	return splitTextRequest(
+		session,
+		request.Texts,
+		maxRequestBytes,
+		func(start, end int) requests.RequestGetTextEmbeddingNumTokens {
+			return tokenCountRequestSlice(request, start, end)
+		},
+	)
+}
+
+func splitTextRequest[Request any](
+	session *session_manager.Session,
+	texts []string,
+	maxRequestBytes int,
+	sliceRequest func(start, end int) Request,
+) ([]textRequestBatch[Request], error) {
+	emptyRequest := sliceRequest(0, 0)
+	emptyPayloadBytes := requestPayloadBytes(session, &emptyRequest)
+	if emptyPayloadBytes > maxRequestBytes {
+		return nil, &serverless_runtime.ServerlessPayloadTooLargeError{
+			Action:          session.Action,
+			PayloadBytes:    emptyPayloadBytes,
+			MaxRequestBytes: maxRequestBytes,
+		}
+	}
+
+	batches := make([]textRequestBatch[Request], 0)
+	start := 0
+	estimatedPayloadBytes := emptyPayloadBytes
+	for itemIndex, text := range texts {
+		encodedText, err := json.Marshal(text)
+		if err != nil {
+			return nil, fmt.Errorf("marshal text at item_index=%d: %w", itemIndex, err)
+		}
+
+		nextPayloadBytes := estimatedPayloadBytes + len(encodedText)
+		if itemIndex > start {
+			nextPayloadBytes++
+		}
+		if nextPayloadBytes <= maxRequestBytes {
+			estimatedPayloadBytes = nextPayloadBytes
+			continue
+		}
+
+		if itemIndex == start {
+			return nil, oversizedTextItemError(session, sliceRequest, itemIndex, maxRequestBytes)
+		}
+		batchRequest := sliceRequest(start, itemIndex)
+		payloadBytes := requestPayloadBytes(session, &batchRequest)
+		if payloadBytes > maxRequestBytes {
+			return nil, fmt.Errorf(
+				"serverless batch size estimate mismatch: payload_bytes=%d max_request_bytes=%d",
+				payloadBytes,
+				maxRequestBytes,
+			)
+		}
+		batches = append(batches, textRequestBatch[Request]{
+			request:         batchRequest,
+			payloadBytes:    payloadBytes,
+			maxRequestBytes: maxRequestBytes,
+			itemOffset:      start,
+			itemCount:       itemIndex - start,
+		})
+		start = itemIndex
+		estimatedPayloadBytes = emptyPayloadBytes + len(encodedText)
+		if estimatedPayloadBytes > maxRequestBytes {
+			return nil, oversizedTextItemError(session, sliceRequest, itemIndex, maxRequestBytes)
+		}
+	}
+
+	if start < len(texts) {
+		batchRequest := sliceRequest(start, len(texts))
+		payloadBytes := requestPayloadBytes(session, &batchRequest)
+		if payloadBytes > maxRequestBytes {
+			return nil, fmt.Errorf(
+				"serverless batch size estimate mismatch: payload_bytes=%d max_request_bytes=%d",
+				payloadBytes,
+				maxRequestBytes,
+			)
+		}
+		batches = append(batches, textRequestBatch[Request]{
+			request:         batchRequest,
+			payloadBytes:    payloadBytes,
+			maxRequestBytes: maxRequestBytes,
+			itemOffset:      start,
+			itemCount:       len(texts) - start,
+		})
+	}
+
+	return batches, nil
+}
+
+func observeServerlessBatchPlan[Request any](
+	session *session_manager.Session,
+	originalItemCount int,
+	maxRequestBytes int,
+	batches []textRequestBatch[Request],
+) {
+	payloadBytes := make([]int, len(batches))
+	for i := range batches {
+		payloadBytes[i] = batches[i].payloadBytes
+	}
+	recordServerlessBatchPlan(session, payloadBytes)
+	log.InfoContext(
+		session.RequestContext(),
+		"serverless text request split into serial batches",
+		"runtime_type", plugin_entities.PLUGIN_RUNTIME_TYPE_SERVERLESS,
+		"action", session.Action,
+		"session_id", session.ID,
+		"original_item_count", originalItemCount,
+		"batch_count", len(batches),
+		"max_request_bytes", maxRequestBytes,
+	)
+}
+
+func logServerlessBatchResult(
+	session *session_manager.Session,
+	result serverlessBatchResultLog,
+) {
+	log.InfoContext(
+		session.RequestContext(),
+		"serverless text batch completed",
+		"runtime_type", plugin_entities.PLUGIN_RUNTIME_TYPE_SERVERLESS,
+		"action", session.Action,
+		"session_id", session.ID,
+		"batch_count", result.batchCount,
+		"batch_index", result.batchIndex,
+		"batch_item_offset", result.itemOffset,
+		"batch_item_count", result.itemCount,
+		"payload_bytes", result.payloadBytes,
+		"max_request_bytes", result.maxRequestBytes,
+		"duration_ms", time.Since(result.startedAt).Milliseconds(),
+		"outcome", result.outcome,
+		"error_type", result.errorType,
+	)
+}
+
+func oversizedTextItemError[Request any](
+	session *session_manager.Session,
+	sliceRequest func(start, end int) Request,
+	itemIndex int,
+	maxRequestBytes int,
+) error {
+	singleRequest := sliceRequest(itemIndex, itemIndex+1)
+	payloadBytes := requestPayloadBytes(session, &singleRequest)
+	recordServerlessOversizeItem(session)
+	log.WarnContext(
+		session.RequestContext(),
+		"serverless text item exceeds request payload limit",
+		"runtime_type", plugin_entities.PLUGIN_RUNTIME_TYPE_SERVERLESS,
+		"action", session.Action,
+		"session_id", session.ID,
+		"item_index", itemIndex,
+		"payload_bytes", payloadBytes,
+		"max_request_bytes", maxRequestBytes,
+		"error_type", "ServerlessPayloadTooLarge",
+	)
+	return &serverless_runtime.ServerlessPayloadTooLargeError{
+		Action:          session.Action,
+		PayloadBytes:    payloadBytes,
+		MaxRequestBytes: maxRequestBytes,
+		ItemIndex:       &itemIndex,
+	}
+}
+
+func requestPayloadBytes[Request any](
+	session *session_manager.Session,
+	request *Request,
+) int {
+	return len(session.Message(
+		session_manager.PLUGIN_IN_STREAM_EVENT_REQUEST,
+		GetInvokePluginMap(session, request),
+	))
+}
+
+func tokenCountRequestSlice(
+	request *requests.RequestGetTextEmbeddingNumTokens,
+	start int,
+	end int,
+) requests.RequestGetTextEmbeddingNumTokens {
+	candidate := *request
+	candidate.Texts = request.Texts[start:end]
+	return candidate
+}
+
+func processServerlessBatches[Request any, Response any](
+	ctx context.Context,
+	session *session_manager.Session,
+	batches []textRequestBatch[Request],
+	consume func(batchIndex int, itemCount int, results []Response) error,
+) error {
+	for batchIndex := range batches {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		batch := &batches[batchIndex]
+		batchStartedAt := time.Now()
+		batchResults, err := invokePluginBatch[Request, Response](ctx, session, &batch.request)
+		if err == nil {
+			err = consume(batchIndex, batch.itemCount, batchResults)
+		}
+		if err != nil {
+			outcome, errorType := serverlessBatchErrorDetails(err)
+			var mismatch *serverlessBatchResultMismatchError
+			if errors.As(err, &mismatch) {
+				recordServerlessBatchMismatch(session, mismatch.Reason)
+			}
+			logServerlessBatchResult(
+				session,
+				serverlessBatchResultLog{
+					batchIndex:      batchIndex,
+					batchCount:      len(batches),
+					itemOffset:      batch.itemOffset,
+					itemCount:       batch.itemCount,
+					payloadBytes:    batch.payloadBytes,
+					maxRequestBytes: batch.maxRequestBytes,
+					startedAt:       batchStartedAt,
+					outcome:         outcome,
+					errorType:       errorType,
+				},
+			)
+			return err
+		}
+
+		logServerlessBatchResult(
+			session,
+			serverlessBatchResultLog{
+				batchIndex:      batchIndex,
+				batchCount:      len(batches),
+				itemOffset:      batch.itemOffset,
+				itemCount:       batch.itemCount,
+				payloadBytes:    batch.payloadBytes,
+				maxRequestBytes: batch.maxRequestBytes,
+				startedAt:       batchStartedAt,
+				outcome:         pluginInvocationOutcomeSuccess,
+			},
+		)
+	}
+	return nil
+}
+
+func serverlessBatchErrorDetails(err error) (outcome string, errorType string) {
+	switch {
+	case errors.Is(err, context.Canceled):
+		return pluginInvocationOutcomeCanceled, "canceled"
+	case errors.Is(err, context.DeadlineExceeded):
+		return pluginInvocationOutcomeCanceled, "deadline_exceeded"
+	}
+
+	var mismatch *serverlessBatchResultMismatchError
+	if errors.As(err, &mismatch) {
+		return pluginInvocationOutcomeError, "ServerlessBatchResultMismatch"
+	}
+	return pluginInvocationOutcomeError, "runtime_error"
+}
+
+func closeServerlessBatchResponse[Response any](
+	ctx context.Context,
+	response *stream.Stream[Response],
+	outcome *pluginInvocationOutcomeTracker,
+	err error,
+) {
+	if ctx.Err() == nil {
+		outcome.markError()
+	}
+	response.CloseWithError(err)
+}
+
+func coordinateTokenCountBatches(
+	ctx context.Context,
+	session *session_manager.Session,
+	originalRequest *requests.RequestGetTextEmbeddingNumTokens,
+	batches []textRequestBatch[requests.RequestGetTextEmbeddingNumTokens],
+	response *stream.Stream[model_entities.GetTextEmbeddingNumTokensResponse],
+	outcome *pluginInvocationOutcomeTracker,
+) {
+	mergedNumTokens := make([]int, 0, len(originalRequest.Texts))
+	err := processServerlessBatches(
+		ctx,
+		session,
+		batches,
+		func(
+			batchIndex int,
+			itemCount int,
+			batchResults []model_entities.GetTextEmbeddingNumTokensResponse,
+		) error {
+			if len(batchResults) == 1 && len(batchResults[0].NumTokens) == itemCount {
+				mergedNumTokens = append(mergedNumTokens, batchResults[0].NumTokens...)
+				return nil
+			}
+
+			actualItems := 0
+			if len(batchResults) == 1 {
+				actualItems = len(batchResults[0].NumTokens)
+			}
+			return &serverlessBatchResultMismatchError{
+				Action:        string(session.Action),
+				BatchIndex:    batchIndex,
+				ExpectedItems: itemCount,
+				ActualItems:   actualItems,
+				ResponseCount: len(batchResults),
+				Reason:        "token_count",
+			}
+		},
+	)
+	if err != nil {
+		closeServerlessBatchResponse(ctx, response, outcome, err)
+		return
+	}
+
+	if len(mergedNumTokens) != len(originalRequest.Texts) {
+		recordServerlessBatchMismatch(session, "final_token_count")
+		outcome.markError()
+		response.CloseWithError(&serverlessBatchResultMismatchError{
+			Action:        string(session.Action),
+			BatchIndex:    len(batches),
+			ExpectedItems: len(originalRequest.Texts),
+			ActualItems:   len(mergedNumTokens),
+			ResponseCount: 1,
+		})
+		return
+	}
+
+	response.WriteBlocking(model_entities.GetTextEmbeddingNumTokensResponse{
+		NumTokens: mergedNumTokens,
+	})
+	if ctx.Err() != nil {
+		response.Close()
+		return
+	}
+	outcome.markSuccess()
+	response.Close()
+}
+
+func coordinateTextEmbeddingBatches(
+	ctx context.Context,
+	session *session_manager.Session,
+	originalRequest *requests.RequestInvokeTextEmbedding,
+	batches []textRequestBatch[requests.RequestInvokeTextEmbedding],
+	response *stream.Stream[model_entities.TextEmbeddingResult],
+	outcome *pluginInvocationOutcomeTracker,
+) {
+	var mergedResult *model_entities.TextEmbeddingResult
+	err := processServerlessBatches(
+		ctx,
+		session,
+		batches,
+		func(batchIndex int, itemCount int, batchResults []model_entities.TextEmbeddingResult) error {
+			if len(batchResults) != 1 {
+				return &serverlessBatchResultMismatchError{
+					Action:        string(session.Action),
+					BatchIndex:    batchIndex,
+					ExpectedItems: itemCount,
+					ResponseCount: len(batchResults),
+					Reason:        "response_count",
+				}
+			}
+			return mergeTextEmbeddingResult(
+				session,
+				batchIndex,
+				itemCount,
+				&mergedResult,
+				batchResults[0],
+			)
+		},
+	)
+	if err != nil {
+		closeServerlessBatchResponse(ctx, response, outcome, err)
+		return
+	}
+
+	if mergedResult == nil || len(mergedResult.Embeddings) != len(originalRequest.Texts) {
+		actualItems := 0
+		if mergedResult != nil {
+			actualItems = len(mergedResult.Embeddings)
+		}
+		recordServerlessBatchMismatch(session, "final_embedding_count")
+		outcome.markError()
+		response.CloseWithError(&serverlessBatchResultMismatchError{
+			Action:        string(session.Action),
+			BatchIndex:    len(batches),
+			ExpectedItems: len(originalRequest.Texts),
+			ActualItems:   actualItems,
+			ResponseCount: 1,
+			Reason:        "final_embedding_count",
+		})
+		return
+	}
+
+	response.WriteBlocking(*mergedResult)
+	if ctx.Err() != nil {
+		response.Close()
+		return
+	}
+	outcome.markSuccess()
+	response.Close()
+}
+
+func mergeTextEmbeddingResult(
+	session *session_manager.Session,
+	batchIndex int,
+	expectedItems int,
+	mergedResult **model_entities.TextEmbeddingResult,
+	batchResult model_entities.TextEmbeddingResult,
+) error {
+	if len(batchResult.Embeddings) != expectedItems {
+		return &serverlessBatchResultMismatchError{
+			Action:        string(session.Action),
+			BatchIndex:    batchIndex,
+			ExpectedItems: expectedItems,
+			ActualItems:   len(batchResult.Embeddings),
+			ResponseCount: 1,
+			Reason:        "embedding_count",
+		}
+	}
+
+	usage := batchResult.Usage
+	if usage.Tokens == nil ||
+		usage.TotalTokens == nil ||
+		usage.Currency == nil ||
+		usage.Latency == nil {
+		return &serverlessBatchResultMismatchError{
+			Action:        string(session.Action),
+			BatchIndex:    batchIndex,
+			ExpectedItems: expectedItems,
+			ActualItems:   len(batchResult.Embeddings),
+			ResponseCount: 1,
+			Reason:        "missing_usage_field",
+		}
+	}
+
+	if *mergedResult == nil {
+		tokens := *usage.Tokens
+		totalTokens := *usage.TotalTokens
+		currency := *usage.Currency
+		latency := *usage.Latency
+		result := batchResult
+		result.Embeddings = append([][]float64(nil), batchResult.Embeddings...)
+		result.Usage.Tokens = &tokens
+		result.Usage.TotalTokens = &totalTokens
+		result.Usage.Currency = &currency
+		result.Usage.Latency = &latency
+		*mergedResult = &result
+		return nil
+	}
+
+	merged := *mergedResult
+	if batchResult.Model != merged.Model {
+		return embeddingBatchMismatch(session, batchIndex, expectedItems, "model")
+	}
+	if !usage.UnitPrice.Equal(merged.Usage.UnitPrice) {
+		return embeddingBatchMismatch(session, batchIndex, expectedItems, "unit_price")
+	}
+	if !usage.PriceUnit.Equal(merged.Usage.PriceUnit) {
+		return embeddingBatchMismatch(session, batchIndex, expectedItems, "price_unit")
+	}
+	if *usage.Currency != *merged.Usage.Currency {
+		return embeddingBatchMismatch(session, batchIndex, expectedItems, "currency")
+	}
+
+	merged.Embeddings = append(merged.Embeddings, batchResult.Embeddings...)
+	*merged.Usage.Tokens += *usage.Tokens
+	*merged.Usage.TotalTokens += *usage.TotalTokens
+	merged.Usage.TotalPrice = merged.Usage.TotalPrice.Add(usage.TotalPrice)
+	*merged.Usage.Latency += *usage.Latency
+	return nil
+}
+
+func embeddingBatchMismatch(
+	session *session_manager.Session,
+	batchIndex int,
+	expectedItems int,
+	reason string,
+) error {
+	return &serverlessBatchResultMismatchError{
+		Action:        string(session.Action),
+		BatchIndex:    batchIndex,
+		ExpectedItems: expectedItems,
+		ActualItems:   expectedItems,
+		ResponseCount: 1,
+		Reason:        reason,
+	}
+}
+
+func invokePluginBatch[Request any, Response any](
+	ctx context.Context,
+	session *session_manager.Session,
+	request *Request,
+) ([]Response, error) {
+	batchOutcome := &pluginInvocationOutcomeTracker{}
+	response, err := invokePluginOnce[Request, Response](ctx, session, request, 1, batchOutcome, nil)
+	if err != nil {
+		return nil, err
+	}
+	return readPluginBatch(ctx, response)
+}
+
+func readPluginBatch[Response any](
+	ctx context.Context,
+	response *stream.Stream[Response],
+) ([]Response, error) {
+	stopCloseOnCancel := context.AfterFunc(ctx, response.Close)
+	defer stopCloseOnCancel()
+
+	var results []Response
+	for response.Next() {
+		result, err := response.Read()
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, result)
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return results, nil
+}

--- a/internal/core/io_tunnel/model_serverless_batch_test.go
+++ b/internal/core/io_tunnel/model_serverless_batch_test.go
@@ -1,0 +1,1101 @@
+package io_tunnel
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/langgenius/dify-plugin-daemon/internal/core/io_tunnel/access_types"
+	"github.com/langgenius/dify-plugin-daemon/internal/core/serverless_runtime"
+	"github.com/langgenius/dify-plugin-daemon/internal/core/session_manager"
+	"github.com/langgenius/dify-plugin-daemon/pkg/entities"
+	"github.com/langgenius/dify-plugin-daemon/pkg/entities/model_entities"
+	"github.com/langgenius/dify-plugin-daemon/pkg/entities/plugin_entities"
+	"github.com/langgenius/dify-plugin-daemon/pkg/entities/requests"
+	"github.com/langgenius/dify-plugin-daemon/pkg/utils/parser"
+	"github.com/langgenius/dify-plugin-daemon/pkg/utils/routine"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+type tokenBatchRuntime struct {
+	mu              sync.Mutex
+	listener        *entities.Broadcast[plugin_entities.SessionMessage]
+	runtimeType     plugin_entities.PluginRuntimeType
+	maxRequestBytes int
+	payloads        [][]byte
+	inFlight        int
+	maxInFlight     int
+	responseFn      func(int, []string) []plugin_entities.SessionMessage
+}
+
+func (r *tokenBatchRuntime) Type() plugin_entities.PluginRuntimeType {
+	if r.runtimeType != "" {
+		return r.runtimeType
+	}
+	return plugin_entities.PLUGIN_RUNTIME_TYPE_SERVERLESS
+}
+
+func (r *tokenBatchRuntime) Configuration() *plugin_entities.PluginDeclaration {
+	return &plugin_entities.PluginDeclaration{}
+}
+
+func (r *tokenBatchRuntime) Identity() (plugin_entities.PluginUniqueIdentifier, error) {
+	return testPluginUniqueIdentifier, nil
+}
+
+func (r *tokenBatchRuntime) HashedIdentity() (string, error) {
+	return plugin_entities.HashedIdentity(testPluginUniqueIdentifier.String()), nil
+}
+
+func (r *tokenBatchRuntime) Checksum() (string, error) {
+	return testPluginUniqueIdentifier.Checksum(), nil
+}
+
+func (r *tokenBatchRuntime) MaxServerlessRequestBytes() int {
+	return r.maxRequestBytes
+}
+
+func (r *tokenBatchRuntime) Listen(string) (*entities.Broadcast[plugin_entities.SessionMessage], error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.listener = entities.NewCallbackHandler[plugin_entities.SessionMessage]()
+	return r.listener, nil
+}
+
+func (r *tokenBatchRuntime) Write(
+	_ string,
+	_ access_types.PluginAccessAction,
+	data []byte,
+) error {
+	r.mu.Lock()
+	listener := r.listener
+	r.payloads = append(r.payloads, append([]byte(nil), data...))
+	callIndex := len(r.payloads) - 1
+	r.inFlight++
+	if r.inFlight > r.maxInFlight {
+		r.maxInFlight = r.inFlight
+	}
+	r.mu.Unlock()
+
+	var message struct {
+		Data struct {
+			Texts []string `json:"texts"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(data, &message); err != nil {
+		return err
+	}
+
+	go func() {
+		messages := r.defaultResponseMessages(message.Data.Texts)
+		if r.responseFn != nil {
+			messages = r.responseFn(callIndex, message.Data.Texts)
+		}
+
+		for _, message := range messages {
+			if message.Type == plugin_entities.SESSION_MESSAGE_TYPE_END ||
+				message.Type == plugin_entities.SESSION_MESSAGE_TYPE_ERROR {
+				r.mu.Lock()
+				r.inFlight--
+				r.mu.Unlock()
+			}
+			listener.Send(message)
+		}
+	}()
+
+	return nil
+}
+
+func (r *tokenBatchRuntime) defaultResponseMessages(texts []string) []plugin_entities.SessionMessage {
+	numTokens := make([]int, len(texts))
+	for i, text := range texts {
+		numTokens[i] = len([]rune(text))
+	}
+	return []plugin_entities.SessionMessage{
+		{
+			Type: plugin_entities.SESSION_MESSAGE_TYPE_STREAM,
+			Data: parser.MarshalJsonBytes(model_entities.GetTextEmbeddingNumTokensResponse{
+				NumTokens: numTokens,
+			}),
+		},
+		{
+			Type: plugin_entities.SESSION_MESSAGE_TYPE_END,
+		},
+	}
+}
+
+type embeddingBatchRuntime struct {
+	tokenBatchRuntime
+	embeddingResponseFn func(int, []string) []plugin_entities.SessionMessage
+}
+
+func (r *embeddingBatchRuntime) Write(
+	_ string,
+	_ access_types.PluginAccessAction,
+	data []byte,
+) error {
+	r.mu.Lock()
+	listener := r.listener
+	r.payloads = append(r.payloads, append([]byte(nil), data...))
+	callIndex := len(r.payloads) - 1
+	r.inFlight++
+	if r.inFlight > r.maxInFlight {
+		r.maxInFlight = r.inFlight
+	}
+	r.mu.Unlock()
+
+	var message struct {
+		Data struct {
+			Texts []string `json:"texts"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(data, &message); err != nil {
+		return err
+	}
+
+	go func() {
+		messages := embeddingResponseMessages(message.Data.Texts)
+		if r.embeddingResponseFn != nil {
+			messages = r.embeddingResponseFn(callIndex, message.Data.Texts)
+		}
+		for _, message := range messages {
+			if message.Type == plugin_entities.SESSION_MESSAGE_TYPE_END ||
+				message.Type == plugin_entities.SESSION_MESSAGE_TYPE_ERROR {
+				r.mu.Lock()
+				r.inFlight--
+				r.mu.Unlock()
+			}
+			listener.Send(message)
+		}
+	}()
+	return nil
+}
+
+func embeddingResponseMessages(texts []string) []plugin_entities.SessionMessage {
+	return []plugin_entities.SessionMessage{
+		{
+			Type: plugin_entities.SESSION_MESSAGE_TYPE_STREAM,
+			Data: parser.MarshalJsonBytes(embeddingResult(texts)),
+		},
+		{Type: plugin_entities.SESSION_MESSAGE_TYPE_END},
+	}
+}
+
+func embeddingResult(texts []string) model_entities.TextEmbeddingResult {
+	tokens := len(texts)
+	totalTokens := len(texts) * 10
+	currency := "USD"
+	latency := float64(len(texts)) * 0.5
+	embeddings := make([][]float64, len(texts))
+	for i, text := range texts {
+		embeddings[i] = []float64{float64(len([]rune(text)))}
+	}
+	return model_entities.TextEmbeddingResult{
+		Model:      "embedding-model",
+		Embeddings: embeddings,
+		Usage: model_entities.EmbeddingUsage{
+			Tokens:      &tokens,
+			TotalTokens: &totalTokens,
+			UnitPrice:   decimal.RequireFromString("0.01"),
+			PriceUnit:   decimal.NewFromInt(1000),
+			TotalPrice:  decimal.RequireFromString("0.02").Mul(decimal.NewFromInt(int64(len(texts)))),
+			Currency:    &currency,
+			Latency:     &latency,
+		},
+	}
+}
+
+func TestGetTextEmbeddingNumTokensServerlessAwareSplitsByFinalPayloadBytes(t *testing.T) {
+	request := newTokenCountRequest([]string{`plain`, `中文`, `emoji 😀`, `quote " slash \`})
+	runtime := &tokenBatchRuntime{}
+	session := newTestSession(
+		t,
+		runtime,
+		access_types.PLUGIN_ACCESS_TYPE_MODEL,
+		access_types.PLUGIN_ACCESS_ACTION_GET_TEXT_EMBEDDING_NUM_TOKENS,
+	)
+
+	twoItemsRequest := *request
+	twoItemsRequest.Texts = request.Texts[:2]
+	runtime.maxRequestBytes = maxTokenCountSingleItemPayloadSize(session, request)
+	runtime.maxRequestBytes = max(runtime.maxRequestBytes, tokenCountPayloadSize(session, &twoItemsRequest))
+
+	response, err := getTextEmbeddingNumTokensServerlessAware(session, request)
+	require.NoError(t, err)
+
+	results := readAllStreamValues(t, response)
+	require.Equal(t, []model_entities.GetTextEmbeddingNumTokensResponse{{
+		NumTokens: []int{5, 2, 7, 15},
+	}}, results)
+
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	require.Len(t, runtime.payloads, 3)
+	for _, payload := range runtime.payloads {
+		require.LessOrEqual(t, len(payload), runtime.maxRequestBytes)
+	}
+	require.Equal(t, 1, runtime.maxInFlight)
+}
+
+func TestGetTextEmbeddingNumTokensServerlessAwareUsesRealRuntimeSerially(t *testing.T) {
+	routine.InitPool(4)
+	var (
+		mu          sync.Mutex
+		inFlight    int
+		maxInFlight int
+		received    []string
+		handlerErr  error
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var message struct {
+			Data struct {
+				Texts []string `json:"texts"`
+			} `json:"data"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&message); err != nil {
+			mu.Lock()
+			handlerErr = err
+			mu.Unlock()
+			return
+		}
+
+		mu.Lock()
+		inFlight++
+		maxInFlight = max(maxInFlight, inFlight)
+		received = append(received, message.Data.Texts...)
+		mu.Unlock()
+		defer func() {
+			mu.Lock()
+			inFlight--
+			mu.Unlock()
+		}()
+
+		numTokens := make([]int, len(message.Data.Texts))
+		for i, text := range message.Data.Texts {
+			numTokens[i] = len([]rune(text))
+		}
+		encoder := json.NewEncoder(w)
+		if err := encoder.Encode(map[string]any{
+			"session_id": r.Header.Get("Dify-Plugin-Session-ID"),
+			"event":      "session",
+			"data": plugin_entities.SessionMessage{
+				Type: plugin_entities.SESSION_MESSAGE_TYPE_STREAM,
+				Data: parser.MarshalJsonBytes(model_entities.GetTextEmbeddingNumTokensResponse{
+					NumTokens: numTokens,
+				}),
+			},
+		}); err != nil {
+			mu.Lock()
+			handlerErr = err
+			mu.Unlock()
+			return
+		}
+		if err := encoder.Encode(map[string]any{
+			"session_id": r.Header.Get("Dify-Plugin-Session-ID"),
+			"event":      "session",
+			"data": plugin_entities.SessionMessage{
+				Type: plugin_entities.SESSION_MESSAGE_TYPE_END,
+			},
+		}); err != nil {
+			mu.Lock()
+			handlerErr = err
+			mu.Unlock()
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	runtime := &serverless_runtime.ServerlessPluginRuntime{
+		Client:                    server.Client(),
+		LambdaURL:                 server.URL,
+		MaxRetryTimes:             1,
+		PluginMaxExecutionTimeout: 10,
+		RuntimeBufferSize:         1024,
+		RuntimeMaxBufferSize:      1024,
+	}
+	request := newTokenCountRequest([]string{"one", "two", "three"})
+	session := newTestSession(
+		t,
+		runtime,
+		access_types.PLUGIN_ACCESS_TYPE_MODEL,
+		access_types.PLUGIN_ACCESS_ACTION_GET_TEXT_EMBEDDING_NUM_TOKENS,
+	)
+	runtime.MaxRequestBytes = maxTokenCountSingleItemPayloadSize(session, request)
+
+	response, err := getTextEmbeddingNumTokensServerlessAware(session, request)
+	require.NoError(t, err)
+	results := readAllStreamValues(t, response)
+
+	require.Equal(t, []model_entities.GetTextEmbeddingNumTokensResponse{{
+		NumTokens: []int{3, 3, 5},
+	}}, results)
+	mu.Lock()
+	defer mu.Unlock()
+	require.NoError(t, handlerErr)
+	require.Equal(t, []string{"one", "two", "three"}, received)
+	require.Equal(t, 1, maxInFlight)
+}
+
+func TestGetTextEmbeddingNumTokensServerlessAwareCancelsRealRuntime(t *testing.T) {
+	routine.InitPool(2)
+	requestStarted := make(chan struct{}, 1)
+	requestCanceled := make(chan struct{}, 1)
+	releaseHandler := make(chan struct{})
+	var (
+		mu           sync.Mutex
+		requestCount int
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		mu.Lock()
+		requestCount++
+		mu.Unlock()
+		select {
+		case requestStarted <- struct{}{}:
+		default:
+		}
+		select {
+		case <-r.Context().Done():
+			select {
+			case requestCanceled <- struct{}{}:
+			default:
+			}
+		case <-releaseHandler:
+		}
+	}))
+	t.Cleanup(func() {
+		close(releaseHandler)
+		server.Close()
+	})
+
+	runtime := &serverless_runtime.ServerlessPluginRuntime{
+		Client:                    server.Client(),
+		LambdaURL:                 server.URL,
+		MaxRetryTimes:             1,
+		PluginMaxExecutionTimeout: 10,
+		RuntimeBufferSize:         1024,
+		RuntimeMaxBufferSize:      1024,
+	}
+	request := newTokenCountRequest([]string{"one", "two"})
+	session := newTestSession(
+		t,
+		runtime,
+		access_types.PLUGIN_ACCESS_TYPE_MODEL,
+		access_types.PLUGIN_ACCESS_ACTION_GET_TEXT_EMBEDDING_NUM_TOKENS,
+	)
+	runtime.MaxRequestBytes = maxTokenCountSingleItemPayloadSize(session, request)
+
+	response, err := getTextEmbeddingNumTokensServerlessAware(session, request)
+	require.NoError(t, err)
+	<-requestStarted
+	response.Close()
+
+	select {
+	case <-requestCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("server request did not observe outer stream cancellation")
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, 1, requestCount)
+}
+
+func TestGetTextEmbeddingNumTokensServerlessAwareDoesNotMutateRequest(t *testing.T) {
+	originalTexts := []string{"one", "two", "three"}
+	request := newTokenCountRequest(originalTexts)
+	runtime := &tokenBatchRuntime{}
+	session := newTestSession(
+		t,
+		runtime,
+		access_types.PLUGIN_ACCESS_TYPE_MODEL,
+		access_types.PLUGIN_ACCESS_ACTION_GET_TEXT_EMBEDDING_NUM_TOKENS,
+	)
+
+	runtime.maxRequestBytes = maxTokenCountSingleItemPayloadSize(session, request)
+
+	response, err := getTextEmbeddingNumTokensServerlessAware(session, request)
+	require.NoError(t, err)
+	readAllStreamValues(t, response)
+
+	require.Equal(t, originalTexts, request.Texts)
+}
+
+func TestGetTextEmbeddingNumTokensServerlessAwareRejectsOversizeSingleItem(t *testing.T) {
+	request := newTokenCountRequest([]string{"too large"})
+	runtime := &tokenBatchRuntime{}
+	session := newTestSession(
+		t,
+		runtime,
+		access_types.PLUGIN_ACCESS_TYPE_MODEL,
+		access_types.PLUGIN_ACCESS_ACTION_GET_TEXT_EMBEDDING_NUM_TOKENS,
+	)
+	runtime.maxRequestBytes = tokenCountPayloadSize(session, request) - 1
+
+	response, err := getTextEmbeddingNumTokensServerlessAware(session, request)
+
+	require.Nil(t, response)
+	require.ErrorContains(t, err, "ServerlessPayloadTooLarge")
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	require.Empty(t, runtime.payloads)
+}
+
+func TestGetTextEmbeddingNumTokensServerlessAwareRejectsOversizeFixedEnvelope(t *testing.T) {
+	request := newTokenCountRequest([]string{"small"})
+	request.Credentials.Credentials["api_key"] = strings.Repeat("x", 1024)
+	runtime := &tokenBatchRuntime{}
+	session := newTestSession(
+		t,
+		runtime,
+		access_types.PLUGIN_ACCESS_TYPE_MODEL,
+		access_types.PLUGIN_ACCESS_ACTION_GET_TEXT_EMBEDDING_NUM_TOKENS,
+	)
+	emptyRequest := *request
+	emptyRequest.Texts = []string{}
+	runtime.maxRequestBytes = tokenCountPayloadSize(session, &emptyRequest) - 1
+
+	response, err := getTextEmbeddingNumTokensServerlessAware(session, request)
+
+	require.Nil(t, response)
+	var payloadTooLarge *serverless_runtime.ServerlessPayloadTooLargeError
+	require.ErrorAs(t, err, &payloadTooLarge)
+	require.Nil(t, payloadTooLarge.ItemIndex)
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	require.Empty(t, runtime.payloads)
+}
+
+func TestGetTextEmbeddingNumTokensServerlessAwareStopsAfterBatchError(t *testing.T) {
+	request := newTokenCountRequest([]string{"one", "two", "three"})
+	runtime := &tokenBatchRuntime{
+		responseFn: func(callIndex int, texts []string) []plugin_entities.SessionMessage {
+			if callIndex == 1 {
+				return []plugin_entities.SessionMessage{{
+					Type: plugin_entities.SESSION_MESSAGE_TYPE_ERROR,
+					Data: parser.MarshalJsonBytes(plugin_entities.ErrorResponse{
+						ErrorType: "ProviderError",
+						Message:   "second batch failed",
+					}),
+				}}
+			}
+			return (&tokenBatchRuntime{}).defaultResponseMessages(texts)
+		},
+	}
+	session := newTestSession(
+		t,
+		runtime,
+		access_types.PLUGIN_ACCESS_TYPE_MODEL,
+		access_types.PLUGIN_ACCESS_ACTION_GET_TEXT_EMBEDDING_NUM_TOKENS,
+	)
+	runtime.maxRequestBytes = maxTokenCountSingleItemPayloadSize(session, request)
+
+	response, err := getTextEmbeddingNumTokensServerlessAware(session, request)
+	require.NoError(t, err)
+
+	values, streamErr := collectTokenCountStream(response)
+	require.ErrorContains(t, streamErr, "second batch failed")
+	require.Empty(t, values)
+
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	require.Len(t, runtime.payloads, 2)
+}
+
+func TestGetTextEmbeddingNumTokensServerlessAwareRejectsMismatchedBatchResult(t *testing.T) {
+	request := newTokenCountRequest([]string{"one", "two", "three"})
+	runtime := &tokenBatchRuntime{
+		responseFn: func(callIndex int, texts []string) []plugin_entities.SessionMessage {
+			if callIndex == 1 {
+				return []plugin_entities.SessionMessage{
+					{
+						Type: plugin_entities.SESSION_MESSAGE_TYPE_STREAM,
+						Data: parser.MarshalJsonBytes(model_entities.GetTextEmbeddingNumTokensResponse{
+							NumTokens: []int{1, 2},
+						}),
+					},
+					{Type: plugin_entities.SESSION_MESSAGE_TYPE_END},
+				}
+			}
+			return (&tokenBatchRuntime{}).defaultResponseMessages(texts)
+		},
+	}
+	session := newTestSession(
+		t,
+		runtime,
+		access_types.PLUGIN_ACCESS_TYPE_MODEL,
+		access_types.PLUGIN_ACCESS_ACTION_GET_TEXT_EMBEDDING_NUM_TOKENS,
+	)
+	runtime.maxRequestBytes = maxTokenCountSingleItemPayloadSize(session, request)
+
+	response, err := getTextEmbeddingNumTokensServerlessAware(session, request)
+	require.NoError(t, err)
+
+	values, streamErr := collectTokenCountStream(response)
+	require.ErrorContains(t, streamErr, "ServerlessBatchResultMismatch")
+	require.Empty(t, values)
+
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	require.Len(t, runtime.payloads, 2)
+}
+
+func TestGetTextEmbeddingNumTokensServerlessAwareKeepsLocalRuntimeAsSingleCall(t *testing.T) {
+	request := newTokenCountRequest([]string{"one", "two", "three"})
+	runtime := &tokenBatchRuntime{
+		runtimeType:     plugin_entities.PLUGIN_RUNTIME_TYPE_LOCAL,
+		maxRequestBytes: 1,
+	}
+	session := newTestSession(
+		t,
+		runtime,
+		access_types.PLUGIN_ACCESS_TYPE_MODEL,
+		access_types.PLUGIN_ACCESS_ACTION_GET_TEXT_EMBEDDING_NUM_TOKENS,
+	)
+
+	response, err := getTextEmbeddingNumTokensServerlessAware(session, request)
+	require.NoError(t, err)
+	values := readAllStreamValues(t, response)
+
+	require.Len(t, values, 1)
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	require.Len(t, runtime.payloads, 1)
+}
+
+func TestGetTextEmbeddingNumTokensServerlessAwareHonorsExactPayloadLimit(t *testing.T) {
+	tests := []struct {
+		name          string
+		limitOffset   int
+		expectedCalls int
+	}{
+		{
+			name:          "exact limit remains one call",
+			limitOffset:   0,
+			expectedCalls: 1,
+		},
+		{
+			name:          "one byte over the limit is split",
+			limitOffset:   -1,
+			expectedCalls: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := newTokenCountRequest([]string{"one", "two"})
+			runtime := &tokenBatchRuntime{}
+			session := newTestSession(
+				t,
+				runtime,
+				access_types.PLUGIN_ACCESS_TYPE_MODEL,
+				access_types.PLUGIN_ACCESS_ACTION_GET_TEXT_EMBEDDING_NUM_TOKENS,
+			)
+			runtime.maxRequestBytes = tokenCountPayloadSize(session, request) + tt.limitOffset
+
+			response, err := getTextEmbeddingNumTokensServerlessAware(session, request)
+			require.NoError(t, err)
+			readAllStreamValues(t, response)
+
+			runtime.mu.Lock()
+			defer runtime.mu.Unlock()
+			require.Len(t, runtime.payloads, tt.expectedCalls)
+		})
+	}
+}
+
+func TestGetTextEmbeddingNumTokensServerlessAwareRequiresExactlyOneResponsePerBatch(t *testing.T) {
+	tests := []struct {
+		name      string
+		responses int
+	}{
+		{name: "zero responses", responses: 0},
+		{name: "multiple responses", responses: 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := newTokenCountRequest([]string{"one", "two"})
+			runtime := &tokenBatchRuntime{
+				responseFn: func(_ int, texts []string) []plugin_entities.SessionMessage {
+					messages := make([]plugin_entities.SessionMessage, 0, tt.responses+1)
+					for range tt.responses {
+						messages = append(messages, plugin_entities.SessionMessage{
+							Type: plugin_entities.SESSION_MESSAGE_TYPE_STREAM,
+							Data: parser.MarshalJsonBytes(model_entities.GetTextEmbeddingNumTokensResponse{
+								NumTokens: []int{len([]rune(texts[0]))},
+							}),
+						})
+					}
+					return append(messages, plugin_entities.SessionMessage{
+						Type: plugin_entities.SESSION_MESSAGE_TYPE_END,
+					})
+				},
+			}
+			session := newTestSession(
+				t,
+				runtime,
+				access_types.PLUGIN_ACCESS_TYPE_MODEL,
+				access_types.PLUGIN_ACCESS_ACTION_GET_TEXT_EMBEDDING_NUM_TOKENS,
+			)
+			runtime.maxRequestBytes = maxTokenCountSingleItemPayloadSize(session, request)
+
+			response, err := getTextEmbeddingNumTokensServerlessAware(session, request)
+			require.NoError(t, err)
+
+			values, streamErr := collectTokenCountStream(response)
+			require.ErrorContains(t, streamErr, "ServerlessBatchResultMismatch")
+			require.Empty(t, values)
+		})
+	}
+}
+
+func TestGetTextEmbeddingNumTokensServerlessAwareStopsAfterOuterCancellation(t *testing.T) {
+	request := newTokenCountRequest([]string{"one", "two", "three"})
+	firstBatchStarted := make(chan struct{}, 1)
+	releaseFirstBatch := make(chan struct{})
+	runtime := &tokenBatchRuntime{
+		responseFn: func(callIndex int, texts []string) []plugin_entities.SessionMessage {
+			if callIndex == 0 {
+				firstBatchStarted <- struct{}{}
+				<-releaseFirstBatch
+			}
+			return (&tokenBatchRuntime{}).defaultResponseMessages(texts)
+		},
+	}
+	session := newTestSession(
+		t,
+		runtime,
+		access_types.PLUGIN_ACCESS_TYPE_MODEL,
+		access_types.PLUGIN_ACCESS_ACTION_GET_TEXT_EMBEDDING_NUM_TOKENS,
+	)
+	runtime.maxRequestBytes = maxTokenCountSingleItemPayloadSize(session, request)
+
+	response, err := getTextEmbeddingNumTokensServerlessAware(session, request)
+	require.NoError(t, err)
+	<-firstBatchStarted
+
+	response.Close()
+	close(releaseFirstBatch)
+
+	require.Eventually(t, func() bool {
+		runtime.mu.Lock()
+		defer runtime.mu.Unlock()
+		return runtime.inFlight == 0
+	}, time.Second, 10*time.Millisecond)
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	require.Len(t, runtime.payloads, 1)
+}
+
+func TestGetTextEmbeddingNumTokensServerlessAwareRecordsOneLogicalInvocation(t *testing.T) {
+	reader := setupPluginInvocationMetricTest(t)
+	request := newTokenCountRequest([]string{"one", "two", "three"})
+	runtime := &tokenBatchRuntime{}
+	session := newTestSession(
+		t,
+		runtime,
+		access_types.PLUGIN_ACCESS_TYPE_MODEL,
+		access_types.PLUGIN_ACCESS_ACTION_GET_TEXT_EMBEDDING_NUM_TOKENS,
+	)
+	runtime.maxRequestBytes = maxTokenCountSingleItemPayloadSize(session, request)
+
+	response, err := getTextEmbeddingNumTokensServerlessAware(session, request)
+	require.NoError(t, err)
+	readAllStreamValues(t, response)
+
+	metrics := collectPluginInvocationMetrics(t, reader)
+	expectedAttrs := expectedPluginMetricAttributes(
+		pluginInvocationOutcomeSuccess,
+		string(plugin_entities.PLUGIN_RUNTIME_TYPE_SERVERLESS),
+		string(access_types.PLUGIN_ACCESS_TYPE_MODEL),
+	)
+	counter, ok := pluginInvocationCounterValue(metrics, expectedAttrs)
+	require.True(t, ok)
+	require.EqualValues(t, 1, counter)
+
+	batchCount, batchCountSum, ok := int64HistogramSummary(metrics, serverlessBatchCountMetricName)
+	require.True(t, ok)
+	require.EqualValues(t, 1, batchCount)
+	require.EqualValues(t, 3, batchCountSum)
+
+	payloadCount, _, ok := int64HistogramSummary(metrics, serverlessBatchPayloadMetricName)
+	require.True(t, ok)
+	require.EqualValues(t, 3, payloadCount)
+}
+
+func TestServerlessBatchLogsExcludeTextAndCredentials(t *testing.T) {
+	var logOutput bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&logOutput, nil)))
+	t.Cleanup(func() {
+		slog.SetDefault(previousLogger)
+	})
+
+	const (
+		sensitiveText       = "private-text-do-not-log"
+		sensitiveCredential = "private-api-key-do-not-log"
+	)
+	request := newTokenCountRequest([]string{sensitiveText, "second"})
+	request.Credentials.Credentials["api_key"] = sensitiveCredential
+	runtime := &tokenBatchRuntime{}
+	session := newTestSession(
+		t,
+		runtime,
+		access_types.PLUGIN_ACCESS_TYPE_MODEL,
+		access_types.PLUGIN_ACCESS_ACTION_GET_TEXT_EMBEDDING_NUM_TOKENS,
+	)
+	runtime.maxRequestBytes = maxTokenCountSingleItemPayloadSize(session, request)
+
+	response, err := getTextEmbeddingNumTokensServerlessAware(session, request)
+	require.NoError(t, err)
+	readAllStreamValues(t, response)
+
+	require.NotContains(t, logOutput.String(), sensitiveText)
+	require.NotContains(t, logOutput.String(), sensitiveCredential)
+}
+
+func TestInvokeTextEmbeddingServerlessAwareMergesResultsAndUsage(t *testing.T) {
+	originalTexts := []string{"a", "bb", "ccc"}
+	request := newTextEmbeddingRequest(originalTexts)
+	runtime := &embeddingBatchRuntime{}
+	session := newTestSession(
+		t,
+		runtime,
+		access_types.PLUGIN_ACCESS_TYPE_MODEL,
+		access_types.PLUGIN_ACCESS_ACTION_INVOKE_TEXT_EMBEDDING,
+	)
+	runtime.maxRequestBytes = maxTextEmbeddingSingleItemPayloadSize(session, request)
+
+	response, err := invokeTextEmbeddingServerlessAware(session, request)
+	require.NoError(t, err)
+	results := readAllStreamValues(t, response)
+
+	require.Len(t, results, 1)
+	result := results[0]
+	require.Equal(t, "embedding-model", result.Model)
+	require.Equal(t, [][]float64{{1}, {2}, {3}}, result.Embeddings)
+	require.Equal(t, 3, *result.Usage.Tokens)
+	require.Equal(t, 30, *result.Usage.TotalTokens)
+	require.True(t, decimal.RequireFromString("0.01").Equal(result.Usage.UnitPrice))
+	require.True(t, decimal.NewFromInt(1000).Equal(result.Usage.PriceUnit))
+	require.True(t, decimal.RequireFromString("0.06").Equal(result.Usage.TotalPrice))
+	require.Equal(t, "USD", *result.Usage.Currency)
+	require.Equal(t, 1.5, *result.Usage.Latency)
+	require.Equal(t, originalTexts, request.Texts)
+
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	require.Len(t, runtime.payloads, 3)
+	require.Equal(t, 1, runtime.maxInFlight)
+	for _, payload := range runtime.payloads {
+		require.LessOrEqual(t, len(payload), runtime.maxRequestBytes)
+	}
+}
+
+func TestInvokeTextEmbeddingServerlessAwareRejectsInconsistentBatchUsage(t *testing.T) {
+	tests := []struct {
+		name   string
+		reason string
+		mutate func(*model_entities.TextEmbeddingResult)
+	}{
+		{
+			name:   "model",
+			reason: "model",
+			mutate: func(result *model_entities.TextEmbeddingResult) {
+				result.Model = "different-model"
+			},
+		},
+		{
+			name:   "unit price",
+			reason: "unit_price",
+			mutate: func(result *model_entities.TextEmbeddingResult) {
+				result.Usage.UnitPrice = decimal.RequireFromString("0.02")
+			},
+		},
+		{
+			name:   "price unit",
+			reason: "price_unit",
+			mutate: func(result *model_entities.TextEmbeddingResult) {
+				result.Usage.PriceUnit = decimal.NewFromInt(1)
+			},
+		},
+		{
+			name:   "currency",
+			reason: "currency",
+			mutate: func(result *model_entities.TextEmbeddingResult) {
+				currency := "EUR"
+				result.Usage.Currency = &currency
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := newTextEmbeddingRequest([]string{"a", "bb", "ccc"})
+			runtime := &embeddingBatchRuntime{
+				embeddingResponseFn: func(callIndex int, texts []string) []plugin_entities.SessionMessage {
+					result := embeddingResult(texts)
+					if callIndex == 1 {
+						tt.mutate(&result)
+					}
+					return []plugin_entities.SessionMessage{
+						{
+							Type: plugin_entities.SESSION_MESSAGE_TYPE_STREAM,
+							Data: parser.MarshalJsonBytes(result),
+						},
+						{Type: plugin_entities.SESSION_MESSAGE_TYPE_END},
+					}
+				},
+			}
+			session := newTestSession(
+				t,
+				runtime,
+				access_types.PLUGIN_ACCESS_TYPE_MODEL,
+				access_types.PLUGIN_ACCESS_ACTION_INVOKE_TEXT_EMBEDDING,
+			)
+			runtime.maxRequestBytes = maxTextEmbeddingSingleItemPayloadSize(session, request)
+
+			response, err := invokeTextEmbeddingServerlessAware(session, request)
+			require.NoError(t, err)
+			values, streamErr := collectTextEmbeddingStream(response)
+
+			require.ErrorContains(t, streamErr, "ServerlessBatchResultMismatch")
+			require.ErrorContains(t, streamErr, "reason="+tt.reason)
+			require.Empty(t, values)
+			runtime.mu.Lock()
+			defer runtime.mu.Unlock()
+			require.Len(t, runtime.payloads, 2)
+		})
+	}
+}
+
+func TestInvokeTextEmbeddingServerlessAwareRejectsEmbeddingCountMismatch(t *testing.T) {
+	request := newTextEmbeddingRequest([]string{"a", "bb"})
+	runtime := &embeddingBatchRuntime{
+		embeddingResponseFn: func(_ int, texts []string) []plugin_entities.SessionMessage {
+			result := embeddingResult(texts)
+			result.Embeddings = append(result.Embeddings, []float64{999})
+			return []plugin_entities.SessionMessage{
+				{
+					Type: plugin_entities.SESSION_MESSAGE_TYPE_STREAM,
+					Data: parser.MarshalJsonBytes(result),
+				},
+				{Type: plugin_entities.SESSION_MESSAGE_TYPE_END},
+			}
+		},
+	}
+	session := newTestSession(
+		t,
+		runtime,
+		access_types.PLUGIN_ACCESS_TYPE_MODEL,
+		access_types.PLUGIN_ACCESS_ACTION_INVOKE_TEXT_EMBEDDING,
+	)
+	runtime.maxRequestBytes = maxTextEmbeddingSingleItemPayloadSize(session, request)
+
+	response, err := invokeTextEmbeddingServerlessAware(session, request)
+	require.NoError(t, err)
+	values, streamErr := collectTextEmbeddingStream(response)
+
+	require.ErrorContains(t, streamErr, "reason=embedding_count")
+	require.Empty(t, values)
+}
+
+func BenchmarkSplitTokenCountRequest100MiB(b *testing.B) {
+	const (
+		requestBytes = 100 * 1024 * 1024
+		textBytes    = 1024 * 1024
+	)
+
+	text := strings.Repeat("a", textBytes)
+	texts := make([]string, requestBytes/textBytes)
+	for i := range texts {
+		texts[i] = text
+	}
+	request := newTokenCountRequest(texts)
+	runtime := &tokenBatchRuntime{
+		maxRequestBytes: 5 * 1024 * 1024,
+	}
+	session := session_manager.NewSession(session_manager.NewSessionPayload{
+		TenantID:               "tenant-1",
+		UserID:                 "user-1",
+		PluginUniqueIdentifier: testPluginUniqueIdentifier,
+		InvokeFrom:             access_types.PLUGIN_ACCESS_TYPE_MODEL,
+		Action:                 access_types.PLUGIN_ACCESS_ACTION_GET_TEXT_EMBEDDING_NUM_TOKENS,
+		RequestContext:         context.Background(),
+		IgnoreCache:            true,
+	})
+	session.BindRuntime(runtime)
+	b.Cleanup(func() {
+		session.Close(session_manager.CloseSessionPayload{IgnoreCache: true})
+	})
+
+	b.ReportAllocs()
+	b.SetBytes(requestBytes)
+	for b.Loop() {
+		batches, err := splitTokenCountRequest(session, request, runtime.maxRequestBytes)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(batches) == 0 {
+			b.Fatal("expected split batches")
+		}
+	}
+}
+
+func newTokenCountRequest(texts []string) *requests.RequestGetTextEmbeddingNumTokens {
+	return &requests.RequestGetTextEmbeddingNumTokens{
+		BaseRequestInvokeModel: requests.BaseRequestInvokeModel{
+			Provider: "provider",
+			Model:    "model",
+		},
+		Credentials: requests.Credentials{
+			Credentials: map[string]any{"api_key": "secret"},
+		},
+		ModelType: model_entities.MODEL_TYPE_TEXT_EMBEDDING,
+		Texts:     texts,
+	}
+}
+
+func newTextEmbeddingRequest(texts []string) *requests.RequestInvokeTextEmbedding {
+	return &requests.RequestInvokeTextEmbedding{
+		BaseRequestInvokeModel: requests.BaseRequestInvokeModel{
+			Provider: "provider",
+			Model:    "model",
+		},
+		Credentials: requests.Credentials{
+			Credentials: map[string]any{"api_key": "secret"},
+		},
+		InvokeTextEmbeddingSchema: requests.InvokeTextEmbeddingSchema{
+			Texts:     texts,
+			InputType: "document",
+		},
+		ModelType: model_entities.MODEL_TYPE_TEXT_EMBEDDING,
+	}
+}
+
+func tokenCountPayloadSize(
+	session *session_manager.Session,
+	request *requests.RequestGetTextEmbeddingNumTokens,
+) int {
+	return len(session.Message(
+		session_manager.PLUGIN_IN_STREAM_EVENT_REQUEST,
+		GetInvokePluginMap(session, request),
+	))
+}
+
+func maxTokenCountSingleItemPayloadSize(
+	session *session_manager.Session,
+	request *requests.RequestGetTextEmbeddingNumTokens,
+) int {
+	maxPayloadBytes := 0
+	for i := range request.Texts {
+		singleItemRequest := *request
+		singleItemRequest.Texts = request.Texts[i : i+1]
+		maxPayloadBytes = max(maxPayloadBytes, tokenCountPayloadSize(session, &singleItemRequest))
+	}
+	return maxPayloadBytes
+}
+
+func maxTextEmbeddingSingleItemPayloadSize(
+	session *session_manager.Session,
+	request *requests.RequestInvokeTextEmbedding,
+) int {
+	maxPayloadBytes := 0
+	for i := range request.Texts {
+		singleItemRequest := *request
+		singleItemRequest.Texts = request.Texts[i : i+1]
+		maxPayloadBytes = max(
+			maxPayloadBytes,
+			len(session.Message(
+				session_manager.PLUGIN_IN_STREAM_EVENT_REQUEST,
+				GetInvokePluginMap(session, &singleItemRequest),
+			)),
+		)
+	}
+	return maxPayloadBytes
+}
+
+func readAllStreamValues[T any](t *testing.T, response interface {
+	Next() bool
+	Read() (T, error)
+}) []T {
+	t.Helper()
+
+	var values []T
+	for response.Next() {
+		value, err := response.Read()
+		require.NoError(t, err)
+		values = append(values, value)
+	}
+	return values
+}
+
+func collectTokenCountStream(
+	response interface {
+		Next() bool
+		Read() (model_entities.GetTextEmbeddingNumTokensResponse, error)
+	},
+) ([]model_entities.GetTextEmbeddingNumTokensResponse, error) {
+	var values []model_entities.GetTextEmbeddingNumTokensResponse
+	for response.Next() {
+		value, err := response.Read()
+		if err != nil {
+			return values, err
+		}
+		values = append(values, value)
+	}
+	return values, nil
+}
+
+func collectTextEmbeddingStream(
+	response interface {
+		Next() bool
+		Read() (model_entities.TextEmbeddingResult, error)
+	},
+) ([]model_entities.TextEmbeddingResult, error) {
+	var values []model_entities.TextEmbeddingResult
+	for response.Next() {
+		value, err := response.Read()
+		if err != nil {
+			return values, err
+		}
+		values = append(values, value)
+	}
+	return values, nil
+}
+
+func int64HistogramSummary(
+	metrics metricdata.ResourceMetrics,
+	metricName string,
+) (uint64, int64, bool) {
+	var count uint64
+	var sum int64
+	found := false
+	for _, scopeMetrics := range metrics.ScopeMetrics {
+		for _, currentMetric := range scopeMetrics.Metrics {
+			if currentMetric.Name != metricName {
+				continue
+			}
+			histogram, ok := currentMetric.Data.(metricdata.Histogram[int64])
+			if !ok {
+				return 0, 0, false
+			}
+			found = true
+			for _, point := range histogram.DataPoints {
+				count += point.Count
+				sum += point.Sum
+			}
+		}
+	}
+	return count, sum, found
+}

--- a/internal/core/io_tunnel/oauth.gen.go
+++ b/internal/core/io_tunnel/oauth.gen.go
@@ -4,9 +4,9 @@ package io_tunnel
 
 import (
 	"github.com/langgenius/dify-plugin-daemon/internal/core/session_manager"
-	"github.com/langgenius/dify-plugin-daemon/pkg/utils/stream"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/oauth_entities"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/requests"
+	"github.com/langgenius/dify-plugin-daemon/pkg/utils/stream"
 )
 
 func GetAuthorizationURL(

--- a/internal/core/io_tunnel/otel_metrics.go
+++ b/internal/core/io_tunnel/otel_metrics.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/langgenius/dify-plugin-daemon/internal/core/session_manager"
+	"github.com/langgenius/dify-plugin-daemon/pkg/entities/plugin_entities"
 	"github.com/langgenius/dify-plugin-daemon/pkg/utils/log"
 	gootel "go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -18,6 +19,10 @@ const (
 
 	pluginInvocationsMetricName        = "plugin.invocations"
 	pluginInvocationDurationMetricName = "plugin.invocation.duration"
+	serverlessBatchCountMetricName     = "plugin.serverless.batch.count"
+	serverlessBatchPayloadMetricName   = "plugin.serverless.batch.payload_bytes"
+	serverlessOversizeItemMetricName   = "plugin.serverless.batch.oversize_items"
+	serverlessMismatchMetricName       = "plugin.serverless.batch.result_mismatches"
 
 	pluginInvocationOutcomeSuccess  = "success"
 	pluginInvocationOutcomeError    = "error"
@@ -32,8 +37,12 @@ const (
 )
 
 type pluginInvocationInstruments struct {
-	counter   metric.Int64Counter
-	durations metric.Float64Histogram
+	counter                    metric.Int64Counter
+	durations                  metric.Float64Histogram
+	serverlessBatchCounts      metric.Int64Histogram
+	serverlessBatchPayloads    metric.Int64Histogram
+	serverlessOversizeItems    metric.Int64Counter
+	serverlessResultMismatches metric.Int64Counter
 }
 
 type pluginInvocationRecorder struct {
@@ -96,6 +105,56 @@ func (t *pluginInvocationOutcomeTracker) outcome() string {
 	}
 }
 
+func recordServerlessBatchPlan(session *session_manager.Session, payloadBytes []int) {
+	instruments, err := getPluginInvocationInstruments()
+	if err != nil || instruments == nil {
+		return
+	}
+
+	ctx := session.RequestContext()
+	attrs := buildServerlessBatchAttributes(session)
+	instruments.serverlessBatchCounts.Record(
+		ctx,
+		int64(len(payloadBytes)),
+		metric.WithAttributeSet(attrs),
+	)
+	for _, payloadSize := range payloadBytes {
+		instruments.serverlessBatchPayloads.Record(
+			ctx,
+			int64(payloadSize),
+			metric.WithAttributeSet(attrs),
+		)
+	}
+}
+
+func recordServerlessOversizeItem(session *session_manager.Session) {
+	instruments, err := getPluginInvocationInstruments()
+	if err != nil || instruments == nil {
+		return
+	}
+	instruments.serverlessOversizeItems.Add(
+		session.RequestContext(),
+		1,
+		metric.WithAttributeSet(buildServerlessBatchAttributes(session)),
+	)
+}
+
+func recordServerlessBatchMismatch(session *session_manager.Session, reason string) {
+	instruments, err := getPluginInvocationInstruments()
+	if err != nil || instruments == nil {
+		return
+	}
+	attrs := buildServerlessBatchAttributes(session)
+	if reason != "" {
+		attrs = attribute.NewSet(append(attrs.ToSlice(), attribute.String("batch.mismatch_reason", reason))...)
+	}
+	instruments.serverlessResultMismatches.Add(
+		session.RequestContext(),
+		1,
+		metric.WithAttributeSet(attrs),
+	)
+}
+
 func getPluginInvocationInstruments() (*pluginInvocationInstruments, error) {
 	pluginInvocationMetricsOnce.Do(func() {
 		meter := gootel.Meter(pluginInvocationMetricScope)
@@ -127,13 +186,93 @@ func getPluginInvocationInstruments() (*pluginInvocationInstruments, error) {
 			return
 		}
 
+		serverlessBatchCounts, err := meter.Int64Histogram(
+			serverlessBatchCountMetricName,
+			metric.WithDescription("Number of serial Lambda requests planned for one logical plugin invocation."),
+			metric.WithUnit("{batch}"),
+		)
+		if err != nil {
+			pluginInvocationMetricsErr = err
+			log.Warn("failed to init serverless batch count histogram", "error", err)
+			return
+		}
+
+		serverlessBatchPayloads, err := meter.Int64Histogram(
+			serverlessBatchPayloadMetricName,
+			metric.WithDescription("Serialized request payload size for each planned serverless batch."),
+			metric.WithUnit("By"),
+		)
+		if err != nil {
+			pluginInvocationMetricsErr = err
+			log.Warn("failed to init serverless batch payload histogram", "error", err)
+			return
+		}
+
+		serverlessOversizeItems, err := meter.Int64Counter(
+			serverlessOversizeItemMetricName,
+			metric.WithDescription("Number of individual text items that exceed the serverless request limit."),
+			metric.WithUnit("{item}"),
+		)
+		if err != nil {
+			pluginInvocationMetricsErr = err
+			log.Warn("failed to init serverless oversize item counter", "error", err)
+			return
+		}
+
+		serverlessResultMismatches, err := meter.Int64Counter(
+			serverlessMismatchMetricName,
+			metric.WithDescription("Number of invalid or inconsistent serverless batch results."),
+			metric.WithUnit("{error}"),
+		)
+		if err != nil {
+			pluginInvocationMetricsErr = err
+			log.Warn("failed to init serverless batch mismatch counter", "error", err)
+			return
+		}
+
 		pluginInvocationMetrics = &pluginInvocationInstruments{
-			counter:   counter,
-			durations: durations,
+			counter:                    counter,
+			durations:                  durations,
+			serverlessBatchCounts:      serverlessBatchCounts,
+			serverlessBatchPayloads:    serverlessBatchPayloads,
+			serverlessOversizeItems:    serverlessOversizeItems,
+			serverlessResultMismatches: serverlessResultMismatches,
 		}
 	})
 
 	return pluginInvocationMetrics, pluginInvocationMetricsErr
+}
+
+func buildServerlessBatchAttributes(session *session_manager.Session) attribute.Set {
+	pluginID := pluginInvocationUnknownValue
+	pluginVersion := pluginInvocationUnknownValue
+	accessType := pluginInvocationUnknownValue
+	action := pluginInvocationUnknownValue
+
+	if session != nil {
+		if session.PluginUniqueIdentifier != "" {
+			if id := session.PluginUniqueIdentifier.PluginID(); id != "" {
+				pluginID = id
+			}
+			if version := string(session.PluginUniqueIdentifier.Version()); version != "" {
+				pluginVersion = version
+			}
+		}
+		if session.InvokeFrom != "" {
+			accessType = string(session.InvokeFrom)
+		}
+		if session.Action != "" {
+			action = string(session.Action)
+		}
+	}
+
+	return attribute.NewSet(
+		attribute.String("plugin.id", pluginID),
+		attribute.String("plugin.version", pluginVersion),
+		attribute.String("plugin.runtime_type", string(plugin_entities.PLUGIN_RUNTIME_TYPE_SERVERLESS)),
+		attribute.String("plugin.access_type", accessType),
+		attribute.String("plugin.action", action),
+	)
 }
 
 func buildPluginInvocationAttributes(session *session_manager.Session, outcome string) attribute.Set {

--- a/internal/core/io_tunnel/tool.gen.go
+++ b/internal/core/io_tunnel/tool.gen.go
@@ -4,9 +4,9 @@ package io_tunnel
 
 import (
 	"github.com/langgenius/dify-plugin-daemon/internal/core/session_manager"
-	"github.com/langgenius/dify-plugin-daemon/pkg/utils/stream"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/requests"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/tool_entities"
+	"github.com/langgenius/dify-plugin-daemon/pkg/utils/stream"
 )
 
 func InvokeTool(

--- a/internal/core/io_tunnel/trigger.gen.go
+++ b/internal/core/io_tunnel/trigger.gen.go
@@ -4,8 +4,8 @@ package io_tunnel
 
 import (
 	"github.com/langgenius/dify-plugin-daemon/internal/core/session_manager"
-	"github.com/langgenius/dify-plugin-daemon/pkg/utils/stream"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/requests"
+	"github.com/langgenius/dify-plugin-daemon/pkg/utils/stream"
 )
 
 func TriggerInvokeEvent(

--- a/internal/core/serverless_connector/client.go
+++ b/internal/core/serverless_connector/client.go
@@ -37,9 +37,9 @@ func Init(config *app.Config) {
 	}
 	SERVERLESS_CONNECTOR_API_KEY = *config.DifyPluginServerlessConnectorAPIKey
 
-	if err := PingWithContext(ctx); err != nil {
-		log.PanicContext(ctx, "Failed to ping serverless connector", "error", err)
-	}
+	// if err := PingWithContext(ctx); err != nil {
+	// 	log.PanicContext(ctx, "Failed to ping serverless connector", "error", err)
+	// }
 
 	log.InfoContext(ctx, "Serverless connector initialized")
 }

--- a/internal/core/serverless_connector/client.go
+++ b/internal/core/serverless_connector/client.go
@@ -37,9 +37,9 @@ func Init(config *app.Config) {
 	}
 	SERVERLESS_CONNECTOR_API_KEY = *config.DifyPluginServerlessConnectorAPIKey
 
-	// if err := PingWithContext(ctx); err != nil {
-	// 	log.PanicContext(ctx, "Failed to ping serverless connector", "error", err)
-	// }
+	if err := PingWithContext(ctx); err != nil {
+		log.PanicContext(ctx, "Failed to ping serverless connector", "error", err)
+	}
 
 	log.InfoContext(ctx, "Serverless connector initialized")
 }

--- a/internal/core/serverless_runtime/io.go
+++ b/internal/core/serverless_runtime/io.go
@@ -3,6 +3,7 @@ package serverless_runtime
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -22,6 +23,27 @@ import (
 )
 
 const serverlessErrorResponseLimit = 4 * 1024
+
+// ServerlessPayloadTooLargeError reports request size metadata without exposing payload contents.
+type ServerlessPayloadTooLargeError struct {
+	Action          access_types.PluginAccessAction
+	PayloadBytes    int
+	MaxRequestBytes int
+	ItemIndex       *int
+}
+
+func (e *ServerlessPayloadTooLargeError) Error() string {
+	message := fmt.Sprintf(
+		"ServerlessPayloadTooLarge: action=%s payload_bytes=%d max_request_bytes=%d",
+		e.Action,
+		e.PayloadBytes,
+		e.MaxRequestBytes,
+	)
+	if e.ItemIndex != nil {
+		message += fmt.Sprintf(" item_index=%d", *e.ItemIndex)
+	}
+	return message
+}
 
 type serverlessErrorResponse struct {
 	ErrorType    string `json:"errorType"`
@@ -116,8 +138,12 @@ func (r *ServerlessPluginRuntime) Listen(sessionId string) (
 	error,
 ) {
 	l := entities.NewCallbackHandler[plugin_entities.SessionMessage]()
-	// store the listener
 	r.listeners.Store(sessionId, l)
+	l.OnClose(func() {
+		r.listeners.DeleteIf(sessionId, func(listener *entities.Broadcast[plugin_entities.SessionMessage]) bool {
+			return listener == l
+		})
+	})
 	return l, nil
 }
 
@@ -134,9 +160,11 @@ func shouldRetryStatusCode(statusCode int) bool {
 // It will retry up to MaxRetryTimes attempts on 502 errors with exponential backoff
 // Backoff duration is capped at 30 seconds to prevent unreasonable wait times
 func (r *ServerlessPluginRuntime) invokeServerlessWithRetry(
+	ctx context.Context,
 	url string,
 	sessionId string,
 	data []byte,
+	action access_types.PluginAccessAction,
 ) (*http.Response, error) {
 	const maxBackoffDuration = 30 * time.Second
 
@@ -155,7 +183,13 @@ func (r *ServerlessPluginRuntime) invokeServerlessWithRetry(
 			if backoffDuration > maxBackoffDuration {
 				backoffDuration = maxBackoffDuration
 			}
-			time.Sleep(backoffDuration)
+			timer := time.NewTimer(backoffDuration)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return nil, ctx.Err()
+			case <-timer.C:
+			}
 		}
 
 		// Make HTTP request to serverless endpoint
@@ -167,10 +201,14 @@ func (r *ServerlessPluginRuntime) invokeServerlessWithRetry(
 				"Dify-Plugin-Session-ID": sessionId,
 			}),
 			http_requests.HttpPayloadReader(io.NopCloser(bytes.NewReader(data))),
-			http_requests.HttpReadTimeout(int64(r.PluginMaxExecutionTimeout*1000)),
+			http_requests.HttpContext(ctx),
 		)
 
 		if err != nil {
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+			recordServerlessRuntimeFailure(action, 0, serverlessRuntimeFailureType(0))
 			log.Warn(
 				"serverless runtime HTTP request attempt failed",
 				"session_id", sessionId,
@@ -188,6 +226,7 @@ func (r *ServerlessPluginRuntime) invokeServerlessWithRetry(
 		if statusCode >= 200 && statusCode < 300 {
 			return response, nil
 		}
+		recordServerlessRuntimeFailure(action, statusCode, serverlessRuntimeFailureType(statusCode))
 
 		// Check if status code should trigger a retry (502 Bad Gateway only)
 		if shouldRetryStatusCode(statusCode) {
@@ -227,14 +266,38 @@ func (r *ServerlessPluginRuntime) Write(
 	action access_types.PluginAccessAction,
 	data []byte,
 ) error {
+	return r.WriteContext(context.Background(), sessionId, action, data)
+}
+
+func (r *ServerlessPluginRuntime) WriteContext(
+	ctx context.Context,
+	sessionId string,
+	action access_types.PluginAccessAction,
+	data []byte,
+) error {
 	l, ok := r.listeners.Load(sessionId)
 	if !ok {
 		return errors.New("session not found")
 	}
+	deleteListener := func() {
+		r.listeners.DeleteIf(sessionId, func(listener *entities.Broadcast[plugin_entities.SessionMessage]) bool {
+			return listener == l
+		})
+	}
 
 	url, err := url.JoinPath(r.LambdaURL, "invoke")
 	if err != nil {
+		deleteListener()
 		return errors.Join(err, errors.New("failed to join lambda url"))
+	}
+
+	if len(data) > r.MaxRequestBytes {
+		deleteListener()
+		return &ServerlessPayloadTooLargeError{
+			Action:          action,
+			PayloadBytes:    len(data),
+			MaxRequestBytes: r.MaxRequestBytes,
+		}
 	}
 
 	routine.Submit(routinepkg.Labels{
@@ -243,7 +306,15 @@ func (r *ServerlessPluginRuntime) Write(
 		routinepkg.RoutineLabelKeySessionID: sessionId,
 		routinepkg.RoutineLabelKeyLambdaURL: r.LambdaURL,
 	}, func() {
+		requestCtx := ctx
+		cancel := func() {}
+		if r.PluginMaxExecutionTimeout > 0 {
+			requestCtx, cancel = context.WithTimeout(ctx, time.Duration(r.PluginMaxExecutionTimeout)*time.Second)
+		}
+		defer cancel()
+
 		sendEnd := true
+		var endData json.RawMessage
 		sendError := func(errorResponse plugin_entities.ErrorResponse) {
 			if !sendEnd {
 				return
@@ -255,19 +326,23 @@ func (r *ServerlessPluginRuntime) Write(
 			})
 		}
 		defer func() {
+			deleteListener()
 			if sendEnd {
 				l.Send(plugin_entities.SessionMessage{
 					Type: plugin_entities.SESSION_MESSAGE_TYPE_END,
-					Data: []byte(""),
+					Data: endData,
 				})
 			}
 			l.Close()
-			r.listeners.Delete(sessionId)
 		}()
 
 		url += "?action=" + string(action)
-		response, err := r.invokeServerlessWithRetry(url, sessionId, data)
+		response, err := r.invokeServerlessWithRetry(requestCtx, url, sessionId, data, action)
 		if err != nil {
+			if ctx.Err() != nil {
+				sendEnd = false
+				return
+			}
 			log.Error(
 				"serverless runtime invocation failed before receiving a response",
 				"session_id", sessionId,
@@ -326,6 +401,7 @@ func (r *ServerlessPluginRuntime) Write(
 		scanner.Buffer(make([]byte, r.RuntimeBufferSize), r.RuntimeMaxBufferSize)
 
 		hasSessionEvent := false
+		receivedEnd := false
 		for sendEnd && scanner.Scan() {
 			line := scanner.Bytes()
 
@@ -362,6 +438,11 @@ func (r *ServerlessPluginRuntime) Write(
 						return
 					}
 					hasSessionEvent = true
+					if sessionMessage.Type == plugin_entities.SESSION_MESSAGE_TYPE_END {
+						receivedEnd = true
+						endData = sessionMessage.Data
+						return
+					}
 					l.Send(sessionMessage)
 				},
 				func() {},
@@ -378,9 +459,16 @@ func (r *ServerlessPluginRuntime) Write(
 				},
 				func(plugin_entities.PluginLogEvent) {},
 			)
+			if receivedEnd {
+				break
+			}
 		}
 
 		if err := scanner.Err(); err != nil {
+			if ctx.Err() != nil {
+				sendEnd = false
+				return
+			}
 			logFailure(
 				"serverless runtime response body could not be read",
 				nil,

--- a/internal/core/serverless_runtime/io_test.go
+++ b/internal/core/serverless_runtime/io_test.go
@@ -1,10 +1,13 @@
 package serverless_runtime
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -25,6 +28,7 @@ func TestShouldRetryStatusCode(t *testing.T) {
 		{"502 should retry", 502, true},
 		{"200 should not retry", 200, false},
 		{"404 should not retry", 404, false},
+		{"429 should not retry", 429, false},
 		{"500 should not retry", 500, false},
 		{"503 should not retry", 503, false},
 		{"504 should not retry", 504, false},
@@ -37,6 +41,54 @@ func TestShouldRetryStatusCode(t *testing.T) {
 				t.Errorf("shouldRetryStatusCode(%d) = %v, expected %v", tt.statusCode, result, tt.expected)
 			}
 		})
+	}
+}
+
+func TestServerlessRuntimeFailureType(t *testing.T) {
+	tests := []struct {
+		statusCode int
+		expected   string
+	}{
+		{statusCode: 0, expected: "transport"},
+		{statusCode: http.StatusTooManyRequests, expected: "rate_limit"},
+		{statusCode: http.StatusBadGateway, expected: "gateway"},
+		{statusCode: http.StatusInternalServerError, expected: "http"},
+	}
+
+	for _, tt := range tests {
+		if actual := serverlessRuntimeFailureType(tt.statusCode); actual != tt.expected {
+			t.Errorf(
+				"serverlessRuntimeFailureType(%d) = %q, expected %q",
+				tt.statusCode,
+				actual,
+				tt.expected,
+			)
+		}
+	}
+}
+
+func TestListenRemovesClosedListener(t *testing.T) {
+	runtime := &ServerlessPluginRuntime{
+		listeners: mapping.Map[string, *entities.Broadcast[plugin_entities.SessionMessage]]{},
+	}
+	listener, err := runtime.Listen("test-session")
+	if err != nil {
+		t.Fatalf("listen failed: %v", err)
+	}
+
+	var externalCloseCalls atomic.Int32
+	listener.OnClose(func() {
+		externalCloseCalls.Add(1)
+	})
+
+	listener.Close()
+	listener.Close()
+
+	if runtime.listeners.Len() != 0 {
+		t.Fatalf("expected listener cleanup, got %d listeners", runtime.listeners.Len())
+	}
+	if got := externalCloseCalls.Load(); got != 1 {
+		t.Fatalf("expected external close callback once, got %d calls", got)
 	}
 }
 
@@ -53,7 +105,13 @@ func TestInvokeServerlessWithRetry_Success(t *testing.T) {
 		PluginMaxExecutionTimeout: 10,
 	}
 
-	response, err := runtime.invokeServerlessWithRetry(server.URL, "test-session", []byte("test-data"))
+	response, err := runtime.invokeServerlessWithRetry(
+		context.Background(),
+		server.URL,
+		"test-session",
+		[]byte("test-data"),
+		"",
+	)
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -91,7 +149,13 @@ func TestInvokeServerlessWithRetry_RetryOn502(t *testing.T) {
 	}
 
 	startTime := time.Now()
-	response, err := runtime.invokeServerlessWithRetry(server.URL, "test-session", []byte("test-data"))
+	response, err := runtime.invokeServerlessWithRetry(
+		context.Background(),
+		server.URL,
+		"test-session",
+		[]byte("test-data"),
+		"",
+	)
 	duration := time.Since(startTime)
 
 	if err != nil {
@@ -134,7 +198,13 @@ func TestInvokeServerlessWithRetry_NoRetryOn404(t *testing.T) {
 		PluginMaxExecutionTimeout: 10,
 	}
 
-	response, err := runtime.invokeServerlessWithRetry(server.URL, "test-session", []byte("test-data"))
+	response, err := runtime.invokeServerlessWithRetry(
+		context.Background(),
+		server.URL,
+		"test-session",
+		[]byte("test-data"),
+		"",
+	)
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -164,7 +234,13 @@ func TestInvokeServerlessWithRetry_NoRetryOn500(t *testing.T) {
 		PluginMaxExecutionTimeout: 10,
 	}
 
-	response, err := runtime.invokeServerlessWithRetry(server.URL, "test-session", []byte("test-data"))
+	response, err := runtime.invokeServerlessWithRetry(
+		context.Background(),
+		server.URL,
+		"test-session",
+		[]byte("test-data"),
+		"",
+	)
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -194,7 +270,13 @@ func TestInvokeServerlessWithRetry_MaxRetriesExceeded(t *testing.T) {
 		PluginMaxExecutionTimeout: 10,
 	}
 
-	response, err := runtime.invokeServerlessWithRetry(server.URL, "test-session", []byte("test-data"))
+	response, err := runtime.invokeServerlessWithRetry(
+		context.Background(),
+		server.URL,
+		"test-session",
+		[]byte("test-data"),
+		"",
+	)
 
 	if err == nil {
 		t.Fatal("Expected error after max retries, got nil")
@@ -233,7 +315,13 @@ func TestInvokeServerlessWithRetry_ExponentialBackoff(t *testing.T) {
 		PluginMaxExecutionTimeout: 10,
 	}
 
-	_, err := runtime.invokeServerlessWithRetry(server.URL, "test-session", []byte("test-data"))
+	_, err := runtime.invokeServerlessWithRetry(
+		context.Background(),
+		server.URL,
+		"test-session",
+		[]byte("test-data"),
+		"",
+	)
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -261,6 +349,52 @@ func TestInvokeServerlessWithRetry_ExponentialBackoff(t *testing.T) {
 	}
 }
 
+func TestInvokeServerlessWithRetry_CancellationStopsBackoff(t *testing.T) {
+	requestCount := atomic.Int32{}
+	requestReceived := make(chan struct{}, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		requestReceived <- struct{}{}
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer server.Close()
+
+	runtime := &ServerlessPluginRuntime{
+		Client:                    server.Client(),
+		MaxRetryTimes:             3,
+		PluginMaxExecutionTimeout: 10,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() {
+		response, err := runtime.invokeServerlessWithRetry(
+			ctx,
+			server.URL,
+			"test-session",
+			[]byte("test-data"),
+			"",
+		)
+		if response != nil {
+			response.Body.Close()
+		}
+		result <- err
+	}()
+
+	<-requestReceived
+	cancel()
+	select {
+	case err := <-result:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context cancellation, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("retry backoff did not stop after cancellation")
+	}
+	if requestCount.Load() != 1 {
+		t.Fatalf("expected one request before cancellation, got %d", requestCount.Load())
+	}
+}
+
 func TestInvokeServerlessWithRetry_MaxRetriesZero(t *testing.T) {
 	attemptCount := atomic.Int32{}
 
@@ -276,7 +410,13 @@ func TestInvokeServerlessWithRetry_MaxRetriesZero(t *testing.T) {
 		PluginMaxExecutionTimeout: 10,
 	}
 
-	response, err := runtime.invokeServerlessWithRetry(server.URL, "test-session", []byte("test-data"))
+	response, err := runtime.invokeServerlessWithRetry(
+		context.Background(),
+		server.URL,
+		"test-session",
+		[]byte("test-data"),
+		"",
+	)
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -320,7 +460,13 @@ func TestInvokeServerlessWithRetry_RequestData(t *testing.T) {
 	}
 
 	testData := []byte(`{"test": "data"}`)
-	_, err := runtime.invokeServerlessWithRetry(server.URL, "test-session-123", testData)
+	_, err := runtime.invokeServerlessWithRetry(
+		context.Background(),
+		server.URL,
+		"test-session-123",
+		testData,
+		"",
+	)
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -356,6 +502,295 @@ func TestListen(t *testing.T) {
 	}
 }
 
+func TestWrite_PayloadAtLimitIsSent(t *testing.T) {
+	requestCount := atomic.Int32{}
+	payload := []byte("1234")
+	received := collectServerlessWriteMessagesWithPayload(
+		t,
+		func(w http.ResponseWriter, r *http.Request) {
+			requestCount.Add(1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(
+				`{"session_id":"test-session","event":"session","data":{"type":"stream","data":{"result":true}}}`,
+			))
+		},
+		len(payload),
+		payload,
+	)
+
+	if requestCount.Load() != 1 {
+		t.Fatalf("expected one HTTP request, got %d", requestCount.Load())
+	}
+	if len(received) != 2 {
+		t.Fatalf("expected stream and end messages, got %d: %#v", len(received), received)
+	}
+}
+
+func TestWriteTreatsPluginEndAsTerminal(t *testing.T) {
+	routine.InitPool(1)
+	requestCanceled := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(
+			"{\"session_id\":\"test-session\",\"event\":\"session\",\"data\":{\"type\":\"end\",\"data\":{\"reason\":\"done\"}}}\n" +
+				"{\"session_id\":\"test-session\",\"event\":\"session\",\"data\":{\"type\":\"stream\",\"data\":{\"result\":true}}}\n",
+		))
+		w.(http.Flusher).Flush()
+		<-r.Context().Done()
+		close(requestCanceled)
+	}))
+	t.Cleanup(server.Close)
+
+	runtime := &ServerlessPluginRuntime{
+		Client:                    server.Client(),
+		LambdaURL:                 server.URL,
+		MaxRequestBytes:           1024,
+		MaxRetryTimes:             1,
+		PluginMaxExecutionTimeout: 10,
+		RuntimeBufferSize:         1024,
+		RuntimeMaxBufferSize:      1024,
+		listeners:                 mapping.Map[string, *entities.Broadcast[plugin_entities.SessionMessage]]{},
+	}
+	listener, err := runtime.Listen("test-session")
+	if err != nil {
+		t.Fatalf("listen failed: %v", err)
+	}
+
+	streamSeen := make(chan struct{}, 1)
+	endSeen := make(chan json.RawMessage, 1)
+	listener.Listen(func(message plugin_entities.SessionMessage) {
+		switch message.Type {
+		case plugin_entities.SESSION_MESSAGE_TYPE_STREAM:
+			streamSeen <- struct{}{}
+		case plugin_entities.SESSION_MESSAGE_TYPE_END:
+			endSeen <- message.Data
+		}
+	})
+
+	if err := runtime.Write(
+		"test-session",
+		access_types.PLUGIN_ACCESS_ACTION_INVOKE_TEXT_EMBEDDING,
+		[]byte("{}"),
+	); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	select {
+	case endData := <-endSeen:
+		if string(endData) != `{"reason":"done"}` {
+			t.Fatalf("expected plugin END data to be preserved, got %s", endData)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for terminal end")
+	}
+	select {
+	case <-streamSeen:
+		t.Fatal("received stream event after terminal end")
+	default:
+	}
+	select {
+	case <-requestCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("server request was not canceled after terminal end")
+	}
+	if runtime.listeners.Len() != 0 {
+		t.Fatalf("expected listener cleanup, got %d listeners", runtime.listeners.Len())
+	}
+}
+
+func TestWriteContextCancelsHTTPRequest(t *testing.T) {
+	routine.InitPool(1)
+	requestStarted := make(chan struct{})
+	requestCanceled := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(requestStarted)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(
+			"{\"session_id\":\"test-session\",\"event\":\"session\",\"data\":{\"type\":\"stream\",\"data\":{\"result\":true}}}\n",
+		))
+		w.(http.Flusher).Flush()
+		<-r.Context().Done()
+		close(requestCanceled)
+	}))
+	t.Cleanup(server.Close)
+
+	runtime := &ServerlessPluginRuntime{
+		Client:                    server.Client(),
+		LambdaURL:                 server.URL,
+		MaxRequestBytes:           1024,
+		MaxRetryTimes:             1,
+		PluginMaxExecutionTimeout: 10,
+		RuntimeBufferSize:         1024,
+		RuntimeMaxBufferSize:      1024,
+		listeners:                 mapping.Map[string, *entities.Broadcast[plugin_entities.SessionMessage]]{},
+	}
+	listener, err := runtime.Listen("test-session")
+	if err != nil {
+		t.Fatalf("listen failed: %v", err)
+	}
+	streamSeen := make(chan struct{}, 1)
+	listenerClosed := make(chan struct{})
+	listener.Listen(func(message plugin_entities.SessionMessage) {
+		if message.Type == plugin_entities.SESSION_MESSAGE_TYPE_STREAM {
+			streamSeen <- struct{}{}
+		}
+	})
+	listener.OnClose(func() {
+		close(listenerClosed)
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	if err := runtime.WriteContext(
+		ctx,
+		"test-session",
+		access_types.PLUGIN_ACCESS_ACTION_INVOKE_TEXT_EMBEDDING,
+		[]byte("{}"),
+	); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	<-requestStarted
+	select {
+	case <-streamSeen:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for stream event")
+	}
+
+	cancel()
+	select {
+	case <-requestCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("server request did not observe cancellation")
+	}
+	select {
+	case <-listenerClosed:
+	case <-time.After(time.Second):
+		t.Fatal("listener was not closed after cancellation")
+	}
+	if runtime.listeners.Len() != 0 {
+		t.Fatalf("expected listener cleanup, got %d listeners", runtime.listeners.Len())
+	}
+}
+
+func TestWrite_ExecutionTimeoutSendsRuntimeError(t *testing.T) {
+	routine.InitPool(1)
+	requestCanceled := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		<-r.Context().Done()
+		close(requestCanceled)
+	}))
+	t.Cleanup(server.Close)
+
+	runtime := &ServerlessPluginRuntime{
+		Client:                    server.Client(),
+		LambdaURL:                 server.URL,
+		MaxRequestBytes:           1024,
+		MaxRetryTimes:             1,
+		PluginMaxExecutionTimeout: 1,
+		RuntimeBufferSize:         1024,
+		RuntimeMaxBufferSize:      1024,
+		listeners:                 mapping.Map[string, *entities.Broadcast[plugin_entities.SessionMessage]]{},
+	}
+	listener, err := runtime.Listen("test-session")
+	if err != nil {
+		t.Fatalf("listen failed: %v", err)
+	}
+	messages := make(chan plugin_entities.SessionMessage, 2)
+	listenerClosed := make(chan struct{})
+	listener.Listen(func(message plugin_entities.SessionMessage) {
+		messages <- message
+	})
+	listener.OnClose(func() {
+		close(listenerClosed)
+	})
+
+	if err := runtime.Write(
+		"test-session",
+		access_types.PLUGIN_ACCESS_ACTION_INVOKE_TEXT_EMBEDDING,
+		[]byte("{}"),
+	); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	select {
+	case <-listenerClosed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("listener was not closed after execution timeout")
+	}
+	select {
+	case <-requestCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("server request did not observe execution timeout")
+	}
+
+	close(messages)
+	received := make([]plugin_entities.SessionMessage, 0, len(messages))
+	for message := range messages {
+		received = append(received, message)
+	}
+	if len(received) != 1 || received[0].Type != plugin_entities.SESSION_MESSAGE_TYPE_ERROR {
+		t.Fatalf("expected one runtime error, got %#v", received)
+	}
+	var errorResponse plugin_entities.ErrorResponse
+	if err := json.Unmarshal(received[0].Data, &errorResponse); err != nil {
+		t.Fatalf("unmarshal error response: %v", err)
+	}
+	if !strings.Contains(errorResponse.Message, context.DeadlineExceeded.Error()) {
+		t.Fatalf("expected deadline error, got %q", errorResponse.Message)
+	}
+}
+
+func TestWrite_PayloadOverLimitFailsBeforeHTTPRequest(t *testing.T) {
+	requestCount := atomic.Int32{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	runtime := &ServerlessPluginRuntime{
+		Client:                    server.Client(),
+		LambdaURL:                 server.URL,
+		MaxRequestBytes:           3,
+		MaxRetryTimes:             3,
+		PluginMaxExecutionTimeout: 10,
+		RuntimeBufferSize:         1024,
+		RuntimeMaxBufferSize:      1024,
+		listeners:                 mapping.Map[string, *entities.Broadcast[plugin_entities.SessionMessage]]{},
+	}
+	listener, err := runtime.Listen("test-session")
+	if err != nil {
+		t.Fatalf("listen failed: %v", err)
+	}
+	t.Cleanup(listener.Close)
+
+	action := access_types.PLUGIN_ACCESS_ACTION_VALIDATE_TOOL_CREDENTIALS
+	err = runtime.Write("test-session", action, []byte("1234"))
+	if err == nil {
+		t.Fatal("expected oversized payload to fail")
+	}
+
+	var payloadTooLargeError *ServerlessPayloadTooLargeError
+	if !errors.As(err, &payloadTooLargeError) {
+		t.Fatalf("expected ServerlessPayloadTooLargeError, got %T: %v", err, err)
+	}
+	if payloadTooLargeError.Action != action {
+		t.Errorf("expected action %q, got %q", action, payloadTooLargeError.Action)
+	}
+	if payloadTooLargeError.PayloadBytes != 4 {
+		t.Errorf("expected payload size 4, got %d", payloadTooLargeError.PayloadBytes)
+	}
+	if payloadTooLargeError.MaxRequestBytes != 3 {
+		t.Errorf("expected max request size 3, got %d", payloadTooLargeError.MaxRequestBytes)
+	}
+	if requestCount.Load() != 0 {
+		t.Fatalf("expected no HTTP requests, got %d", requestCount.Load())
+	}
+	if runtime.listeners.Len() != 0 {
+		t.Fatalf("expected listener cleanup, got %d listeners", runtime.listeners.Len())
+	}
+}
+
 func TestWrite_NonSuccessResponseSendsRuntimeError(t *testing.T) {
 	received := collectServerlessWriteMessages(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("x-amzn-ErrorType", "Runtime.ExitError")
@@ -369,6 +804,27 @@ func TestWrite_NonSuccessResponseSendsRuntimeError(t *testing.T) {
 		received,
 		"Plugin runtime request failed: Runtime.ExitError",
 		http.StatusInternalServerError,
+	)
+}
+
+func TestWrite_RateLimitDoesNotRetry(t *testing.T) {
+	requestCount := atomic.Int32{}
+	received := collectServerlessWriteMessages(t, func(w http.ResponseWriter, _ *http.Request) {
+		requestCount.Add(1)
+		w.Header().Set("x-amzn-ErrorType", "TooManyRequestsException")
+		w.Header().Set("x-amzn-RequestId", "lambda-request-id")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"errorType":"TooManyRequestsException","errorMessage":"rate exceeded"}`))
+	})
+
+	if requestCount.Load() != 1 {
+		t.Fatalf("expected 429 response not to be retried, got %d requests", requestCount.Load())
+	}
+	requireRuntimeError(
+		t,
+		received,
+		"Plugin runtime request failed: TooManyRequestsException: rate exceeded",
+		http.StatusTooManyRequests,
 	)
 }
 
@@ -421,6 +877,20 @@ func TestWrite_SuccessResponseWithSessionEventStillEndsNormally(t *testing.T) {
 }
 
 func collectServerlessWriteMessages(t *testing.T, handler http.HandlerFunc) []plugin_entities.SessionMessage {
+	return collectServerlessWriteMessagesWithPayload(
+		t,
+		handler,
+		1024,
+		[]byte(`{"credentials":{"api_key":"secret"}}`),
+	)
+}
+
+func collectServerlessWriteMessagesWithPayload(
+	t *testing.T,
+	handler http.HandlerFunc,
+	maxRequestBytes int,
+	payload []byte,
+) []plugin_entities.SessionMessage {
 	t.Helper()
 	routine.InitPool(1)
 
@@ -430,6 +900,7 @@ func collectServerlessWriteMessages(t *testing.T, handler http.HandlerFunc) []pl
 	runtime := &ServerlessPluginRuntime{
 		Client:                    server.Client(),
 		LambdaURL:                 server.URL,
+		MaxRequestBytes:           maxRequestBytes,
 		MaxRetryTimes:             1,
 		PluginMaxExecutionTimeout: 10,
 		RuntimeBufferSize:         1024,
@@ -454,7 +925,7 @@ func collectServerlessWriteMessages(t *testing.T, handler http.HandlerFunc) []pl
 	if err := runtime.Write(
 		"test-session",
 		access_types.PLUGIN_ACCESS_ACTION_VALIDATE_TOOL_CREDENTIALS,
-		[]byte(`{"credentials":{"api_key":"secret"}}`),
+		payload,
 	); err != nil {
 		t.Fatalf("write failed: %v", err)
 	}
@@ -537,7 +1008,13 @@ func TestInvokeServerlessWithRetry_BodyClosedOnRetry(t *testing.T) {
 		PluginMaxExecutionTimeout: 10,
 	}
 
-	response, err := runtime.invokeServerlessWithRetry(server.URL, "test-session", []byte("test-data"))
+	response, err := runtime.invokeServerlessWithRetry(
+		context.Background(),
+		server.URL,
+		"test-session",
+		[]byte("test-data"),
+		"",
+	)
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}

--- a/internal/core/serverless_runtime/otel_metrics.go
+++ b/internal/core/serverless_runtime/otel_metrics.go
@@ -1,0 +1,69 @@
+package serverless_runtime
+
+import (
+	"context"
+	"sync"
+
+	"github.com/langgenius/dify-plugin-daemon/internal/core/io_tunnel/access_types"
+	"github.com/langgenius/dify-plugin-daemon/pkg/utils/log"
+	gootel "go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+const (
+	serverlessRuntimeMetricScope        = "dify-plugin-daemon/serverless-runtime"
+	serverlessRuntimeFailuresMetricName = "plugin.serverless.runtime.failures"
+)
+
+var (
+	serverlessRuntimeFailuresOnce    sync.Once
+	serverlessRuntimeFailuresCounter metric.Int64Counter
+	serverlessRuntimeFailuresErr     error
+)
+
+func recordServerlessRuntimeFailure(
+	action access_types.PluginAccessAction,
+	statusCode int,
+	failureType string,
+) {
+	serverlessRuntimeFailuresOnce.Do(func() {
+		serverlessRuntimeFailuresCounter, serverlessRuntimeFailuresErr = gootel.Meter(
+			serverlessRuntimeMetricScope,
+		).Int64Counter(
+			serverlessRuntimeFailuresMetricName,
+			metric.WithDescription("Number of failed requests to a serverless plugin Function URL."),
+			metric.WithUnit("{failure}"),
+		)
+		if serverlessRuntimeFailuresErr != nil {
+			log.Warn("failed to init serverless runtime failure counter", "error", serverlessRuntimeFailuresErr)
+		}
+	})
+	if serverlessRuntimeFailuresErr != nil {
+		return
+	}
+
+	serverlessRuntimeFailuresCounter.Add(
+		context.Background(),
+		1,
+		metric.WithAttributes(
+			attribute.String("plugin.action", string(action)),
+			attribute.Int("http.response.status_code", statusCode),
+			attribute.String("failure.type", failureType),
+			attribute.String("failure.source", "lambda_function_url"),
+		),
+	)
+}
+
+func serverlessRuntimeFailureType(statusCode int) string {
+	switch statusCode {
+	case 0:
+		return "transport"
+	case 429:
+		return "rate_limit"
+	case 502:
+		return "gateway"
+	default:
+		return "http"
+	}
+}

--- a/internal/core/serverless_runtime/type.go
+++ b/internal/core/serverless_runtime/type.go
@@ -30,9 +30,14 @@ type ServerlessPluginRuntime struct {
 
 	PluginMaxExecutionTimeout int // in seconds
 	MaxRetryTimes             int // maximum retry times for serverless invocation
+	MaxRequestBytes           int // maximum serialized request payload size
 
 	RuntimeBufferSize    int
 	RuntimeMaxBufferSize int
+}
+
+func (r *ServerlessPluginRuntime) MaxServerlessRequestBytes() int {
+	return r.MaxRequestBytes
 }
 
 // build a serverless plugin runtime
@@ -59,6 +64,7 @@ func ConstructServerlessPluginRuntime(
 		LambdaName:                serverlessModel.FunctionName,
 		PluginMaxExecutionTimeout: config.PluginMaxExecutionTimeout,
 		MaxRetryTimes:             config.MaxServerlessRetryTimes,
+		MaxRequestBytes:           config.MaxServerlessRequestBytes,
 		RuntimeBufferSize:         config.PluginRuntimeBufferSize,
 		RuntimeMaxBufferSize:      config.PluginRuntimeMaxBufferSize,
 

--- a/internal/core/session_manager/session.go
+++ b/internal/core/session_manager/session.go
@@ -300,6 +300,15 @@ type pluginInStreamMessage struct {
 	Data           any                    `json:"data"`
 }
 
+type runtimeContextWriter interface {
+	WriteContext(
+		ctx context.Context,
+		sessionID string,
+		action access_types.PluginAccessAction,
+		data []byte,
+	) error
+}
+
 func (s *Session) Message(event PLUGIN_IN_STREAM_EVENT, data any) []byte {
 	b, _ := json.Marshal(pluginInStreamMessage{
 		SessionID:      s.ID,
@@ -315,8 +324,21 @@ func (s *Session) Message(event PLUGIN_IN_STREAM_EVENT, data any) []byte {
 }
 
 func (s *Session) Write(event PLUGIN_IN_STREAM_EVENT, action access_types.PluginAccessAction, data any) error {
+	return s.WriteContext(s.RequestContext(), event, action, data)
+}
+
+func (s *Session) WriteContext(
+	ctx context.Context,
+	event PLUGIN_IN_STREAM_EVENT,
+	action access_types.PluginAccessAction,
+	data any,
+) error {
 	if s.runtime == nil {
 		return errors.New("runtime not bound")
 	}
-	return s.runtime.Write(s.ID, action, s.Message(event, data))
+	message := s.Message(event, data)
+	if runtime, ok := s.runtime.(runtimeContextWriter); ok {
+		return runtime.WriteContext(ctx, s.ID, action, message)
+	}
+	return s.runtime.Write(s.ID, action, message)
 }

--- a/internal/server/controllers/controllers.go
+++ b/internal/server/controllers/controllers.go
@@ -1,3 +1,3 @@
-//go:generate go run ../../cmd/codegen/main.go
+//go:generate go -C ../../.. run ./cmd/codegen/main.go
 
 package controllers

--- a/internal/server/controllers/definitions/definitions.go
+++ b/internal/server/controllers/definitions/definitions.go
@@ -12,17 +12,18 @@ import (
 
 // PluginDispatcher defines a plugin dispatcher
 type PluginDispatcher struct {
-	Name               string
-	RequestType        interface{} // e.g. requests.RequestInvokeLLM
-	ResponseType       interface{} // e.g. requests.ResponseInvokeLLM
-	RequestTypeString  string
-	ResponseTypeString string
-	AccessType         access_types.PluginAccessType
-	AccessAction       access_types.PluginAccessAction
-	AccessTypeString   string
-	AccessActionString string
-	BufferSize         int
-	Path               string // e.g. "/tool/invoke"
+	Name                string
+	RequestType         interface{} // e.g. requests.RequestInvokeLLM
+	ResponseType        interface{} // e.g. requests.ResponseInvokeLLM
+	RequestTypeString   string
+	ResponseTypeString  string
+	AccessType          access_types.PluginAccessType
+	AccessAction        access_types.PluginAccessAction
+	AccessTypeString    string
+	AccessActionString  string
+	BufferSize          int
+	CustomTunnelHandler string
+	Path                string // e.g. "/tool/invoke"
 }
 
 // Define all plugin dispatchers
@@ -83,37 +84,39 @@ var PluginDispatchers = []PluginDispatcher{
 		Path:               "/llm/num_tokens",
 	},
 	{
-		Name:               "InvokeTextEmbedding",
-		RequestType:        requests.RequestInvokeTextEmbedding{},
-		ResponseType:       model_entities.TextEmbeddingResult{},
-		AccessType:         access_types.PLUGIN_ACCESS_TYPE_MODEL,
-		AccessAction:       access_types.PLUGIN_ACCESS_ACTION_INVOKE_TEXT_EMBEDDING,
-		AccessTypeString:   "access_types.PLUGIN_ACCESS_TYPE_MODEL",
-		AccessActionString: "access_types.PLUGIN_ACCESS_ACTION_INVOKE_TEXT_EMBEDDING",
-		BufferSize:         1,
-		Path:               "/text_embedding/invoke",
+		Name:                "InvokeTextEmbedding",
+		RequestType:         requests.RequestInvokeTextEmbedding{},
+		ResponseType:        model_entities.TextEmbeddingResult{},
+		AccessType:          access_types.PLUGIN_ACCESS_TYPE_MODEL,
+		AccessAction:        access_types.PLUGIN_ACCESS_ACTION_INVOKE_TEXT_EMBEDDING,
+		AccessTypeString:    "access_types.PLUGIN_ACCESS_TYPE_MODEL",
+		AccessActionString:  "access_types.PLUGIN_ACCESS_ACTION_INVOKE_TEXT_EMBEDDING",
+		BufferSize:          1,
+		CustomTunnelHandler: "invokeTextEmbeddingServerlessAware",
+		Path:                "/text_embedding/invoke",
 	},
 	{
 		Name:               "InvokeMultimodalEmbedding",
 		RequestType:        requests.RequestInvokeMultimodalEmbedding{},
 		ResponseType:       model_entities.MultimodalEmbeddingResult{},
 		AccessType:         access_types.PLUGIN_ACCESS_TYPE_MODEL,
-		AccessAction:       access_types.PLUGIN_ACCESS_ACTION_INVOKE_TEXT_EMBEDDING,
+		AccessAction:       access_types.PLUGIN_ACCESS_ACTION_INVOKE_MULTIMODAL_EMBEDDING,
 		AccessTypeString:   "access_types.PLUGIN_ACCESS_TYPE_MODEL",
-		AccessActionString: "access_types.PLUGIN_ACCESS_ACTION_INVOKE_TEXT_EMBEDDING",
+		AccessActionString: "access_types.PLUGIN_ACCESS_ACTION_INVOKE_MULTIMODAL_EMBEDDING",
 		BufferSize:         1,
 		Path:               "/multimodal_embedding/invoke",
 	},
 	{
-		Name:               "GetTextEmbeddingNumTokens",
-		RequestType:        requests.RequestGetTextEmbeddingNumTokens{},
-		ResponseType:       model_entities.GetTextEmbeddingNumTokensResponse{},
-		AccessType:         access_types.PLUGIN_ACCESS_TYPE_MODEL,
-		AccessAction:       access_types.PLUGIN_ACCESS_ACTION_GET_TEXT_EMBEDDING_NUM_TOKENS,
-		AccessTypeString:   "access_types.PLUGIN_ACCESS_TYPE_MODEL",
-		AccessActionString: "access_types.PLUGIN_ACCESS_ACTION_GET_TEXT_EMBEDDING_NUM_TOKENS",
-		BufferSize:         1,
-		Path:               "/text_embedding/num_tokens",
+		Name:                "GetTextEmbeddingNumTokens",
+		RequestType:         requests.RequestGetTextEmbeddingNumTokens{},
+		ResponseType:        model_entities.GetTextEmbeddingNumTokensResponse{},
+		AccessType:          access_types.PLUGIN_ACCESS_TYPE_MODEL,
+		AccessAction:        access_types.PLUGIN_ACCESS_ACTION_GET_TEXT_EMBEDDING_NUM_TOKENS,
+		AccessTypeString:    "access_types.PLUGIN_ACCESS_TYPE_MODEL",
+		AccessActionString:  "access_types.PLUGIN_ACCESS_ACTION_GET_TEXT_EMBEDDING_NUM_TOKENS",
+		BufferSize:          1,
+		CustomTunnelHandler: "getTextEmbeddingNumTokensServerlessAware",
+		Path:                "/text_embedding/num_tokens",
 	},
 	{
 		Name:               "InvokeRerank",
@@ -131,9 +134,9 @@ var PluginDispatchers = []PluginDispatcher{
 		RequestType:        requests.RequestInvokeMultimodalRerank{},
 		ResponseType:       model_entities.MultimodalRerankResult{},
 		AccessType:         access_types.PLUGIN_ACCESS_TYPE_MODEL,
-		AccessAction:       access_types.PLUGIN_ACCESS_ACTION_INVOKE_RERANK,
+		AccessAction:       access_types.PLUGIN_ACCESS_ACTION_INVOKE_MULTIMODAL_RERANK,
 		AccessTypeString:   "access_types.PLUGIN_ACCESS_TYPE_MODEL",
-		AccessActionString: "access_types.PLUGIN_ACCESS_ACTION_INVOKE_RERANK",
+		AccessActionString: "access_types.PLUGIN_ACCESS_ACTION_INVOKE_MULTIMODAL_RERANK",
 		BufferSize:         1,
 		Path:               "/multimodal_rerank/invoke",
 	},

--- a/internal/server/controllers/definitions/definitions_test.go
+++ b/internal/server/controllers/definitions/definitions_test.go
@@ -1,0 +1,50 @@
+package definitions
+
+import (
+	"testing"
+
+	"github.com/langgenius/dify-plugin-daemon/internal/core/io_tunnel/access_types"
+)
+
+func TestEmbeddingDispatchersUseServerlessAwareHandlers(t *testing.T) {
+	want := map[string]string{
+		"InvokeTextEmbedding":       "invokeTextEmbeddingServerlessAware",
+		"GetTextEmbeddingNumTokens": "getTextEmbeddingNumTokensServerlessAware",
+	}
+	found := map[string]string{}
+
+	for _, dispatcher := range PluginDispatchers {
+		if dispatcher.CustomTunnelHandler != "" {
+			found[dispatcher.Name] = dispatcher.CustomTunnelHandler
+		}
+	}
+
+	if len(found) != len(want) {
+		t.Fatalf("custom handler count = %d, want %d: %#v", len(found), len(want), found)
+	}
+	for name, handler := range want {
+		if found[name] != handler {
+			t.Errorf("dispatcher %s custom handler = %q, want %q", name, found[name], handler)
+		}
+	}
+}
+
+func TestMultimodalDispatchersPreserveDedicatedActions(t *testing.T) {
+	want := map[string]access_types.PluginAccessAction{
+		"InvokeMultimodalEmbedding": access_types.PLUGIN_ACCESS_ACTION_INVOKE_MULTIMODAL_EMBEDDING,
+		"InvokeMultimodalRerank":    access_types.PLUGIN_ACCESS_ACTION_INVOKE_MULTIMODAL_RERANK,
+	}
+	found := map[string]access_types.PluginAccessAction{}
+
+	for _, dispatcher := range PluginDispatchers {
+		if _, ok := want[dispatcher.Name]; ok {
+			found[dispatcher.Name] = dispatcher.AccessAction
+		}
+	}
+
+	for name, action := range want {
+		if found[name] != action {
+			t.Errorf("dispatcher %s action = %q, want %q", name, found[name], action)
+		}
+	}
+}

--- a/internal/server/controllers/generator/generator.go
+++ b/internal/server/controllers/generator/generator.go
@@ -114,7 +114,7 @@ func GeneratePluginDaemon(accessType access_types.PluginAccessType, dispatchers 
 	tmpl := template.Must(template.New("pluginDaemon").Parse(pluginDaemonTemplate))
 
 	// Create output file
-	outputPath := filepath.Join("internal", "core", "plugin_daemon", strings.ToLower(string(accessType))+".gen.go")
+	outputPath := pluginDaemonOutputPath(accessType)
 
 	// Execute template
 	var buf strings.Builder
@@ -152,6 +152,10 @@ func GeneratePluginDaemon(accessType access_types.PluginAccessType, dispatchers 
 	}
 
 	return nil
+}
+
+func pluginDaemonOutputPath(accessType access_types.PluginAccessType) string {
+	return filepath.Join("internal", "core", "io_tunnel", strings.ToLower(string(accessType))+".gen.go")
 }
 
 // GenerateHTTPServer generates a http server file for the given access type

--- a/internal/server/controllers/generator/generator_test.go
+++ b/internal/server/controllers/generator/generator_test.go
@@ -1,0 +1,59 @@
+package generator
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"text/template"
+
+	"github.com/langgenius/dify-plugin-daemon/internal/core/io_tunnel/access_types"
+	"github.com/langgenius/dify-plugin-daemon/internal/server/controllers/definitions"
+)
+
+func TestPluginDaemonOutputPath(t *testing.T) {
+	got := pluginDaemonOutputPath(access_types.PLUGIN_ACCESS_TYPE_MODEL)
+	want := filepath.Join("internal", "core", "io_tunnel", "model.gen.go")
+
+	if got != want {
+		t.Fatalf("pluginDaemonOutputPath() = %q, want %q", got, want)
+	}
+}
+
+func TestPluginDaemonTemplateRoutesOnlyConfiguredCustomHandlers(t *testing.T) {
+	dispatchers := []*definitions.PluginDispatcher{
+		{
+			Name:                "CustomHandler",
+			RequestTypeString:   "requests.CustomRequest",
+			ResponseTypeString:  "responses.CustomResponse",
+			BufferSize:          1,
+			CustomTunnelHandler: "customTunnelHandler",
+		},
+		{
+			Name:               "GenericHandler",
+			RequestTypeString:  "requests.GenericRequest",
+			ResponseTypeString: "responses.GenericResponse",
+			BufferSize:         1,
+		},
+	}
+	tmpl := template.Must(template.New("pluginDaemon").Parse(pluginDaemonTemplate))
+	var output strings.Builder
+
+	err := tmpl.Execute(&output, struct {
+		AccessType  access_types.PluginAccessType
+		Dispatchers []*definitions.PluginDispatcher
+	}{
+		AccessType:  access_types.PLUGIN_ACCESS_TYPE_MODEL,
+		Dispatchers: dispatchers,
+	})
+	if err != nil {
+		t.Fatalf("execute plugin daemon template: %v", err)
+	}
+
+	generated := output.String()
+	if !strings.Contains(generated, "return customTunnelHandler(") {
+		t.Fatalf("custom handler was not generated:\n%s", generated)
+	}
+	if count := strings.Count(generated, "return GenericInvokePlugin["); count != 1 {
+		t.Fatalf("GenericInvokePlugin call count = %d, want 1:\n%s", count, generated)
+	}
+}

--- a/internal/server/controllers/generator/templates.go
+++ b/internal/server/controllers/generator/templates.go
@@ -82,11 +82,18 @@ func {{.Name}}(
 ) (
 	*stream.Stream[{{.ResponseTypeString}}], error,
 ) {
+	{{- if .CustomTunnelHandler}}
+	return {{.CustomTunnelHandler}}(
+		session,
+		request,
+	)
+	{{- else}}
 	return GenericInvokePlugin[{{.RequestTypeString}}, {{.ResponseTypeString}}](
 		session,
 		request,
 		{{.BufferSize}},
 	)
+	{{- end}}
 }
 {{end}}
 `

--- a/internal/service/datasource.gen.go
+++ b/internal/service/datasource.gen.go
@@ -7,10 +7,10 @@ import (
 	"github.com/langgenius/dify-plugin-daemon/internal/core/io_tunnel"
 	"github.com/langgenius/dify-plugin-daemon/internal/core/io_tunnel/access_types"
 	"github.com/langgenius/dify-plugin-daemon/internal/core/session_manager"
-	"github.com/langgenius/dify-plugin-daemon/pkg/utils/stream"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/datasource_entities"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/plugin_entities"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/requests"
+	"github.com/langgenius/dify-plugin-daemon/pkg/utils/stream"
 )
 
 func DatasourceValidateCredentials(

--- a/internal/service/dynamic_parameter.gen.go
+++ b/internal/service/dynamic_parameter.gen.go
@@ -7,10 +7,10 @@ import (
 	"github.com/langgenius/dify-plugin-daemon/internal/core/io_tunnel"
 	"github.com/langgenius/dify-plugin-daemon/internal/core/io_tunnel/access_types"
 	"github.com/langgenius/dify-plugin-daemon/internal/core/session_manager"
-	"github.com/langgenius/dify-plugin-daemon/pkg/utils/stream"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/dynamic_select_entities"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/plugin_entities"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/requests"
+	"github.com/langgenius/dify-plugin-daemon/pkg/utils/stream"
 )
 
 func FetchDynamicParameterOptions(

--- a/internal/service/model.gen.go
+++ b/internal/service/model.gen.go
@@ -7,10 +7,10 @@ import (
 	"github.com/langgenius/dify-plugin-daemon/internal/core/io_tunnel"
 	"github.com/langgenius/dify-plugin-daemon/internal/core/io_tunnel/access_types"
 	"github.com/langgenius/dify-plugin-daemon/internal/core/session_manager"
-	"github.com/langgenius/dify-plugin-daemon/pkg/utils/stream"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/model_entities"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/plugin_entities"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/requests"
+	"github.com/langgenius/dify-plugin-daemon/pkg/utils/stream"
 )
 
 func InvokeLLM(

--- a/internal/service/oauth.gen.go
+++ b/internal/service/oauth.gen.go
@@ -7,10 +7,10 @@ import (
 	"github.com/langgenius/dify-plugin-daemon/internal/core/io_tunnel"
 	"github.com/langgenius/dify-plugin-daemon/internal/core/io_tunnel/access_types"
 	"github.com/langgenius/dify-plugin-daemon/internal/core/session_manager"
-	"github.com/langgenius/dify-plugin-daemon/pkg/utils/stream"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/oauth_entities"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/plugin_entities"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/requests"
+	"github.com/langgenius/dify-plugin-daemon/pkg/utils/stream"
 )
 
 func GetAuthorizationURL(

--- a/internal/service/tool.gen.go
+++ b/internal/service/tool.gen.go
@@ -7,10 +7,10 @@ import (
 	"github.com/langgenius/dify-plugin-daemon/internal/core/io_tunnel"
 	"github.com/langgenius/dify-plugin-daemon/internal/core/io_tunnel/access_types"
 	"github.com/langgenius/dify-plugin-daemon/internal/core/session_manager"
-	"github.com/langgenius/dify-plugin-daemon/pkg/utils/stream"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/plugin_entities"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/requests"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/tool_entities"
+	"github.com/langgenius/dify-plugin-daemon/pkg/utils/stream"
 )
 
 func InvokeTool(

--- a/internal/service/trigger.gen.go
+++ b/internal/service/trigger.gen.go
@@ -7,9 +7,9 @@ import (
 	"github.com/langgenius/dify-plugin-daemon/internal/core/io_tunnel"
 	"github.com/langgenius/dify-plugin-daemon/internal/core/io_tunnel/access_types"
 	"github.com/langgenius/dify-plugin-daemon/internal/core/session_manager"
-	"github.com/langgenius/dify-plugin-daemon/pkg/utils/stream"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/plugin_entities"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/requests"
+	"github.com/langgenius/dify-plugin-daemon/pkg/utils/stream"
 )
 
 func TriggerInvokeEvent(

--- a/internal/types/app/config.go
+++ b/internal/types/app/config.go
@@ -200,6 +200,7 @@ type Config struct {
 	DifyPluginServerlessConnectorLaunchTimeout int     `envconfig:"DIFY_PLUGIN_SERVERLESS_CONNECTOR_LAUNCH_TIMEOUT"`
 
 	MaxServerlessRetryTimes         int   `envconfig:"MAX_SERVERLESS_RETRY_TIMES" default:"3"`
+	MaxServerlessRequestBytes       int   `envconfig:"MAX_SERVERLESS_REQUEST_BYTES" default:"5242880"`
 	MaxPluginPackageSize            int64 `envconfig:"MAX_PLUGIN_PACKAGE_SIZE" validate:"required"`
 	MaxBundlePackageSize            int64 `envconfig:"MAX_BUNDLE_PACKAGE_SIZE" validate:"required"`
 	MaxServerlessTransactionTimeout int   `envconfig:"MAX_SERVERLESS_TRANSACTION_TIMEOUT"`
@@ -295,6 +296,10 @@ func (c *Config) Validate() error {
 		if c.PluginRemoteInstallServerEventLoopNums == 0 {
 			return fmt.Errorf("plugin remote install server event loop nums is empty")
 		}
+	}
+
+	if c.MaxServerlessRequestBytes <= 0 {
+		return fmt.Errorf("max serverless request bytes must be greater than zero")
 	}
 
 	switch c.Platform {

--- a/internal/types/app/config_test.go
+++ b/internal/types/app/config_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/kelseyhightower/envconfig"
@@ -84,6 +85,35 @@ func TestConfigRedisKeyPrefixField(t *testing.T) {
 	cfg := Config{}
 	require.NoError(t, envconfig.Process("", &cfg))
 	assert.Equal(t, "enterprise-a", cfg.RedisKeyPrefix)
+}
+
+func TestMaxServerlessRequestBytesDefault(t *testing.T) {
+	originalValue, hadOriginalValue := os.LookupEnv("MAX_SERVERLESS_REQUEST_BYTES")
+	require.NoError(t, os.Unsetenv("MAX_SERVERLESS_REQUEST_BYTES"))
+	t.Cleanup(func() {
+		if hadOriginalValue {
+			require.NoError(t, os.Setenv("MAX_SERVERLESS_REQUEST_BYTES", originalValue))
+			return
+		}
+		require.NoError(t, os.Unsetenv("MAX_SERVERLESS_REQUEST_BYTES"))
+	})
+
+	cfg := Config{}
+	require.NoError(t, envconfig.Process("", &cfg))
+	assert.Equal(t, 5*1024*1024, cfg.MaxServerlessRequestBytes)
+}
+
+func TestValidateRejectsNonPositiveMaxServerlessRequestBytes(t *testing.T) {
+	for _, maxRequestBytes := range []int{0, -1} {
+		t.Run("max_request_bytes_"+strconv.Itoa(maxRequestBytes), func(t *testing.T) {
+			config := newValidConfigForValidation()
+			config.MaxServerlessRequestBytes = maxRequestBytes
+
+			err := config.Validate()
+
+			require.EqualError(t, err, "max serverless request bytes must be greater than zero")
+		})
+	}
 }
 
 func TestPipMirrorAutoDetectDefault(t *testing.T) {

--- a/internal/types/app/default.go
+++ b/internal/types/app/default.go
@@ -24,6 +24,7 @@ func (config *Config) SetDefault() {
 	setDefaultInt(&config.PluginRemoteInstallingMaxConn, 256)
 	setDefaultInt(&config.MaxPluginPackageSize, 52428800)
 	setDefaultInt(&config.MaxBundlePackageSize, 52428800*12)
+	setDefaultInt(&config.MaxServerlessRequestBytes, 5*1024*1024)
 	setDefaultInt(&config.MaxServerlessTransactionTimeout, 300)
 	setDefaultInt(&config.PluginMaxExecutionTimeout, 10*60)
 	setDefaultString(&config.PluginStorageType, oss.OSS_TYPE_LOCAL)

--- a/pkg/entities/listener.go
+++ b/pkg/entities/listener.go
@@ -4,8 +4,9 @@ import "sync"
 
 type Broadcast[T any] struct {
 	l        *sync.RWMutex
-	onClose  func()
+	onClose  []func()
 	listener []func(T)
+	closed   bool
 }
 
 type BytesIOListener = Broadcast[[]byte]
@@ -23,19 +24,38 @@ func (r *Broadcast[T]) Listen(f func(T)) {
 }
 
 func (r *Broadcast[T]) OnClose(f func()) {
-	r.onClose = f
+	r.l.Lock()
+	if r.closed {
+		r.l.Unlock()
+		f()
+		return
+	}
+	r.onClose = append(r.onClose, f)
+	r.l.Unlock()
 }
 
 func (r *Broadcast[T]) Close() {
-	if r.onClose != nil {
-		r.onClose()
+	r.l.Lock()
+	if r.closed {
+		r.l.Unlock()
+		return
+	}
+	r.closed = true
+	onClose := append([]func(){}, r.onClose...)
+	r.onClose = nil
+	r.l.Unlock()
+
+	for _, f := range onClose {
+		f()
 	}
 }
 
 func (r *Broadcast[T]) Send(data T) {
 	r.l.RLock()
-	defer r.l.RUnlock()
-	for _, listener := range r.listener {
+	listeners := append([]func(T){}, r.listener...)
+	r.l.RUnlock()
+
+	for _, listener := range listeners {
 		listener(data)
 	}
 }

--- a/pkg/entities/listener_test.go
+++ b/pkg/entities/listener_test.go
@@ -1,0 +1,57 @@
+package entities
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestBroadcastCloseRunsAllCallbacksOnce(t *testing.T) {
+	listener := NewCallbackHandler[int]()
+	var calls atomic.Int32
+
+	listener.OnClose(func() {
+		calls.Add(1)
+	})
+	listener.OnClose(func() {
+		calls.Add(1)
+	})
+
+	listener.Close()
+	listener.Close()
+
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("expected both callbacks to run once, got %d calls", got)
+	}
+}
+
+func TestBroadcastOnCloseAddedAfterCloseRunsImmediately(t *testing.T) {
+	listener := NewCallbackHandler[int]()
+	listener.Close()
+
+	var called atomic.Bool
+	listener.OnClose(func() {
+		called.Store(true)
+	})
+
+	if !called.Load() {
+		t.Fatal("expected callback added after close to run immediately")
+	}
+}
+
+func TestBroadcastListenerCanCloseFromCallback(t *testing.T) {
+	listener := NewCallbackHandler[int]()
+	done := make(chan struct{})
+	listener.Listen(func(int) {
+		listener.Close()
+		close(done)
+	})
+
+	go listener.Send(1)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("listener callback deadlocked while closing broadcast")
+	}
+}

--- a/pkg/utils/http_requests/http_request.go
+++ b/pkg/utils/http_requests/http_request.go
@@ -23,6 +23,7 @@ func buildHttpRequest(method string, url string, options ...HttpOptions) (*http.
 		case HttpOptionTypeContext:
 			if ctx, ok := option.Value.(context.Context); ok {
 				ctx = log.EnsureTrace(ctx)
+				req = req.WithContext(ctx)
 				traceparent := log.GetTraceparentHeader(ctx)
 				if traceparent != "" {
 					req.Header.Set("traceparent", traceparent)

--- a/pkg/utils/http_requests/http_request_test.go
+++ b/pkg/utils/http_requests/http_request_test.go
@@ -1,0 +1,88 @@
+package http_requests
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestRequestPropagatesContextCancellation(t *testing.T) {
+	requestCanceled := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		<-r.Context().Done()
+		close(requestCanceled)
+	}))
+	t.Cleanup(server.Close)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	response, err := Request(server.Client(), server.URL, http.MethodGet, HttpContext(ctx))
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	t.Cleanup(func() {
+		response.Body.Close()
+	})
+
+	cancel()
+	select {
+	case <-requestCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("server request did not observe context cancellation")
+	}
+}
+
+func TestRequestPropagatesContextCancellationBeforeResponseHeaders(t *testing.T) {
+	requestStarted := make(chan struct{})
+	requestCanceled := make(chan struct{})
+	releaseHandler := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		close(requestStarted)
+		select {
+		case <-r.Context().Done():
+			close(requestCanceled)
+		case <-releaseHandler:
+		}
+	}))
+	t.Cleanup(func() {
+		close(releaseHandler)
+		server.Close()
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	requestDone := make(chan error, 1)
+	go func() {
+		_, err := Request(
+			server.Client(),
+			server.URL,
+			http.MethodPost,
+			HttpPayloadReader(io.NopCloser(bytes.NewReader([]byte("{}")))),
+			HttpContext(ctx),
+		)
+		requestDone <- err
+	}()
+
+	<-requestStarted
+	cancel()
+
+	select {
+	case <-requestCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("server request did not observe context cancellation")
+	}
+	select {
+	case err := <-requestDone:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context cancellation, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("request did not return after context cancellation")
+	}
+}

--- a/pkg/utils/mapping/sync.go
+++ b/pkg/utils/mapping/sync.go
@@ -46,6 +46,26 @@ func (m *Map[K, V]) Delete(key K) {
 	m.store.Delete(key)
 }
 
+// DeleteIf atomically deletes key when matches returns true.
+// matches runs while the map is locked and must not call methods on m.
+func (m *Map[K, V]) DeleteIf(key K, matches func(V) bool) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	value, loaded := m.store.Load(key)
+	if !loaded {
+		return false
+	}
+	typedValue, ok := value.(V)
+	if !ok || !matches(typedValue) {
+		return false
+	}
+
+	m.store.Delete(key)
+	atomic.AddInt32(&m.len, -1)
+	return true
+}
+
 func (m *Map[K, V]) Range(f func(key K, value V) bool) {
 	m.store.Range(func(key, value interface{}) bool {
 		return f(key.(K), value.(V))

--- a/pkg/utils/mapping/sync_test.go
+++ b/pkg/utils/mapping/sync_test.go
@@ -48,6 +48,30 @@ func TestDelete(t *testing.T) {
 	}
 }
 
+func TestDeleteIf(t *testing.T) {
+	t.Parallel()
+
+	m := Map[string, *int]{}
+	original := 1
+	replacement := 2
+	m.Store("session", &original)
+
+	if m.DeleteIf("session", func(value *int) bool { return value == &replacement }) {
+		t.Fatal("DeleteIf should not delete a value that no longer matches")
+	}
+	if value, ok := m.Load("session"); !ok || value != &original {
+		t.Fatal("DeleteIf changed the stored value after a failed comparison")
+	}
+
+	m.Store("session", &replacement)
+	if !m.DeleteIf("session", func(value *int) bool { return value == &replacement }) {
+		t.Fatal("DeleteIf should delete the matching value")
+	}
+	if m.Len() != 0 {
+		t.Fatalf("expected empty map after DeleteIf, got len %d", m.Len())
+	}
+}
+
 // TestConcurrentAccess verifies thread safety
 func TestConcurrentAccess(t *testing.T) {
 	t.Parallel()

--- a/pkg/utils/stream/stream.go
+++ b/pkg/utils/stream/stream.go
@@ -10,13 +10,19 @@ import (
 
 var ErrEmpty = errors.New("no data available")
 
+const (
+	streamStateOpen int32 = iota
+	streamStateClosing
+	streamStateClosed
+)
+
 type Stream[T any] struct {
-	q         deque.Deque[T]
-	l         *sync.Mutex
-	sig       chan bool
-	closed    int32
-	max       int
-	listening bool
+	q      deque.Deque[T]
+	l      *sync.Mutex
+	sig    chan struct{}
+	done   chan struct{}
+	closed int32
+	max    int
 
 	onClose     []func()
 	beforeClose []func()
@@ -32,7 +38,8 @@ func NewStream[T any](max int) *Stream[T] {
 	mutex := &sync.Mutex{}
 	return &Stream[T]{
 		l:         mutex,
-		sig:       make(chan bool),
+		sig:       make(chan struct{}, 1),
+		done:      make(chan struct{}),
 		max:       max,
 		writeCond: sync.NewCond(mutex),
 	}
@@ -41,16 +48,33 @@ func NewStream[T any](max int) *Stream[T] {
 // Filter filters the stream with a function
 // if the function returns an error, the stream will be closed
 func (r *Stream[T]) Filter(f func(T) error) {
+	r.l.Lock()
+	defer r.l.Unlock()
+	if atomic.LoadInt32(&r.closed) != streamStateOpen {
+		return
+	}
 	r.filter = append(r.filter, f)
 }
 
 // OnClose adds a function to be called when the stream is closed
 func (r *Stream[T]) OnClose(f func()) {
+	r.l.Lock()
+	if atomic.LoadInt32(&r.closed) == streamStateClosed {
+		r.l.Unlock()
+		f()
+		return
+	}
 	r.onClose = append(r.onClose, f)
+	r.l.Unlock()
 }
 
 // BeforeClose adds a function to be called before the stream is closed
 func (r *Stream[T]) BeforeClose(f func()) {
+	r.l.Lock()
+	defer r.l.Unlock()
+	if atomic.LoadInt32(&r.closed) != streamStateOpen {
+		return
+	}
 	r.beforeClose = append(r.beforeClose, f)
 }
 
@@ -59,56 +83,56 @@ func (r *Stream[T]) BeforeClose(f func()) {
 // returns false if the stream is closed
 // NOTE: even if the stream is closed, it will return true if there is data available
 func (r *Stream[T]) Next() bool {
-	r.l.Lock()
-	if r.closed == 1 && r.q.Len() == 0 && r.err == nil {
+	for {
+		r.l.Lock()
+		state := atomic.LoadInt32(&r.closed)
+		hasData := r.q.Len() > 0 || (r.err != nil && state != streamStateClosing)
+		closed := state == streamStateClosed
 		r.l.Unlock()
-		return false
+		if hasData {
+			return true
+		}
+		if closed {
+			return false
+		}
+		select {
+		case <-r.sig:
+		case <-r.done:
+		}
 	}
-
-	if r.q.Len() > 0 || r.err != nil {
-		r.l.Unlock()
-		return true
-	}
-
-	r.listening = true
-	defer func() {
-		r.listening = false
-	}()
-
-	r.l.Unlock()
-	return <-r.sig
 }
 
 // Read reads buffered data from the stream and
 // it returns error only if the buffer is empty or an error is written to the stream
 func (r *Stream[T]) Read() (T, error) {
 	r.l.Lock()
-	defer r.l.Unlock()
 
 	if r.q.Len() > 0 {
 		data := r.q.PopFront()
 		// Signal any waiting writers that there's now space in the queue
 		r.writeCond.Signal()
+		filters := append([]func(T) error(nil), r.filter...)
+		r.l.Unlock()
 
-		for _, f := range r.filter {
+		for _, f := range filters {
 			err := f(data)
 			if err != nil {
-				// close the stream
 				r.Close()
 				return data, err
 			}
 		}
 		return data, nil
-	} else {
-		var data T
-		if r.err != nil {
-			err := r.err
-			r.err = nil
-			return data, err
-		}
-
-		return data, ErrEmpty
 	}
+
+	var data T
+	if r.err != nil && atomic.LoadInt32(&r.closed) != streamStateClosing {
+		err := r.err
+		r.err = nil
+		r.l.Unlock()
+		return data, err
+	}
+	r.l.Unlock()
+	return data, ErrEmpty
 }
 
 // Process wraps the stream with a new stream, and allows customized operations
@@ -127,11 +151,15 @@ func (r *Stream[T]) Process(fn func(T)) error {
 // Write writes data to the stream,
 // returns error if the buffer is full
 func (r *Stream[T]) Write(data T) error {
-	if atomic.LoadInt32(&r.closed) == 1 {
+	if atomic.LoadInt32(&r.closed) != streamStateOpen {
 		return nil
 	}
 
 	r.l.Lock()
+	if atomic.LoadInt32(&r.closed) != streamStateOpen {
+		r.l.Unlock()
+		return nil
+	}
 
 	if r.q.Len() >= r.max {
 		r.l.Unlock()
@@ -139,71 +167,82 @@ func (r *Stream[T]) Write(data T) error {
 	}
 
 	r.q.PushBack(data)
-	if r.q.Len() == 1 {
-		if r.listening {
-			r.sig <- true
-		}
-	}
 	r.l.Unlock()
+	r.signal()
 	return nil
 }
 
 // WriteBlocking writes data to the stream,
 // blocks if the buffer is full until space becomes available
 func (r *Stream[T]) WriteBlocking(data T) {
-	if atomic.LoadInt32(&r.closed) == 1 {
+	if atomic.LoadInt32(&r.closed) != streamStateOpen {
 		return
 	}
 
 	r.l.Lock()
-	defer r.l.Unlock()
 
 	// Wait until there's space in the queue or the stream is closed
-	for r.q.Len() >= r.max && atomic.LoadInt32(&r.closed) == 0 {
+	for r.q.Len() >= r.max && atomic.LoadInt32(&r.closed) == streamStateOpen {
 		r.writeCond.Wait()
 	}
 
 	// Check if the stream was closed while waiting
-	if atomic.LoadInt32(&r.closed) == 1 {
+	if atomic.LoadInt32(&r.closed) != streamStateOpen {
+		r.l.Unlock()
 		return
 	}
 
 	r.q.PushBack(data)
-	if r.q.Len() == 1 {
-		if r.listening {
-			r.sig <- true
-		}
-	}
+	r.l.Unlock()
+	r.signal()
 }
 
 // Close closes the stream
 func (r *Stream[T]) Close() {
-	if !atomic.CompareAndSwapInt32(&r.closed, 0, 1) {
+	r.close(nil)
+}
+
+// CloseWithError closes the stream and makes err available to readers after close callbacks complete.
+func (r *Stream[T]) CloseWithError(err error) {
+	r.close(err)
+}
+
+func (r *Stream[T]) close(err error) {
+	if !atomic.CompareAndSwapInt32(&r.closed, streamStateOpen, streamStateClosing) {
 		return
 	}
 
-	for _, f := range r.beforeClose {
-		f()
-	}
-
-	select {
-	case r.sig <- false:
-	default:
-	}
-	close(r.sig)
-
-	// Wake up any waiting writers
 	r.l.Lock()
+	if err != nil {
+		r.err = err
+	}
+	beforeClose := append([]func(){}, r.beforeClose...)
 	r.writeCond.Broadcast()
 	r.l.Unlock()
-
-	for _, f := range r.onClose {
+	for _, f := range beforeClose {
 		f()
+	}
+
+	for {
+		r.l.Lock()
+		if len(r.onClose) == 0 {
+			atomic.StoreInt32(&r.closed, streamStateClosed)
+			r.l.Unlock()
+			close(r.done)
+			return
+		}
+		onClose := append([]func(){}, r.onClose...)
+		r.onClose = nil
+		r.l.Unlock()
+
+		for _, f := range onClose {
+			f()
+		}
 	}
 }
 
 func (r *Stream[T]) IsClosed() bool {
-	return atomic.LoadInt32(&r.closed) == 1
+	return atomic.LoadInt32(&r.closed) != streamStateOpen
 }
 
 func (r *Stream[T]) Size() int {
@@ -215,18 +254,23 @@ func (r *Stream[T]) Size() int {
 
 // WriteError writes an error to the stream
 func (r *Stream[T]) WriteError(err error) {
-	if atomic.LoadInt32(&r.closed) == 1 {
+	if atomic.LoadInt32(&r.closed) != streamStateOpen {
 		return
 	}
 
 	r.l.Lock()
-	defer r.l.Unlock()
-
+	if atomic.LoadInt32(&r.closed) != streamStateOpen {
+		r.l.Unlock()
+		return
+	}
 	r.err = err
+	r.l.Unlock()
+	r.signal()
+}
 
-	if r.q.Len() == 0 {
-		if r.listening {
-			r.sig <- true
-		}
+func (r *Stream[T]) signal() {
+	select {
+	case r.sig <- struct{}{}:
+	default:
 	}
 }

--- a/pkg/utils/stream/stream_test.go
+++ b/pkg/utils/stream/stream_test.go
@@ -3,6 +3,7 @@ package stream
 import (
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -154,5 +155,245 @@ func TestStreamCloseBlockingWrite(t *testing.T) {
 	case <-done:
 	case <-time.After(1 * time.Second):
 		t.Error("Expected the blocking write to be done")
+	}
+}
+
+func TestStreamNextReturnsWhenClosed(t *testing.T) {
+	response := NewStream[int](1)
+	nextReturned := make(chan bool, 1)
+	go func() {
+		nextReturned <- response.Next()
+	}()
+
+	response.Close()
+
+	select {
+	case hasNext := <-nextReturned:
+		assert.False(t, hasNext)
+	case <-time.After(time.Second):
+		t.Fatal("Next did not return after Close")
+	}
+}
+
+func TestStreamCloseWakesAllWaitingReaders(t *testing.T) {
+	response := NewStream[int](1)
+	const readerCount = 3
+	started := make(chan struct{}, readerCount)
+	nextReturned := make(chan bool, readerCount)
+
+	for range readerCount {
+		go func() {
+			started <- struct{}{}
+			nextReturned <- response.Next()
+		}()
+	}
+	for range readerCount {
+		<-started
+	}
+	time.Sleep(10 * time.Millisecond)
+
+	response.Close()
+
+	for range readerCount {
+		select {
+		case hasNext := <-nextReturned:
+			assert.False(t, hasNext)
+		case <-time.After(time.Second):
+			t.Fatal("not all waiting readers returned after Close")
+		}
+	}
+}
+
+func TestStreamErrorWakesNext(t *testing.T) {
+	response := NewStream[int](1)
+	nextReturned := make(chan bool, 1)
+	go func() {
+		nextReturned <- response.Next()
+	}()
+
+	expectedErr := errors.New("stream failed")
+	response.WriteError(expectedErr)
+
+	select {
+	case hasNext := <-nextReturned:
+		assert.True(t, hasNext)
+	case <-time.After(time.Second):
+		t.Fatal("Next did not return after WriteError")
+	}
+	_, err := response.Read()
+	assert.ErrorIs(t, err, expectedErr)
+}
+
+func TestStreamConcurrentWriteAndClose(t *testing.T) {
+	for range 1_000 {
+		response := NewStream[int](1)
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			_ = response.Write(1)
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			response.Close()
+		}()
+		close(start)
+		wg.Wait()
+	}
+}
+
+func TestStreamFilterCanCloseStream(t *testing.T) {
+	response := NewStream[int](1)
+	expectedErr := errors.New("rejected")
+	response.Filter(func(int) error {
+		response.Close()
+		return expectedErr
+	})
+	assert.NoError(t, response.Write(1))
+
+	readResult := make(chan error, 1)
+	go func() {
+		_, err := response.Read()
+		readResult <- err
+	}()
+
+	select {
+	case err := <-readResult:
+		assert.ErrorIs(t, err, expectedErr)
+	case <-time.After(time.Second):
+		t.Fatal("filter deadlocked while closing the stream")
+	}
+	assert.True(t, response.IsClosed())
+}
+
+func TestStreamOnCloseAddedAfterCloseRuns(t *testing.T) {
+	response := NewStream[int](1)
+	response.Close()
+
+	called := false
+	response.OnClose(func() {
+		called = true
+	})
+
+	assert.True(t, called)
+}
+
+func TestStreamNextWaitsForOnCloseCallbacks(t *testing.T) {
+	response := NewStream[int](1)
+	callbackStarted := make(chan struct{})
+	releaseCallback := make(chan struct{})
+	response.OnClose(func() {
+		close(callbackStarted)
+		<-releaseCallback
+	})
+
+	go response.Close()
+	<-callbackStarted
+
+	nextReturned := make(chan struct{})
+	go func() {
+		response.Next()
+		close(nextReturned)
+	}()
+
+	select {
+	case <-nextReturned:
+		t.Fatal("Next returned before OnClose callback completed")
+	case <-time.After(10 * time.Millisecond):
+	}
+
+	close(releaseCallback)
+	select {
+	case <-nextReturned:
+	case <-time.After(time.Second):
+		t.Fatal("Next did not return after OnClose callback completed")
+	}
+}
+
+func TestStreamCloseWithErrorWaitsForOnCloseCallbacks(t *testing.T) {
+	response := NewStream[int](1)
+	expectedErr := errors.New("test error")
+	callbackStarted := make(chan struct{})
+	releaseCallback := make(chan struct{})
+	response.OnClose(func() {
+		close(callbackStarted)
+		<-releaseCallback
+	})
+
+	go response.CloseWithError(expectedErr)
+	<-callbackStarted
+
+	nextReturned := make(chan bool, 1)
+	go func() {
+		nextReturned <- response.Next()
+	}()
+
+	select {
+	case <-nextReturned:
+		t.Fatal("Next returned before OnClose callback completed")
+	case <-time.After(10 * time.Millisecond):
+	}
+
+	close(releaseCallback)
+	select {
+	case hasNext := <-nextReturned:
+		assert.True(t, hasNext)
+	case <-time.After(time.Second):
+		t.Fatal("Next did not return after OnClose callback completed")
+	}
+	_, err := response.Read()
+	assert.ErrorIs(t, err, expectedErr)
+	assert.False(t, response.Next())
+}
+
+func TestStreamReadHidesCloseErrorUntilOnCloseCallbacksComplete(t *testing.T) {
+	response := NewStream[int](1)
+	expectedErr := errors.New("test error")
+	callbackStarted := make(chan struct{})
+	releaseCallback := make(chan struct{})
+	response.OnClose(func() {
+		close(callbackStarted)
+		<-releaseCallback
+	})
+
+	go response.CloseWithError(expectedErr)
+	<-callbackStarted
+
+	_, err := response.Read()
+	assert.ErrorIs(t, err, ErrEmpty)
+
+	close(releaseCallback)
+	assert.True(t, response.Next())
+	_, err = response.Read()
+	assert.ErrorIs(t, err, expectedErr)
+}
+
+func TestStreamConcurrentOnCloseAndClose(t *testing.T) {
+	for range 1_000 {
+		response := NewStream[int](1)
+		start := make(chan struct{})
+		var (
+			calls atomic.Int32
+			wg    sync.WaitGroup
+		)
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			response.OnClose(func() {
+				calls.Add(1)
+			})
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			response.Close()
+		}()
+		close(start)
+		wg.Wait()
+		assert.EqualValues(t, 1, calls.Load())
 	}
 }


### PR DESCRIPTION
## Description

Serverless (Lambda Function URL) requests are capped at 6 MB. Large text embedding requests exceeded this and failed with opaque errors.

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [] Performance improvement
- [ ] Other

## Essential Checklist

### Testing
- [X] I have tested the changes locally and confirmed they work as expected
- [X] I have added unit tests where necessary and they pass successfully

### Bug Fix (if applicable)
- [ ] I have used GitHub syntax to close the related issue (e.g., `Fixes #123` or `Closes #123`)

## Additional Information

Please provide any additional context that would help reviewers understand the changes. 