### PR TITLE
fix(packager): reject zip entries that escape the extraction directory

### DIFF
--- a/pkg/plugin_packager/decoder/zip.go
+++ b/pkg/plugin_packager/decoder/zip.go
@@ -298,21 +298,29 @@ func (z *ZipPluginDecoder) UniqueIdentity() (plugin_entities.PluginUniqueIdentif
 func (z *ZipPluginDecoder) ExtractTo(dst string) error {
 	// copy to working directory
 	if err := z.Walk(func(filename, dir string) error {
-		workingPath := path.Join(dst, dir)
+		entryName := path.Join(dir, filename)
+		target := filepath.Join(dst, filepath.FromSlash(entryName))
+
+		// zip entry names are attacker-controlled; path.Join only cleans the
+		// result, so a "../" prefix escapes dst into an arbitrary write. Reject
+		// any entry whose resolved path is not contained in dst.
+		rel, err := filepath.Rel(dst, target)
+		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+			return fmt.Errorf("illegal file path in plugin package: %q", entryName)
+		}
+
 		// check if directory exists
-		if err := os.MkdirAll(workingPath, 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
 			return err
 		}
 
-		bytes, err := z.ReadFile(filepath.Join(dir, filename))
+		bytes, err := z.ReadFile(entryName)
 		if err != nil {
 			return err
 		}
 
-		filename = filepath.Join(workingPath, filename)
-
 		// copy file
-		if err := os.WriteFile(filename, bytes, 0644); err != nil {
+		if err := os.WriteFile(target, bytes, 0644); err != nil {
 			return err
 		}
 

--- a/pkg/plugin_packager/decoder/zip.go
+++ b/pkg/plugin_packager/decoder/zip.go
@@ -296,6 +296,18 @@ func (z *ZipPluginDecoder) UniqueIdentity() (plugin_entities.PluginUniqueIdentif
 }
 
 func (z *ZipPluginDecoder) ExtractTo(dst string) error {
+	if err := os.MkdirAll(dst, 0755); err != nil {
+		return err
+	}
+
+	// Root-scoped handle: writes through it cannot escape dst, even via
+	// symlink or path trickery the lexical check below might miss.
+	root, err := os.OpenRoot(dst)
+	if err != nil {
+		return err
+	}
+	defer root.Close()
+
 	// copy to working directory
 	if err := z.Walk(func(filename, dir string) error {
 		entryName := path.Join(dir, filename)
@@ -310,7 +322,7 @@ func (z *ZipPluginDecoder) ExtractTo(dst string) error {
 		}
 
 		// check if directory exists
-		if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+		if err := root.MkdirAll(filepath.Dir(rel), 0755); err != nil {
 			return err
 		}
 
@@ -320,7 +332,15 @@ func (z *ZipPluginDecoder) ExtractTo(dst string) error {
 		}
 
 		// copy file
-		if err := os.WriteFile(target, bytes, 0644); err != nil {
+		out, err := root.OpenFile(rel, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+		if err != nil {
+			return err
+		}
+		if _, err := out.Write(bytes); err != nil {
+			out.Close()
+			return err
+		}
+		if err := out.Close(); err != nil {
 			return err
 		}
 

--- a/pkg/plugin_packager/decoder/zip_extract_test.go
+++ b/pkg/plugin_packager/decoder/zip_extract_test.go
@@ -1,0 +1,75 @@
+package decoder
+
+import (
+	"archive/zip"
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func buildTestZip(t *testing.T, entries map[string]string) []byte {
+	t.Helper()
+	buf := new(bytes.Buffer)
+	w := zip.NewWriter(buf)
+	for name, content := range entries {
+		fw, err := w.Create(name)
+		if err != nil {
+			t.Fatalf("create entry %q: %v", name, err)
+		}
+		if _, err := fw.Write([]byte(content)); err != nil {
+			t.Fatalf("write entry %q: %v", name, err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close zip writer: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestExtractToRejectsPathTraversal(t *testing.T) {
+	dst := t.TempDir()
+	outside := filepath.Join(filepath.Dir(dst), "evil-escaped-marker.txt")
+	defer os.Remove(outside)
+
+	dec := &ZipPluginDecoder{
+		reader: mustZipReader(t, buildTestZip(t, map[string]string{
+			"../../evil-escaped-marker.txt": "pwned",
+		})),
+	}
+
+	err := dec.ExtractTo(dst)
+	if err == nil {
+		t.Fatal("expected traversal entry to be rejected, got nil error")
+	}
+	if _, statErr := os.Stat(outside); !os.IsNotExist(statErr) {
+		t.Fatalf("traversal entry escaped dst: %s exists", outside)
+	}
+}
+
+func TestExtractToAllowsNormalEntries(t *testing.T) {
+	dst := t.TempDir()
+	dec := &ZipPluginDecoder{
+		reader: mustZipReader(t, buildTestZip(t, map[string]string{
+			"manifest.yaml":  "name: test",
+			"sub/dir/ok.txt": "fine",
+		})),
+	}
+
+	if err := dec.ExtractTo(dst); err != nil {
+		t.Fatalf("normal entries rejected: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dst, "sub", "dir", "ok.txt"))
+	if err != nil || string(got) != "fine" {
+		t.Fatalf("nested entry not extracted correctly: %v %q", err, got)
+	}
+}
+
+func mustZipReader(t *testing.T, b []byte) *zip.Reader {
+	t.Helper()
+	r, err := zip.NewReader(bytes.NewReader(b), int64(len(b)))
+	if err != nil {
+		t.Fatalf("open zip: %v", err)
+	}
+	return r
+}


### PR DESCRIPTION
## Description

`ZipPluginDecoder.ExtractTo` builds the output path with `path.Join(dst, dir)` / `filepath.Join(workingPath, filename)` from raw zip entry names. `path.Join` cleans the result but does not contain it, so an entry named `../../evil.py` resolves **outside** the plugin working directory.

Impact: installing an attacker-crafted `.difypkg` yields arbitrary file write on the daemon host - overwriting runtime files, or planting code that the daemon subsequently loads/executes - anywhere signature verification is disabled (local/self-hosted installs) or the package otherwise reaches extraction.

## Type of Change

- [x] Bug fix

## Essential Checklist

### Testing
- [x] I have tested the changes locally and confirmed they work as expected
- [x] I have added unit tests where necessary and they pass successfully

Each entry is now resolved against the destination with `filepath.Rel` and rejected unless strictly contained (`illegal file path in plugin package`). On rejection the partially-written working directory is removed, matching the existing error path.

Added `pkg/plugin_packager/decoder/zip_extract_test.go`:
- `TestExtractToRejectsPathTraversal`: a `../../` entry errors and nothing is written outside `dst`
- `TestExtractToAllowsNormalEntries`: nested legitimate entries still extract correctly

`go test ./pkg/plugin_packager/decoder/ -run TestExtractTo -count=1 -v` - both pass.

## Additional Information

The read paths (`ReadFile`/`ReadDir`) are unaffected; this hardens only the write sink. Behavior for well-formed packages (including marketplace packages) is unchanged.

Made with [Cursor](https://cursor.com)