### PR TITLE
fix: route cloud debug plugins to runtime owner

### DIFF
--- a/internal/core/plugin_manager/manager.go
+++ b/internal/core/plugin_manager/manager.go
@@ -1,7 +1,6 @@
 package plugin_manager
 
 import (
-	"errors"
 	"fmt"
 
 	lru "github.com/hashicorp/golang-lru/v2"
@@ -203,13 +202,19 @@ func (p *PluginManager) Config() *app.Config {
 // check if the plugin is already running on this node
 func (c *PluginManager) NeedRedirecting(
 	identity plugin_entities.PluginUniqueIdentifier,
+	runtimeType plugin_entities.PluginRuntimeType,
 ) (bool, error) {
-	if identity.RemoteLike() {
+	// Plugin installations provide the authoritative runtime type. Direct
+	// invocation does not have installation context, so keep the identifier
+	// heuristic as a compatibility fallback only for that path.
+	isRemoteRuntime := runtimeType == plugin_entities.PLUGIN_RUNTIME_TYPE_REMOTE
+	if runtimeType == "" {
+		isRemoteRuntime = identity.RemoteLike()
+	}
+
+	if isRemoteRuntime {
 		_, err := c.controlPanel.GetPluginRuntime(identity)
 		if err != nil {
-			if errors.Is(err, controlpanel.ErrPluginRuntimeNotFound) {
-				return true, nil
-			}
 			return true, err
 		}
 		return false, nil

--- a/internal/core/plugin_manager/manager_test.go
+++ b/internal/core/plugin_manager/manager_test.go
@@ -1,0 +1,96 @@
+package plugin_manager
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	controlpanel "github.com/langgenius/dify-plugin-daemon/internal/core/control_panel"
+	"github.com/langgenius/dify-plugin-daemon/internal/core/debugging_runtime"
+	"github.com/langgenius/dify-plugin-daemon/internal/types/app"
+	"github.com/langgenius/dify-plugin-daemon/pkg/entities/plugin_entities"
+)
+
+func TestNeedRedirectingUsesInstallationRuntimeType(t *testing.T) {
+	identifier := plugin_entities.PluginUniqueIdentifier(
+		"langgenius/test_debug_plugin:0.0.1@0123456789abcdef0123456789abcdef",
+	)
+	controlPanel := controlpanel.NewControlPanel(
+		&app.Config{PluginLocalLaunchingConcurrent: 1},
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+	manager := &PluginManager{
+		config:       &app.Config{Platform: app.PLATFORM_SERVERLESS},
+		controlPanel: controlPanel,
+	}
+
+	needRedirecting, err := manager.NeedRedirecting(
+		identifier,
+		plugin_entities.PLUGIN_RUNTIME_TYPE_REMOTE,
+	)
+	require.True(t, needRedirecting)
+	require.ErrorIs(t, err, controlpanel.ErrPluginRuntimeNotFound)
+
+	debugRuntime := &debugging_runtime.RemotePluginRuntime{}
+	storeDebuggingPluginRuntime(t, controlPanel, identifier, debugRuntime)
+
+	needRedirecting, err = manager.NeedRedirecting(
+		identifier,
+		plugin_entities.PLUGIN_RUNTIME_TYPE_REMOTE,
+	)
+	require.False(t, needRedirecting)
+	require.NoError(t, err)
+}
+
+func TestNeedRedirectingDoesNotRedirectServerlessInstallation(t *testing.T) {
+	identifier := plugin_entities.PluginUniqueIdentifier(
+		"01234567-89ab-cdef-0123-456789abcdef/test_plugin:0.0.1@0123456789abcdef0123456789abcdef",
+	)
+	manager := &PluginManager{
+		config: &app.Config{Platform: app.PLATFORM_SERVERLESS},
+	}
+
+	needRedirecting, err := manager.NeedRedirecting(
+		identifier,
+		plugin_entities.PLUGIN_RUNTIME_TYPE_SERVERLESS,
+	)
+	require.False(t, needRedirecting)
+	require.NoError(t, err)
+}
+
+func TestNeedRedirectingFallsBackToIdentifierForDirectInvocation(t *testing.T) {
+	identifier := plugin_entities.PluginUniqueIdentifier(
+		"01234567-89ab-cdef-0123-456789abcdef/test_plugin:0.0.1@0123456789abcdef0123456789abcdef",
+	)
+	controlPanel := controlpanel.NewControlPanel(
+		&app.Config{PluginLocalLaunchingConcurrent: 1},
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+	manager := &PluginManager{
+		config:       &app.Config{Platform: app.PLATFORM_SERVERLESS},
+		controlPanel: controlPanel,
+	}
+
+	needRedirecting, err := manager.NeedRedirecting(identifier, "")
+	require.True(t, needRedirecting)
+	require.ErrorIs(t, err, controlpanel.ErrPluginRuntimeNotFound)
+}
+
+func TestNeedRedirectingKeepsDirectServerlessInvocationLocal(t *testing.T) {
+	identifier := plugin_entities.PluginUniqueIdentifier(
+		"langgenius/test_plugin:0.0.1@0123456789abcdef0123456789abcdef",
+	)
+	manager := &PluginManager{
+		config: &app.Config{Platform: app.PLATFORM_SERVERLESS},
+	}
+
+	needRedirecting, err := manager.NeedRedirecting(identifier, "")
+	require.False(t, needRedirecting)
+	require.NoError(t, err)
+}

--- a/internal/server/endpoint.go
+++ b/internal/server/endpoint.go
@@ -93,7 +93,10 @@ func (app *App) EndpointHandler(ctx *gin.Context, hookId string, maxExecutionTim
 	}
 
 	// check if plugin exists in current node
-	if needRedirecting, originalError := app.pluginManager.NeedRedirecting(pluginUniqueIdentifier); needRedirecting {
+	if needRedirecting, originalError := app.pluginManager.NeedRedirecting(
+		pluginUniqueIdentifier,
+		plugin_entities.PluginRuntimeType(pluginInstallation.RuntimeType),
+	); needRedirecting {
 		app.redirectPluginInvokeByPluginIdentifier(ctx, pluginUniqueIdentifier, originalError)
 	} else {
 		service.Endpoint(ctx, endpoint, pluginInstallation, maxExecutionTime, path)

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -104,8 +104,24 @@ func (app *App) RedirectPluginInvoke() gin.HandlerFunc {
 			return
 		}
 
+		runtimeType := plugin_entities.PluginRuntimeType("")
+		if installationAny, ok := ctx.Get(constants.CONTEXT_KEY_PLUGIN_INSTALLATION); ok {
+			installation, ok := installationAny.(models.PluginInstallation)
+			if !ok {
+				ctx.AbortWithStatusJSON(
+					500,
+					exception.InternalServerError(errors.New("failed to parse plugin installation")).ToResponse(),
+				)
+				return
+			}
+			runtimeType = plugin_entities.PluginRuntimeType(installation.RuntimeType)
+		}
+
 		// check if plugin in current node
-		if needRedirecting, originalError := app.pluginManager.NeedRedirecting(identity); needRedirecting {
+		if needRedirecting, originalError := app.pluginManager.NeedRedirecting(
+			identity,
+			runtimeType,
+		); needRedirecting {
 			app.redirectPluginInvokeByPluginIdentifier(ctx, identity, originalError)
 			ctx.Abort()
 		} else {


### PR DESCRIPTION
## Summary

<img width="2084" height="1478" alt="img_v3_02140_321a2590-6f3d-4344-b89f-830588a95e8g" src="https://github.com/user-attachments/assets/ef832376-a11b-44a3-8e4f-e1dcfbd179a0" />
Fix intermittent remote debug plugin invocation failures in multi-node plugin-daemon deployments.

Remote debug plugins are now identified using the persisted installation runtime type instead of inferring their runtime type from the plugin author's format.

## Background

Historically, `RemotePluginRuntime.Identity()` replaced the plugin manifest author with the tenant UUID:

```text
<tenant-uuid>/<plugin-name>:<version>@<checksum>
```

PluginUniqueIdentifier.RemoteLike() therefore used “the author is a UUID” as an implicit marker for remote debug plugins.
This behavior changed in #731 while fixing #730. To keep plugin_id consistent between runtime listings and installation records, remote debug identities started preserving the manifest author:
```
langgenius/openai:<version>@<checksum>
```
Preserving the manifest author was the correct fix for plugin identity consistency, but it invalidated the UUID-based remote runtime detection.
#761 later restored cross-node redirection for remote debug plugins, but continued to gate the redirect logic with:
```
identity.RemoteLike()
```
For identities such as langgenius/openai, RemoteLike() returns false.

In a multi-node serverless deployment, a remote debug runtime only exists on the node that owns the debugging connection. Requests routed to that node succeed, while requests routed to another replica are treated as normal serverless invocations. Since a newly debugged plugin does not have a serverless runtime, those requests fail with a runtime/node-not-found error.

This made the issue appear intermittent and dependent on load-balancer routing.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Other

## Essential Checklist

### Testing
- [ ] I have tested the changes locally and confirmed they work as expected
- [ ] I have added unit tests where necessary and they pass successfully

### Bug Fix (if applicable)
- [ ] I have used GitHub syntax to close the related issue (e.g., `Fixes #123` or `Closes #123`)

## Additional Information

Please provide any additional context that would help reviewers understand the changes. 