### PR TITLE
fix(tts): propagate output mime type

### DIFF
--- a/pkg/entities/model_entities/tts.go
+++ b/pkg/entities/model_entities/tts.go
@@ -1,7 +1,8 @@
 package model_entities
 
 type TTSResult struct {
-	Result string `json:"result"` // in hex
+	Result   string `json:"result"` // in hex
+	MimeType string `json:"mime_type,omitempty"`
 }
 
 type TTSModelVoice struct {

--- a/pkg/entities/model_entities/tts_test.go
+++ b/pkg/entities/model_entities/tts_test.go
@@ -1,0 +1,34 @@
+package model_entities
+
+import (
+	"testing"
+
+	"github.com/langgenius/dify-plugin-daemon/pkg/utils/parser"
+)
+
+func TestTTSResultJSONCompatibility(t *testing.T) {
+	tests := []struct {
+		name     string
+		payload  string
+		mimeType string
+		expected string
+	}{
+		{"current", `{"result":"52494646","mime_type":"audio/wav"}`, "audio/wav", `{"result":"52494646","mime_type":"audio/wav"}`},
+		{"legacy", `{"result":"52494646"}`, "", `{"result":"52494646"}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := parser.UnmarshalJsonBytes[TTSResult]([]byte(tt.payload))
+			if err != nil {
+				t.Fatalf("unmarshal TTS result: %v", err)
+			}
+			if result.MimeType != tt.mimeType {
+				t.Fatalf("mime type = %q, want %q", result.MimeType, tt.mimeType)
+			}
+			if got := parser.MarshalJson(result); got != tt.expected {
+				t.Fatalf("marshaled result = %s, want %s", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Propagate the optional `mime_type` from TTS plugin stream results through daemon JSON responses.
Legacy plugin responses remain compatible because empty MIME types are omitted.

Related to langgenius/dify#35880.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Other

## Essential Checklist

### Testing

- [x] I have tested the changes locally and confirmed they work as expected
- [x] I have added unit tests where necessary and they pass successfully

### Bug Fix

- [ ] I have used GitHub syntax to close the related issue

This daemon change is one part of a cross-repository fix and must not close the upstream issue by itself.

## Additional Information

- `go test -count=1 ./pkg/entities/model_entities ./internal/core/io_tunnel ./internal/service`
- `git diff --check`