### PR TITLE
fix(local-runtime): stop inheriting daemon environment in plugin subprocesses

### DIFF
--- a/internal/core/local_runtime/subprocess.go
+++ b/internal/core/local_runtime/subprocess.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"time"
 
+	"github.com/langgenius/dify-plugin-daemon/internal/types/app"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/constants"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/plugin_entities"
 	routinepkg "github.com/langgenius/dify-plugin-daemon/pkg/routine"
@@ -32,19 +33,66 @@ func (r *LocalPluginRuntime) getInstanceCmd() (*exec.Cmd, error) {
 		return nil, fmt.Errorf("unsupported language: %s", r.Config.Meta.Runner.Language)
 	}
 
-	cmd.Env = cmd.Environ()
-	if r.appConfig.HttpsProxy != "" {
-		cmd.Env = append(cmd.Env, fmt.Sprintf("HTTPS_PROXY=%s", r.appConfig.HttpsProxy))
-	}
-	if r.appConfig.HttpProxy != "" {
-		cmd.Env = append(cmd.Env, fmt.Sprintf("HTTP_PROXY=%s", r.appConfig.HttpProxy))
-	}
-	if r.appConfig.NoProxy != "" {
-		cmd.Env = append(cmd.Env, fmt.Sprintf("NO_PROXY=%s", r.appConfig.NoProxy))
-	}
-	cmd.Env = append(cmd.Env, "INSTALL_METHOD=local", "PATH="+os.Getenv("PATH"))
+	cmd.Env = BuildPluginCommandEnv(r.appConfig)
 	cmd.Dir = r.State.WorkingPath
 	return cmd, nil
+}
+
+// pluginCommandEnvAllowlist lists the only process environment variables a
+// plugin subprocess may inherit. Daemon credentials such as DB_PASSWORD,
+// SERVER_KEY or DIFY_INNER_API_KEY must never reach plugin code.
+var pluginCommandEnvAllowlist = []string{
+	"PATH",
+	"HOME",
+	"LANG",
+	"LC_ALL",
+	"LC_CTYPE",
+	"TMPDIR",
+	"TEMP",
+	"TMP",
+	"TZ",
+	"SSL_CERT_FILE",
+	"REQUESTS_CA_BUNDLE",
+	"HTTP_PROXY",
+	"HTTPS_PROXY",
+	"NO_PROXY",
+	"http_proxy",
+	"https_proxy",
+	"no_proxy",
+}
+
+// BuildPluginCommandEnv builds the environment of a plugin subprocess from an
+// explicit allowlist instead of inheriting the daemon process environment,
+// mirroring buildUVCommandEnv for the dependency installer. Proxy settings
+// from the daemon config take precedence over inherited proxy variables.
+func BuildPluginCommandEnv(appConfig *app.Config) []string {
+	envByKey := make(map[string]string, len(pluginCommandEnvAllowlist)+4)
+	for _, key := range pluginCommandEnvAllowlist {
+		if value, ok := os.LookupEnv(key); ok {
+			envByKey[key] = value
+		}
+	}
+
+	if appConfig != nil {
+		if appConfig.HttpProxy != "" {
+			envByKey["HTTP_PROXY"] = appConfig.HttpProxy
+		}
+		if appConfig.HttpsProxy != "" {
+			envByKey["HTTPS_PROXY"] = appConfig.HttpsProxy
+		}
+		if appConfig.NoProxy != "" {
+			envByKey["NO_PROXY"] = appConfig.NoProxy
+		}
+	}
+
+	envByKey["INSTALL_METHOD"] = "local"
+
+	env := make([]string, 0, len(envByKey))
+	for key, value := range envByKey {
+		env = append(env, key+"="+value)
+	}
+	slices.Sort(env)
+	return env
 }
 
 // getInstanceStdio gets the stdin, stdout, and stderr pipes for the plugin instance

--- a/internal/core/local_runtime/subprocess_test.go
+++ b/internal/core/local_runtime/subprocess_test.go
@@ -1,0 +1,98 @@
+package local_runtime
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/langgenius/dify-plugin-daemon/internal/types/app"
+	"github.com/langgenius/dify-plugin-daemon/pkg/entities/constants"
+	"github.com/langgenius/dify-plugin-daemon/pkg/entities/plugin_entities"
+	"github.com/stretchr/testify/require"
+)
+
+func pluginEnvSliceToMap(t *testing.T, env []string) map[string]string {
+	t.Helper()
+	envByKey := make(map[string]string, len(env))
+	for _, item := range env {
+		key, value, found := strings.Cut(item, "=")
+		require.True(t, found)
+		envByKey[key] = value
+	}
+	return envByKey
+}
+
+func TestBuildPluginCommandEnv(t *testing.T) {
+	t.Setenv("PATH", "/test/bin")
+	t.Setenv("HOME", "/test/home")
+	t.Setenv("LANG", "en_US.UTF-8")
+	t.Setenv("HTTP_PROXY", "http://env-proxy:8080")
+	t.Setenv("DB_PASSWORD", "must-not-be-inherited")
+	t.Setenv("SERVER_KEY", "must-not-be-inherited")
+	t.Setenv("DIFY_INNER_API_KEY", "must-not-be-inherited")
+	t.Setenv("AWS_ACCESS_KEY_ID", "must-not-be-inherited")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "must-not-be-inherited")
+	t.Setenv("REDIS_PASSWORD", "must-not-be-inherited")
+	t.Setenv("ADMIN_API_KEY", "must-not-be-inherited")
+	t.Setenv("UNRELATED_SECRET", "must-not-be-inherited")
+
+	env := BuildPluginCommandEnv(&app.Config{
+		HttpsProxy: "https://config-proxy:8443",
+		NoProxy:    "localhost,127.0.0.1",
+	})
+	envByKey := pluginEnvSliceToMap(t, env)
+
+	// allowlisted variables are passed through
+	require.Equal(t, "/test/bin", envByKey["PATH"])
+	require.Equal(t, "/test/home", envByKey["HOME"])
+	require.Equal(t, "en_US.UTF-8", envByKey["LANG"])
+	require.Equal(t, "http://env-proxy:8080", envByKey["HTTP_PROXY"])
+	require.Equal(t, "local", envByKey["INSTALL_METHOD"])
+
+	// proxy settings from the daemon config take precedence
+	require.Equal(t, "https://config-proxy:8443", envByKey["HTTPS_PROXY"])
+	require.Equal(t, "localhost,127.0.0.1", envByKey["NO_PROXY"])
+
+	// daemon secrets never reach the plugin process
+	for _, key := range []string{
+		"DB_PASSWORD",
+		"SERVER_KEY",
+		"DIFY_INNER_API_KEY",
+		"AWS_ACCESS_KEY_ID",
+		"AWS_SECRET_ACCESS_KEY",
+		"REDIS_PASSWORD",
+		"ADMIN_API_KEY",
+		"UNRELATED_SECRET",
+	} {
+		require.NotContains(t, envByKey, key)
+	}
+}
+
+func TestGetInstanceCmdDoesNotInheritDaemonEnv(t *testing.T) {
+	t.Setenv("PATH", "/test/bin")
+	t.Setenv("DB_PASSWORD", "must-not-be-inherited")
+	t.Setenv("SERVER_KEY", "must-not-be-inherited")
+	t.Setenv("DIFY_INNER_API_KEY", "must-not-be-inherited")
+
+	// minimal fake venv so getVirtualEnvironmentPythonPath succeeds
+	workDir := t.TempDir()
+	venvBin := filepath.Join(workDir, ".venv", "bin")
+	require.NoError(t, os.MkdirAll(venvBin, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(venvBin, "python"), []byte("#!/bin/sh\n"), 0o755))
+
+	r := &LocalPluginRuntime{appConfig: &app.Config{}}
+	r.State = plugin_entities.PluginRuntimeState{WorkingPath: workDir}
+	r.Config.Meta.Runner.Language = constants.Python
+	r.Config.Meta.Runner.Entrypoint = "main"
+
+	cmd, err := r.getInstanceCmd()
+	require.NoError(t, err)
+
+	envByKey := pluginEnvSliceToMap(t, cmd.Env)
+	require.Equal(t, "/test/bin", envByKey["PATH"])
+	require.Equal(t, "local", envByKey["INSTALL_METHOD"])
+	require.NotContains(t, envByKey, "DB_PASSWORD")
+	require.NotContains(t, envByKey, "SERVER_KEY")
+	require.NotContains(t, envByKey, "DIFY_INNER_API_KEY")
+}

--- a/pkg/slim/local.go
+++ b/pkg/slim/local.go
@@ -169,7 +169,7 @@ func execPlugin(
 
 	cmd := exec.Command(pythonPath, "-m", rt.Config.Meta.Runner.Entrypoint)
 	cmd.Dir = rt.State.WorkingPath
-	cmd.Env = append(os.Environ(), "INSTALL_METHOD=local", "PATH="+os.Getenv("PATH"))
+	cmd.Env = local_runtime.BuildPluginCommandEnv(appConfig)
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {


### PR DESCRIPTION
Plugin subprocesses no longer receive a copy of the daemon's own environment variables.

## What

`getInstanceCmd` built plugin processes with `cmd.Environ()`, which copies the daemon process's entire environment into every plugin subprocess. In every real deployment that environment carries the daemon's full credential set: `DB_PASSWORD` / `DB_USERNAME` (direct Postgres access to all tenant plugin data), `SERVER_KEY` (the shared key protecting the daemon's management and dispatch routes), `DIFY_INNER_API_KEY` (the daemon's identity for Dify's internal API), Redis and cloud storage credentials, `ADMIN_API_KEY`, and anything else the operator places in the container env. Any installed plugin could read all of it from `os.environ` and exfiltrate it over the network, since plugins make arbitrary outbound calls by design. The slim CLI's local mode had the same pattern (`os.Environ()`), running marketplace-downloaded plugin code with the developer's full shell environment.

## Why

The local runtime's design (separate process per plugin, dedicated working directory, stdio-only IPC, heartbeat watchdog) exists to run third-party marketplace code at reduced trust. Inheriting the daemon environment defeats the confidentiality half of that isolation, and plugins need none of these variables to function: daemon to plugin traffic is stdio-framed, and plugin configuration arrives per-invocation rather than through the environment. The repo already recognized this pattern for the short-lived `uv` installer child process (`buildUVCommandEnv`, with a test asserting `UNRELATED_SECRET` is not inherited); the long-lived plugin process was missed.

## How

Replace inheritance with an explicit allowlist builder, `BuildPluginCommandEnv`, mirroring `buildUVCommandEnv`. It passes through what plugins legitimately need: `PATH`, `HOME`, locale variables (`LANG`, `LC_ALL`, `LC_CTYPE`), temp directories (`TMPDIR`, `TEMP`, `TMP`), `TZ`, custom CA bundles (`SSL_CERT_FILE`, `REQUESTS_CA_BUNDLE`), and proxy variables in both cases, with the daemon config's proxy settings (`HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY`, themselves loaded from env or config) taking precedence. `INSTALL_METHOD=local` is set exactly as before. Everything else, including all `*_KEY` / `*_SECRET` / `*_PASSWORD` / `*_TOKEN` style credentials, never reaches plugin code. The slim CLI local mode now uses the same builder.

## How verified

- New `internal/core/local_runtime/subprocess_test.go`: `TestBuildPluginCommandEnv` asserts allowlisted variables pass through, config proxy settings win over inherited ones, and `DB_PASSWORD` / `SERVER_KEY` / `DIFY_INNER_API_KEY` / `AWS_*` / `REDIS_PASSWORD` / `ADMIN_API_KEY` are absent. `TestGetInstanceCmdDoesNotInheritDaemonEnv` builds the real plugin command against a fake venv and asserts the same on `cmd.Env`, proving the spawn site is wired to the allowlist.
- `go build` passes for the touched packages, and `go test ./internal/core/local_runtime/... ./pkg/slim/...` passes in full. (A whole-repo `go build ./...` additionally requires the gitignored `pkg/license/private_key/PRIVATE_KEY.pem`, unrelated to this change.)

Same disclosure class as our merged #796: a one-line omission visible in the public source, fixed directly via public PR.

Made with [Cursor](https://cursor.com)