### PR TITLE
fix: isolate backwards invocation contexts

### DIFF
--- a/internal/core/dify_invocation/calldify/types.go
+++ b/internal/core/dify_invocation/calldify/types.go
@@ -4,16 +4,24 @@ import (
 	"context"
 	"net/http"
 	"net/url"
+
+	"github.com/langgenius/dify-plugin-daemon/internal/core/dify_invocation"
 )
 
 type RealBackwardsInvocation struct {
-	difyInnerApiKey        string
-	difyInnerApiBaseurl    *url.URL
-	client                 *http.Client
-	writeTimeout           int64
-	readTimeout            int64
-	responseMaxBufferSize  int64
-	traceCtx               context.Context
+	difyInnerApiKey       string
+	difyInnerApiBaseurl   *url.URL
+	client                *http.Client
+	writeTimeout          int64
+	readTimeout           int64
+	responseMaxBufferSize int64
+	traceCtx              context.Context
+}
+
+func (i *RealBackwardsInvocation) WithContext(ctx context.Context) dify_invocation.BackwardsInvocation {
+	invocation := *i
+	invocation.traceCtx = ctx
+	return &invocation
 }
 
 func (i *RealBackwardsInvocation) SetContext(ctx context.Context) {

--- a/internal/core/dify_invocation/calldify/types_test.go
+++ b/internal/core/dify_invocation/calldify/types_test.go
@@ -1,0 +1,20 @@
+package calldify
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithContextReturnsIndependentInvocations(t *testing.T) {
+	base := &RealBackwardsInvocation{}
+	canceledContext, cancel := context.WithCancel(context.Background())
+	first := base.WithContext(canceledContext)
+	second := base.WithContext(context.Background())
+	cancel()
+
+	require.ErrorIs(t, first.Context().Err(), context.Canceled)
+	require.NoError(t, second.Context().Err())
+	require.NoError(t, base.Context().Err())
+}

--- a/internal/core/dify_invocation/invcation.go
+++ b/internal/core/dify_invocation/invcation.go
@@ -9,6 +9,7 @@ import (
 )
 
 type BackwardsInvocation interface {
+	WithContext(ctx context.Context) BackwardsInvocation
 	SetContext(ctx context.Context)
 	Context() context.Context
 	// InvokeLLM

--- a/internal/core/dify_invocation/mock/mock.go
+++ b/internal/core/dify_invocation/mock/mock.go
@@ -21,6 +21,12 @@ func NewMockedDifyInvocation() dify_invocation.BackwardsInvocation {
 	return &MockedDifyInvocation{}
 }
 
+func (m *MockedDifyInvocation) WithContext(ctx context.Context) dify_invocation.BackwardsInvocation {
+	invocation := *m
+	invocation.ctx = ctx
+	return &invocation
+}
+
 func (m *MockedDifyInvocation) SetContext(ctx context.Context) {
 	m.ctx = ctx
 }

--- a/internal/core/plugin_manager/manager.go
+++ b/internal/core/plugin_manager/manager.go
@@ -1,6 +1,7 @@
 package plugin_manager
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -198,7 +199,7 @@ func (p *PluginManager) Launch(configuration *app.Config) {
 }
 
 func (p *PluginManager) BackwardsInvocation() dify_invocation.BackwardsInvocation {
-	return p.backwardsInvocation
+	return p.backwardsInvocation.WithContext(context.Background())
 }
 
 func (p *PluginManager) Config() *app.Config {

--- a/internal/core/plugin_manager/manager_test.go
+++ b/internal/core/plugin_manager/manager_test.go
@@ -1,15 +1,32 @@
 package plugin_manager
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	controlpanel "github.com/langgenius/dify-plugin-daemon/internal/core/control_panel"
 	"github.com/langgenius/dify-plugin-daemon/internal/core/debugging_runtime"
+	invocationmock "github.com/langgenius/dify-plugin-daemon/internal/core/dify_invocation/mock"
 	"github.com/langgenius/dify-plugin-daemon/internal/types/app"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/plugin_entities"
 )
+
+func TestBackwardsInvocationContextsAreIsolated(t *testing.T) {
+	manager := &PluginManager{
+		backwardsInvocation: invocationmock.NewMockedDifyInvocation(),
+	}
+
+	first := manager.BackwardsInvocation()
+	second := manager.BackwardsInvocation()
+	canceledContext, cancel := context.WithCancel(context.Background())
+	first.SetContext(canceledContext)
+	cancel()
+
+	require.ErrorIs(t, first.Context().Err(), context.Canceled)
+	require.NoError(t, second.Context().Err())
+}
 
 func TestNeedRedirectingUsesInstallationRuntimeType(t *testing.T) {
 	identifier := plugin_entities.PluginUniqueIdentifier(


### PR DESCRIPTION
## Description

`PluginManager` currently returns one shared `BackwardsInvocation`. Plugin sessions mutate that instance with their HTTP request context. After a request finishes, its canceled context can therefore leak into later endpoint setup or listing calls, causing `/inner/api/invoke/encrypt` to fail locally with `context canceled` before the request reaches Dify API.

Fixes #787

### Root cause

`Session.propagateTraceContext` calls `SetContext` on the invocation returned by `PluginManager`. Because the manager returned its stored singleton directly, the session replaced the singleton's context. The canceled request context then remained attached to all later callers.

### Changes

- adds `WithContext` to create a context-bound invocation copy while reusing the HTTP client and immutable configuration
- returns a fresh invocation from `PluginManager.BackwardsInvocation()`
- preserves per-session cancellation by propagating the active request context only to that session's copy
- updates the mock implementation and adds regression tests for both the concrete invocation and manager behavior

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Other

## Essential Checklist

### Testing
- [x] I have tested the changes locally and confirmed they work as expected
- [x] I have added unit tests where necessary and they pass successfully

### Bug Fix (if applicable)
- [x] I have used GitHub syntax to close the related issue (e.g., `Fixes #123` or `Closes #123`)

## Additional Information

Validation performed locally:

```bash
go run cmd/license/generate/main.go
go test -v -timeout 1m ./cmd/... ./internal/... ./pkg/...
go test -race ./internal/core/plugin_manager ./internal/core/dify_invocation/calldify ./internal/core/session_manager
```

The full unit test suite and focused race tests pass. A control test on the unmodified `main` branch reproduces the same `context canceled` error, while the patched branch completes the request successfully.
