### PR TITLE
fix: prevent plugin declaration cache eviction loop from spinning forever

### DIFF
--- a/pkg/utils/cache/helper/combined.go
+++ b/pkg/utils/cache/helper/combined.go
@@ -24,57 +24,40 @@ type memCacheItem struct {
 
 type memCache struct {
 	sync.RWMutex
-	items    map[string]*memCacheItem
-	itemSize int64
+	items map[string]*memCacheItem
 }
 
 var (
-	// 500MB memory cache
-	maxMemCacheSize = int64(1024)
+	// max number of cached items
+	maxMemCacheSize = 1024
 	// 600s TTL
 	maxTTL = 600 * time.Second
 
 	pluginCache = &memCache{
-		items:    make(map[string]*memCacheItem),
-		itemSize: 0,
+		items: make(map[string]*memCacheItem),
 	}
 )
 
 func (c *memCache) get(key string) *plugin_entities.PluginDeclaration {
-	c.RLock()
-	item, exists := c.items[key]
-	c.RUnlock()
+	// accessCount and lastAccess are mutated on every hit, so a read lock is not
+	// enough to inspect them
+	c.Lock()
+	defer c.Unlock()
 
+	item, exists := c.items[key]
 	if !exists {
 		return nil
 	}
 
-	// Check TTL with a read lock first
 	if time.Since(item.lastAccess) > maxTTL {
-		c.Lock()
-		// Double check after acquiring write lock
-		if item, exists = c.items[key]; exists {
-			if time.Since(item.lastAccess) > maxTTL {
-				c.itemSize--
-				delete(c.items, key)
-			}
-		}
-		c.Unlock()
+		delete(c.items, key)
 		return nil
 	}
 
-	// Update access count and time atomically
-	c.Lock()
-	if item, exists = c.items[key]; exists {
-		item.accessCount++
-		item.lastAccess = time.Now()
-	}
-	c.Unlock()
+	item.accessCount++
+	item.lastAccess = time.Now()
 
-	if exists {
-		return item.declaration
-	}
-	return nil
+	return item.declaration
 }
 
 func (c *memCache) set(key string, declaration *plugin_entities.PluginDeclaration) {
@@ -85,13 +68,12 @@ func (c *memCache) set(key string, declaration *plugin_entities.PluginDeclaratio
 	now := time.Now()
 	for k, v := range c.items {
 		if now.Sub(v.lastAccess) > maxTTL {
-			c.itemSize--
 			delete(c.items, k)
 		}
 	}
 
 	// Remove least accessed items if cache is full
-	for c.itemSize >= maxMemCacheSize {
+	for len(c.items) >= maxMemCacheSize {
 		var leastKey string
 		var leastCount int64 = -1
 		var oldestAccess = time.Now()
@@ -106,10 +88,12 @@ func (c *memCache) set(key string, declaration *plugin_entities.PluginDeclaratio
 			}
 		}
 
-		if leastKey != "" {
-			c.itemSize--
-			delete(c.items, leastKey)
+		// nothing left to evict, never spin on a loop that cannot make progress
+		if leastKey == "" {
+			break
 		}
+
+		delete(c.items, leastKey)
 	}
 
 	// Add new item
@@ -118,7 +102,6 @@ func (c *memCache) set(key string, declaration *plugin_entities.PluginDeclaratio
 		accessCount: 1,
 		lastAccess:  now,
 	}
-	c.itemSize++
 }
 
 func CombinedGetPluginDeclaration(

--- a/pkg/utils/cache/helper/combined_test.go
+++ b/pkg/utils/cache/helper/combined_test.go
@@ -1,0 +1,156 @@
+package helper
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/langgenius/dify-plugin-daemon/pkg/entities/plugin_entities"
+)
+
+func newTestCache() *memCache {
+	return &memCache{items: make(map[string]*memCacheItem)}
+}
+
+func declarationNamed(name string) *plugin_entities.PluginDeclaration {
+	declaration := &plugin_entities.PluginDeclaration{}
+	declaration.Name = name
+	return declaration
+}
+
+// withinTimeout fails the test instead of hanging the suite when work never returns.
+func withinTimeout(t *testing.T, timeout time.Duration, work func()) {
+	t.Helper()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		work()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		t.Fatalf("work did not finish within %s", timeout)
+	}
+}
+
+// Regression for the eviction loop spinning forever under the write lock: external
+// deletes used to leave the size counter above the real map length, and once that
+// drift reached maxMemCacheSize the loop could no longer evict its way out.
+func TestSetTerminatesWhenEntriesAreDeletedExternally(t *testing.T) {
+	c := newTestCache()
+
+	withinTimeout(t, 30*time.Second, func() {
+		for i := 0; i < maxMemCacheSize+64; i++ {
+			key := fmt.Sprintf("key-%d", i)
+			c.set(key, declarationNamed(fmt.Sprintf("declaration-%d", i)))
+
+			c.Lock()
+			delete(c.items, key)
+			c.Unlock()
+		}
+	})
+}
+
+func TestSetTerminatesWhenOverwritingTheSameKey(t *testing.T) {
+	c := newTestCache()
+
+	withinTimeout(t, 30*time.Second, func() {
+		for i := 0; i < maxMemCacheSize*4; i++ {
+			c.set("stable-key", declarationNamed(fmt.Sprintf("declaration-%d", i)))
+		}
+	})
+
+	c.RLock()
+	size := len(c.items)
+	c.RUnlock()
+
+	if size != 1 {
+		t.Fatalf("overwriting one key should leave one entry, got %d", size)
+	}
+
+	declaration := c.get("stable-key")
+	if declaration == nil {
+		t.Fatal("expected the overwritten key to still be cached")
+	}
+	if want := fmt.Sprintf("declaration-%d", maxMemCacheSize*4-1); declaration.Name != want {
+		t.Fatalf("expected the last write to win, want %q got %q", want, declaration.Name)
+	}
+}
+
+func TestSetEvictsToStayWithinMaxSize(t *testing.T) {
+	c := newTestCache()
+
+	withinTimeout(t, 60*time.Second, func() {
+		for i := 0; i < maxMemCacheSize+128; i++ {
+			c.set(fmt.Sprintf("key-%d", i), declarationNamed(fmt.Sprintf("declaration-%d", i)))
+		}
+	})
+
+	c.RLock()
+	size := len(c.items)
+	c.RUnlock()
+
+	if size > maxMemCacheSize {
+		t.Fatalf("cache grew past maxMemCacheSize: got %d want <= %d", size, maxMemCacheSize)
+	}
+}
+
+func TestGetEvictsExpiredEntries(t *testing.T) {
+	c := newTestCache()
+	c.set("expired-key", declarationNamed("expired-declaration"))
+
+	c.Lock()
+	c.items["expired-key"].lastAccess = time.Now().Add(-2 * maxTTL)
+	c.Unlock()
+
+	if declaration := c.get("expired-key"); declaration != nil {
+		t.Fatalf("expected expired entry to be a miss, got %q", declaration.Name)
+	}
+
+	c.RLock()
+	_, exists := c.items["expired-key"]
+	c.RUnlock()
+
+	if exists {
+		t.Fatal("expected expired entry to be removed from the cache")
+	}
+}
+
+// Exercises the concurrent overwrite pattern from CombinedGetPluginDeclaration, where
+// several goroutines miss on the same key and all call set. Meaningful under -race.
+func TestConcurrentGetSetAndDelete(t *testing.T) {
+	c := newTestCache()
+
+	withinTimeout(t, 60*time.Second, func() {
+		var wg sync.WaitGroup
+		for worker := 0; worker < 16; worker++ {
+			wg.Add(1)
+			go func(worker int) {
+				defer wg.Done()
+				for i := 0; i < 512; i++ {
+					key := fmt.Sprintf("key-%d", i%32)
+					if c.get(key) == nil {
+						c.set(key, declarationNamed(fmt.Sprintf("declaration-%d-%d", worker, i)))
+					}
+					if i%64 == 0 {
+						c.Lock()
+						delete(c.items, key)
+						c.Unlock()
+					}
+				}
+			}(worker)
+		}
+		wg.Wait()
+	})
+
+	c.RLock()
+	size := len(c.items)
+	c.RUnlock()
+
+	if size > maxMemCacheSize {
+		t.Fatalf("cache grew past maxMemCacheSize: got %d want <= %d", size, maxMemCacheSize)
+	}
+}


### PR DESCRIPTION
## Description

`memCache.set` in `pkg/utils/cache/helper/combined.go` could enter an infinite loop while holding the cache write lock, blocking every reader of the plugin declaration cache until the process was restarted.

Closes #783

### Root cause

`memCache` tracked its size in a hand-maintained `itemSize` counter kept alongside `c.items`. Let `D = itemSize - len(c.items)`.

`DeletePluginDeclarationCache` removed an entry from the map without decrementing `itemSize`, so every call raised `D` by one, permanently. Once `D >= maxMemCacheSize`, the eviction loop in `set` could no longer terminate — it drained the map, `leastKey` stayed `""`, nothing was deleted, and `itemSize` never fell below the threshold. The loop then spun under `c.Lock()`, pinning a core while every reader piled up on `RLock`.

### Note on the reported cause

The issue attributes the drift to `itemSize++` firing unconditionally on overwrites. That is a real accounting bug, but **it cannot by itself reach the terminal condition**, so a fix that only makes the increment conditional would not stop the hang.

Tracking `D` through each operation:

| Operation | Effect on `D` |
|---|---|
| Eviction pass, TTL sweep in `set`, `get` TTL path | invariant — both sides decrement together |
| `set` insert | invariant |
| `set` overwrite | +1 |
| `DeletePluginDeclarationCache` | +1, never rebalanced |

An overwrite requires the key to be present, so `len(c.items) >= 1`; and eviction runs immediately before the add whenever `itemSize >= maxMemCacheSize`, exiting at exactly `maxMemCacheSize - 1`. Inductively that pins `D <= maxMemCacheSize - 1` — one short of the terminal condition, indefinitely. `DeletePluginDeclarationCache` is the only source outside that rebalancing, and is what actually drives `D` over the line.

This is confirmed by the tests in this PR run against the unfixed code: the overwrite-only test passes, while the test that interleaves `set` with an external delete hangs.

### Changes

- Drive eviction off `len(c.items)` and drop `itemSize` entirely. This removes the whole class of drift, including the `DeletePluginDeclarationCache` source, rather than patching one contributor.
- `break` out of the eviction loop when there is nothing left to evict, so no future accounting error can reintroduce a non-terminating loop.
- Collapse `get` to a single write lock. It read `item.lastAccess` after releasing `RLock` while other goroutines mutated that field under `Lock` — a data race the detector flags. The read lock bought no concurrency anyway, since every cache hit already took the write lock to bump `accessCount`.

Net effect on the implementation file is 19 insertions, 36 deletions.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Other

## Essential Checklist

### Testing
- [x] I have tested the changes locally and confirmed they work as expected
- [x] I have added unit tests where necessary and they pass successfully

### Bug Fix (if applicable)
- [x] I have used GitHub syntax to close the related issue (e.g., `Fixes #123` or `Closes #123`)

## Additional Information

### Verification

Each failure was reproduced against the unfixed code first, rather than assumed.

| Check | Before | After |
|---|---|---|
| `TestSetTerminatesWhenEntriesAreDeletedExternally` | hangs, killed at 30s timeout | passes in 0.00s |
| `TestSetTerminatesWhenOverwritingTheSameKey` | passes (see note above) | passes |
| `go test -race` on concurrent get/set/delete | `WARNING: DATA RACE` in `get` | clean |
| `go test -race -count=2 ./pkg/utils/cache/helper/` | — | `ok` |
| `go vet`, `gofmt` | — | clean |

The new tests wrap the work in a timeout so a regression fails the suite rather than hanging CI.

`go build ./...` reports `pattern PRIVATE_KEY.pem: no matching files found`. That is pre-existing on `main`, unrelated to this change, and unaffected by it.

### Not addressed

Point 3 of the issue — the `O(n)` scan per evicted item — is left alone. The `O(n*k)` behaviour it describes was a consequence of the drift: with `len(c.items)` driving the loop, `set` evicts exactly one entry per call in steady state, so `k = 1`. Converting to a heap or LRU list is a worthwhile but separate design change.
