### PR TITLE
refactor(tool)!: rename date-picker type to date-range

### DIFF
--- a/pkg/entities/plugin_entities/constant.go
+++ b/pkg/entities/plugin_entities/constant.go
@@ -20,7 +20,7 @@ const (
 	OBJECT         = "object"
 	CHECKBOX       = "checkbox"
 	DATE           = "date"
-	DATE_PICKER    = "date-picker"
+	DATE_RANGE     = "date-range"
 )
 
 type ParameterOption struct {

--- a/pkg/entities/plugin_entities/tool_declaration.go
+++ b/pkg/entities/plugin_entities/tool_declaration.go
@@ -51,7 +51,7 @@ const (
 	TOOL_PARAMETER_OBJECT              ToolParameterType = OBJECT
 	TOOL_PARAMETER_TYPE_CHECKBOX       ToolParameterType = CHECKBOX
 	TOOL_PARAMETER_TYPE_DATE           ToolParameterType = DATE
-	TOOL_PARAMETER_TYPE_DATE_PICKER    ToolParameterType = DATE_PICKER
+	TOOL_PARAMETER_TYPE_DATE_RANGE     ToolParameterType = DATE_RANGE
 )
 
 func isToolParameterType(fl validator.FieldLevel) bool {
@@ -73,7 +73,7 @@ func isToolParameterType(fl validator.FieldLevel) bool {
 		string(TOOL_PARAMETER_OBJECT),
 		string(TOOL_PARAMETER_TYPE_CHECKBOX),
 		string(TOOL_PARAMETER_TYPE_DATE),
-		string(TOOL_PARAMETER_TYPE_DATE_PICKER):
+		string(TOOL_PARAMETER_TYPE_DATE_RANGE):
 		return true
 	}
 	return false

--- a/pkg/entities/plugin_entities/tool_declaration_test.go
+++ b/pkg/entities/plugin_entities/tool_declaration_test.go
@@ -75,7 +75,7 @@ func TestFullFunctionToolProvider_Validate(t *testing.T) {
 			"parameters": [
 				{
 					"name": "parameter",
-					"type": "string",
+					"type": "date-range",
 					"label": {
 						"en_US": "label",
 						"zh_Hans": "标签",
@@ -155,7 +155,7 @@ tools:
       llm: description
     parameters:
       - name: parameter
-        type: string
+        type: date-range
         label:
           en_US: label
           zh_Hans: 标签
@@ -688,7 +688,7 @@ func TestWrongIdentityTagsToolProvider_Validate(t *testing.T) {
 	}
 }
 
-func TestWrongToolParameterTypeToolProvider_Validate(t *testing.T) {
+func TestLegacyDatePickerToolParameterTypeToolProvider_Validate(t *testing.T) {
 	const data = `
 {
 	"identity": {
@@ -730,7 +730,7 @@ func TestWrongToolParameterTypeToolProvider_Validate(t *testing.T) {
 			"parameters": [
 				{
 					"name": "parameter",
-					"type": "wrong",
+					"type": "date-picker",
 					"label": {
 						"en_US": "label",
 						"zh_Hans": "标签",


### PR DESCRIPTION
## Summary

- rename the tool parameter constant from `DATE_PICKER` to `DATE_RANGE`
- change the accepted manifest value from `date-picker` to `date-range`
- cover acceptance of `date-range` and rejection of the legacy value in declaration tests

## Why

The parameter carries a `{ start, end }` date range. Naming the wire type `date-range` aligns it with the existing `date` type and avoids coupling the protocol to a picker UI.

## Breaking change

This intentionally removes support for `date-picker` without a compatibility alias. Plugin manifests using the earlier value must migrate to `date-range`.

## Related

- langgenius/dify#36163
- langgenius/dify-plugin-sdks#377
- follows up on #733

## Validation

- `go test ./pkg/entities/plugin_entities`
- `go test ./pkg/entities/...`
- `gofmt`
- `git diff --check`
