### PR TITLE
fix(persistence): validate delete and exist keys

### DIFF
--- a/internal/core/persistence/persistence.go
+++ b/internal/core/persistence/persistence.go
@@ -133,6 +133,10 @@ func (c *Persistence) Load(tenantId string, pluginId string, key string) ([]byte
 }
 
 func (c *Persistence) Delete(tenantId string, pluginId string, key string) (int64, error) {
+	if err := c.checkPathTraversal(key); err != nil {
+		return 0, err
+	}
+
 	// delete from cache and storage
 	deletedNum, err := cache.Del(c.getCacheKey(tenantId, pluginId, key))
 	if err != nil {
@@ -165,6 +169,10 @@ func (c *Persistence) Delete(tenantId string, pluginId string, key string) (int6
 }
 
 func (c *Persistence) Exist(tenantId string, pluginId string, key string) (int64, error) {
+	if err := c.checkPathTraversal(key); err != nil {
+		return 0, err
+	}
+
 	existNum, err := cache.Exist(c.getCacheKey(tenantId, pluginId, key))
 	if err != nil {
 		return 0, err

--- a/internal/core/persistence/persistence_test.go
+++ b/internal/core/persistence/persistence_test.go
@@ -212,4 +212,15 @@ func TestPersistencePathTraversal(t *testing.T) {
 			assert.Equal(t, err != nil, tc.wantErr)
 		})
 	}
+
+	victimKey := strings.RandomString(10)
+	assert.NoError(t, persistence.Save("victim_tenant", "victim_plugin", -1, victimKey, []byte("data")))
+
+	traversalKey := "../../victim_tenant/victim_plugin/" + victimKey
+	_, err = persistence.Exist("attacker_tenant", "attacker_plugin", traversalKey)
+	assert.EqualError(t, err, "invalid key: path traversal attempt detected")
+	_, err = persistence.Delete("attacker_tenant", "attacker_plugin", traversalKey)
+	assert.EqualError(t, err, "invalid key: path traversal attempt detected")
+	_, err = persistence.Load("victim_tenant", "victim_plugin", victimKey)
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
## Description

Validate persistence keys before `Delete` and `Exist` reach the cache, storage, or database.
This aligns them with `Save` and `Load` and prevents traversal keys from probing or deleting another tenant or plugin’s data.

Refs langgenius/dify#37990

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Other

## Essential Checklist

### Testing

- [ ] I have tested the changes locally and confirmed they work as expected
- [x] I have added unit tests where necessary and they pass successfully

### Bug Fix (if applicable)

- [ ] I have used GitHub syntax to close the related issue (the related issue is a cross-repository umbrella checklist)

## Additional Information

- `go vet ./internal/core/persistence`
- `go test ./internal/core/persistence -run ^TestPersistencePathTraversal$ -count=1`
- The local persistence suite skips its service-backed assertions when Redis or PostgreSQL is unavailable; CI starts both services and runs the regression test.