### PR TITLE
fix: prevent concurrent plugin install conflicts

### DIFF
--- a/internal/types/models/curd/atomic.go
+++ b/internal/types/models/curd/atomic.go
@@ -36,9 +36,21 @@ func InstallPlugin(
 		defer helper.DeleteModelInstallationsCache(tenantId)
 	}
 
-	err := db.WithTransaction(func(tx *gorm.DB) error {
-		pluginID := pluginUniqueIdentifier.PluginID()
+	pluginID := pluginUniqueIdentifier.PluginID()
 
+	// Avoid taking the shared plugin lock when the tenant is already installed.
+	_, err := db.GetOne[models.PluginInstallation](
+		db.Equal("plugin_id", pluginID),
+		db.Equal("tenant_id", tenantId),
+	)
+	if err == nil {
+		return nil, nil, ErrPluginAlreadyInstalled
+	}
+	if !errors.Is(err, db.ErrDatabaseNotFound) {
+		return nil, nil, err
+	}
+
+	err = db.WithTransaction(func(tx *gorm.DB) error {
 		plugin := &models.Plugin{
 			PluginID:               pluginID,
 			PluginUniqueIdentifier: pluginUniqueIdentifier.String(),
@@ -187,8 +199,8 @@ func InstallPlugin(
 	}
 
 	// Invalidate plugin installation cache to avoid stale reads
-	pluginID := pluginToBeReturns.PluginID
-	pluginInstallationCacheKey := helper.PluginInstallationCacheKey(pluginID, tenantId)
+	installedPluginID := pluginToBeReturns.PluginID
+	pluginInstallationCacheKey := helper.PluginInstallationCacheKey(installedPluginID, tenantId)
 	if _, delErr := cache.AutoDelete[models.PluginInstallation](pluginInstallationCacheKey); delErr != nil {
 		log.Warn("failed to clear plugin installation cache", "key", pluginInstallationCacheKey, "error", delErr)
 	}

--- a/internal/types/models/curd/atomic.go
+++ b/internal/types/models/curd/atomic.go
@@ -12,6 +12,7 @@ import (
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/manifest_entities"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/plugin_entities"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // Create plugin for a tenant, create plugin if it has never been created before
@@ -38,80 +39,54 @@ func InstallPlugin(
 	err := db.WithTransaction(func(tx *gorm.DB) error {
 		pluginID := pluginUniqueIdentifier.PluginID()
 
-		// check if already installed
-		_, err := db.GetOne[models.PluginInstallation](
-			db.Equal("plugin_id", pluginID),
-			db.Equal("tenant_id", tenantId),
-		)
-
-		if err == nil {
-			return ErrPluginAlreadyInstalled
+		plugin := &models.Plugin{
+			PluginID:               pluginID,
+			PluginUniqueIdentifier: pluginUniqueIdentifier.String(),
+			InstallType:            installType,
+			Source:                 source,
 		}
 
-		// Find existing plugin by unique_identifier only
-		// Don't use plugin_id in query since it may differ for remote plugins
+		if installType == plugin_entities.PLUGIN_RUNTIME_TYPE_REMOTE {
+			plugin.RemoteDeclaration = *declaration
+		}
+
+		// A missing row cannot be protected by SELECT FOR UPDATE. Create it atomically,
+		// then lock the persisted row so installs for the same plugin are serialized.
+		if err := tx.Clauses(clause.OnConflict{
+			Columns:   []clause.Column{{Name: "plugin_unique_identifier"}},
+			DoNothing: true,
+		}).Create(plugin).Error; err != nil {
+			return err
+		}
+
+		// Find the persisted plugin by unique_identifier only. Don't use plugin_id in
+		// the query since it may differ for remote plugins.
 		p, err := db.GetOne[models.Plugin](
 			db.WithTransactionContext(tx),
 			db.Equal("plugin_unique_identifier", pluginUniqueIdentifier.String()),
 			db.WLock(),
 		)
-
-		if errors.Is(err, db.ErrDatabaseNotFound) {
-			plugin := &models.Plugin{
-				PluginID:               pluginID,
-				PluginUniqueIdentifier: pluginUniqueIdentifier.String(),
-				InstallType:            installType,
-				Refers:                 1,
-				Source:                 source,
-			}
-
-			if installType == plugin_entities.PLUGIN_RUNTIME_TYPE_REMOTE {
-				plugin.RemoteDeclaration = *declaration
-			}
-
-			err := db.Create(plugin, tx)
-			if err != nil {
-				// Handle potential duplicate creation due to race: refetch and update refers
-				// to achieve idempotent behavior under concurrency.
-				p2, gerr := db.GetOne[models.Plugin](
-					db.WithTransactionContext(tx),
-					db.Equal("plugin_unique_identifier", pluginUniqueIdentifier.String()),
-					db.Equal("install_type", string(installType)),
-					db.WLock(),
-				)
-				if gerr != nil {
-					return err
-				}
-				p2.Refers++
-				if uerr := db.Update(&p2, tx); uerr != nil {
-					return uerr
-				}
-				pluginToBeReturns = &p2
-			} else {
-				pluginToBeReturns = plugin
-			}
-		} else if err != nil {
-			return err
-		} else {
-			p.Refers++
-			err := db.Update(&p, tx)
-			if err != nil {
-				return err
-			}
-			pluginToBeReturns = &p
-		}
-
-		// remove exists installation
-		if err := db.DeleteByCondition(
-			models.PluginInstallation{
-				PluginID:    pluginToBeReturns.PluginID,
-				RuntimeType: string(installType),
-				TenantID:    tenantId,
-			},
-			tx,
-		); err != nil {
+		if err != nil {
 			return err
 		}
+
+		_, err = db.GetOne[models.PluginInstallation](
+			db.WithTransactionContext(tx),
+			db.Equal("plugin_id", p.PluginID),
+			db.Equal("tenant_id", tenantId),
+		)
+		if err == nil {
+			return ErrPluginAlreadyInstalled
+		}
+		if !errors.Is(err, db.ErrDatabaseNotFound) {
+			return err
+		}
+
+		p.Refers++
+		if err := db.Update(&p, tx); err != nil {
+			return err
+		}
+		pluginToBeReturns = &p
 
 		installation := &models.PluginInstallation{
 			PluginID:               pluginToBeReturns.PluginID,

--- a/internal/types/models/curd/install_concurrency_test.go
+++ b/internal/types/models/curd/install_concurrency_test.go
@@ -12,28 +12,40 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestInstallPlugin_IdempotentUnderConcurrency ensures creating the same plugin/installation
-// concurrently is idempotent: only one plugin and one installation row are persisted.
-func TestInstallPlugin_IdempotentUnderConcurrency(t *testing.T) {
-	tenantID := uuid.NewString()
+func newConcurrencyTestIdentifier(t *testing.T) plugin_entities.PluginUniqueIdentifier {
+	t.Helper()
+
 	pluginName := "concurrency_demo_" + uuid.NewString()
 	checksum := uuid.NewString()
 	checksum = strings.ReplaceAll(checksum, "-", "")
-	// 32 hex chars
 	if len(checksum) > 32 {
 		checksum = checksum[:32]
 	}
 
 	identifier, err := plugin_entities.NewPluginUniqueIdentifier("tester/" + pluginName + ":1.0.0.0@" + checksum)
 	require.NoError(t, err)
+	return identifier
+}
 
-	const workers = 8
+func installPluginConcurrently(
+	t *testing.T,
+	identifier plugin_entities.PluginUniqueIdentifier,
+	tenantIDs []string,
+) []error {
+	t.Helper()
+
+	workers := len(tenantIDs)
+	start := make(chan struct{})
+	var ready sync.WaitGroup
 	var wg sync.WaitGroup
+	ready.Add(workers)
 	wg.Add(workers)
 	errs := make(chan error, workers)
-	for i := 0; i < workers; i++ {
+	for _, tenantID := range tenantIDs {
 		go func() {
 			defer wg.Done()
+			ready.Done()
+			<-start
 			_, _, err := InstallPlugin(
 				tenantID,
 				identifier,
@@ -45,16 +57,58 @@ func TestInstallPlugin_IdempotentUnderConcurrency(t *testing.T) {
 			errs <- err
 		}()
 	}
+	ready.Wait()
+	close(start)
 	wg.Wait()
 	close(errs)
 
-	// Validate DB state: exactly one plugin and one installation persisted
+	results := make([]error, 0, workers)
+	for err := range errs {
+		results = append(results, err)
+	}
+	return results
+}
+
+func fetchConcurrencyTestPlugin(
+	t *testing.T,
+	identifier plugin_entities.PluginUniqueIdentifier,
+) models.Plugin {
+	t.Helper()
+
 	plugins, err := db.GetAll[models.Plugin](
 		db.Equal("plugin_unique_identifier", identifier.String()),
 		db.Equal("install_type", string(plugin_entities.PLUGIN_RUNTIME_TYPE_LOCAL)),
 	)
 	require.NoError(t, err)
 	require.Len(t, plugins, 1, "should persist exactly one plugin record")
+	return plugins[0]
+}
+
+// TestInstallPlugin_IdempotentUnderConcurrency ensures repeated concurrent installation
+// for one tenant creates one installation and increments the reference count once.
+func TestInstallPlugin_IdempotentUnderConcurrency(t *testing.T) {
+	tenantID := uuid.NewString()
+	identifier := newConcurrencyTestIdentifier(t)
+
+	const workers = 8
+	tenantIDs := make([]string, workers)
+	for i := range tenantIDs {
+		tenantIDs[i] = tenantID
+	}
+
+	errs := installPluginConcurrently(t, identifier, tenantIDs)
+	successes := 0
+	for _, err := range errs {
+		if err == nil {
+			successes++
+			continue
+		}
+		require.ErrorIs(t, err, ErrPluginAlreadyInstalled)
+	}
+	require.Equal(t, 1, successes)
+
+	plugin := fetchConcurrencyTestPlugin(t, identifier)
+	require.Equal(t, 1, plugin.Refers)
 
 	installations, err := db.GetAll[models.PluginInstallation](
 		db.Equal("plugin_unique_identifier", identifier.String()),
@@ -73,4 +127,39 @@ func TestInstallPlugin_IdempotentUnderConcurrency(t *testing.T) {
 		map[string]any{"from": "test"},
 	)
 	require.ErrorIs(t, err, ErrPluginAlreadyInstalled)
+}
+
+// TestInstallPlugin_ConcurrentTenants ensures every tenant can install a plugin while
+// the shared plugin record is created and its reference count is updated concurrently.
+func TestInstallPlugin_ConcurrentTenants(t *testing.T) {
+	identifier := newConcurrencyTestIdentifier(t)
+
+	const workers = 8
+	tenantIDs := make([]string, workers)
+	for i := range tenantIDs {
+		tenantIDs[i] = uuid.NewString()
+	}
+
+	for _, err := range installPluginConcurrently(t, identifier, tenantIDs) {
+		require.NoError(t, err)
+	}
+
+	plugin := fetchConcurrencyTestPlugin(t, identifier)
+	require.Equal(t, workers, plugin.Refers)
+
+	installations, err := db.GetAll[models.PluginInstallation](
+		db.Equal("plugin_unique_identifier", identifier.String()),
+	)
+	require.NoError(t, err)
+	require.Len(t, installations, workers)
+
+	expectedTenants := make(map[string]struct{}, workers)
+	for _, tenantID := range tenantIDs {
+		expectedTenants[tenantID] = struct{}{}
+	}
+	for _, installation := range installations {
+		require.Contains(t, expectedTenants, installation.TenantID)
+		delete(expectedTenants, installation.TenantID)
+	}
+	require.Empty(t, expectedTenants)
 }


### PR DESCRIPTION
## Description

- atomically create and lock shared plugin records before updating installation state
- keep tenant installations idempotent and plugin reference counts consistent under concurrency
- cover concurrent installs for the same tenant and across independent tenants

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Other

## Essential Checklist

### Testing
- [x] I have tested the changes locally and confirmed they work as expected
- [x] I have added unit tests where necessary and they pass successfully

### Bug Fix (if applicable)
- [ ] I have used GitHub syntax to close the related issue (e.g., `Fixes #123` or `Closes #123`)

## Additional Information

Tracked in Linear: [SNP-623](https://linear.app/dify/issue/SNP-623/prevent-concurrent-plugin-installation-failures-in-plugin-daemon)