### PR TITLE
fix: separate backwards LLM stream timeout budgets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -249,6 +249,20 @@ PLUGIN_MODEL_INSTALLATIONS_CACHE_TTL=1440
 DIFY_BACKWARDS_INVOCATION_WRITE_TIMEOUT=5000
 # dify backwards invocation read timeout in milliseconds
 DIFY_BACKWARDS_INVOCATION_READ_TIMEOUT=240000
+
+# LLM-only reverse-call budgets, all in milliseconds. These do not alter tools,
+# embeddings, storage, or other reverse calls. Zero means inherit, not unlimited.
+# Total includes connection setup/headers/body and is also bounded by caller cancellation.
+# Total defaults to DIFY_BACKWARDS_INVOCATION_READ_TIMEOUT.
+DIFY_BACKWARDS_INVOCATION_LLM_TOTAL_TIMEOUT=0
+# First decoded response frame (not first output token); defaults to the LLM total.
+# Also bounds a blocking LLM call waiting for its one final response.
+DIFY_BACKWARDS_INVOCATION_LLM_FIRST_RESPONSE_TIMEOUT=0
+# Read-idle timer starts after the first frame and resets on received bytes/frames.
+# Defaults to DIFY_BACKWARDS_INVOCATION_READ_TIMEOUT.
+DIFY_BACKWARDS_INVOCATION_LLM_IDLE_TIMEOUT=0
+# Example for longer LLM calls: TOTAL=600000, FIRST_RESPONSE=600000, IDLE=240000.
+# Keep outer plugin/SDK/serverless execution budgets longer than the single-call budget.
 PLUGIN_IGNORE_UV_LOCK=false
 # auto-detect pip mirror at daemon startup by measuring latency to official PyPI and each candidate
 # a candidate is selected only if it is faster than official PyPI by defined amount; if no candidate meets

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ daemon supports a global Redis prefix via `REDIS_KEY_PREFIX`.
 
 ## Documentation
 
+- [Backwards LLM invocation timeouts](docs/backwards-llm-timeouts.md)
+
 ### Development Guide
 
 For developers working on this codebase, see our comprehensive development documentation:

--- a/docs/backwards-llm-timeouts.md
+++ b/docs/backwards-llm-timeouts.md
@@ -1,0 +1,60 @@
+# Backwards LLM invocation timeouts
+
+Agent strategy plugins can invoke an LLM through the daemon's reverse connection
+to Dify's inner API. That connection uses framed responses even when the model
+request has `stream: false`.
+
+LLM and structured-output LLM reverse calls have three transport budgets. All
+values below are milliseconds. Zero means **inherit**, not unlimited.
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `DIFY_BACKWARDS_INVOCATION_LLM_TOTAL_TIMEOUT` | `0` | Entire reverse HTTP request, including headers and response body. Inherits `DIFY_BACKWARDS_INVOCATION_READ_TIMEOUT` (normally `240000`). |
+| `DIFY_BACKWARDS_INVOCATION_LLM_FIRST_RESPONSE_TIMEOUT` | `0` | Time until the first decoded response frame. Inherits the effective LLM total budget. |
+| `DIFY_BACKWARDS_INVOCATION_LLM_IDLE_TIMEOUT` | `0` | Maximum read inactivity after the first decoded frame. Incoming body bytes or decoded frames reset it. Inherits `DIFY_BACKWARDS_INVOCATION_READ_TIMEOUT`. |
+
+These budgets do not change the timeout settings for tool, embedding, storage,
+or other reverse calls. They also do not change the forward model invocation
+protocol. The first-response budget is not a first-token SLA: an empty model
+delta can already be a valid response frame. A blocking model invocation waits
+under its first-response/total budgets, not the post-response idle budget.
+
+For example, to allow a reverse LLM call to run for up to ten minutes without
+changing the existing four-minute budget for other reverse calls:
+
+```dotenv
+DIFY_BACKWARDS_INVOCATION_READ_TIMEOUT=240000
+DIFY_BACKWARDS_INVOCATION_LLM_TOTAL_TIMEOUT=600000
+DIFY_BACKWARDS_INVOCATION_LLM_FIRST_RESPONSE_TIMEOUT=600000
+DIFY_BACKWARDS_INVOCATION_LLM_IDLE_TIMEOUT=240000
+```
+
+Keep the enclosing plugin/Agent execution budget longer than the single LLM call
+budget. Check `PLUGIN_MAX_EXECUTION_TIMEOUT`, the SDK's invocation timeout,
+serverless transaction limits, and API/worker HTTP read timeouts separately;
+their units and semantics differ. A caller cancellation or earlier parent
+deadline always wins. Multiple LLM/tool calls share the enclosing execution
+budget; increasing the per-call limit does not grant unlimited Agent execution.
+
+Timeout messages include `phase=first_response`, `phase=read_idle`, or
+`phase=total`, and `timeout_ms`. They use the existing reverse-call error envelope
+so older SDKs can display the reason without a protocol upgrade. The daemon
+cancels the reverse HTTP request and releases its timers/body when it completes
+or the consumer closes it. Cancellation of the provider's actual computation
+still depends on the downstream API/runtime/SDK honoring the disconnect.
+
+No automatic retries are added. Retrying an entire Agent execution can repeat
+tool side effects and model charges.
+
+## Long-stream regression
+
+The optional integration test below uses a local framed HTTP producer, not a
+model provider. It runs a legacy control and the LLM policy concurrently, proving
+that the deployment budgets permit an active stream past the old four-minute
+cutoff. Export the daemon timeout settings from the example above first.
+
+```sh
+DIFY_TEST_BACKWARDS_LLM_STREAM_SECONDS=260 go test \
+  ./internal/core/dify_invocation/calldify \
+  -run '^TestBackwardsLLMLongStream$' -v -count=1 -timeout=8m
+```

--- a/internal/core/dify_invocation/calldify/http_client.go
+++ b/internal/core/dify_invocation/calldify/http_client.go
@@ -7,15 +7,19 @@ import (
 	"time"
 
 	"github.com/langgenius/dify-plugin-daemon/internal/core/dify_invocation"
+	"github.com/langgenius/dify-plugin-daemon/pkg/utils/http_requests"
 	otelhttp "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
 type NewDifyInvocationDaemonPayload struct {
-	BaseUrl              string
-	CallingKey           string
-	WriteTimeout         int64
-	ReadTimeout          int64
-	ResponseMaxBufferSize int64
+	BaseUrl                 string
+	CallingKey              string
+	WriteTimeout            int64
+	ReadTimeout             int64
+	LLMFirstResponseTimeout int64
+	LLMIdleTimeout          int64
+	LLMTotalTimeout         int64
+	ResponseMaxBufferSize   int64
 }
 
 func NewDifyInvocationDaemon(payload NewDifyInvocationDaemonPayload) (dify_invocation.BackwardsInvocation, error) {
@@ -40,6 +44,23 @@ func NewDifyInvocationDaemon(payload NewDifyInvocationDaemonPayload) (dify_invoc
 	invocation.difyInnerApiKey = payload.CallingKey
 	invocation.writeTimeout = payload.WriteTimeout
 	invocation.readTimeout = payload.ReadTimeout
+	total := payload.LLMTotalTimeout
+	if total == 0 {
+		total = payload.ReadTimeout
+	}
+	firstResponse := payload.LLMFirstResponseTimeout
+	if firstResponse == 0 {
+		firstResponse = total
+	}
+	idle := payload.LLMIdleTimeout
+	if idle == 0 {
+		idle = payload.ReadTimeout
+	}
+	invocation.llmStreamTimeouts = http_requests.StreamTimeouts{
+		FirstResponse: time.Duration(firstResponse) * time.Millisecond,
+		ReadIdle:      time.Duration(idle) * time.Millisecond,
+		Total:         time.Duration(total) * time.Millisecond,
+	}
 	invocation.responseMaxBufferSize = payload.ResponseMaxBufferSize
 
 	return invocation, nil

--- a/internal/core/dify_invocation/calldify/http_request.go
+++ b/internal/core/dify_invocation/calldify/http_request.go
@@ -117,13 +117,15 @@ func StreamResponse[T any](i *RealBackwardsInvocation, method string, path strin
 }
 
 func (i *RealBackwardsInvocation) InvokeLLM(payload *dify_invocation.InvokeLLMRequest) (*stream.Stream[model_entities.LLMResultChunk], error) {
-	return StreamResponse[model_entities.LLMResultChunk](i, "POST", "invoke/llm", http_requests.HttpPayloadJson(payload))
+	return StreamResponse[model_entities.LLMResultChunk](i, "POST", "invoke/llm",
+		http_requests.HttpPayloadJson(payload), http_requests.HttpStreamTimeouts(i.llmStreamTimeouts))
 }
 
 func (i *RealBackwardsInvocation) InvokeLLMWithStructuredOutput(payload *dify_invocation.InvokeLLMWithStructuredOutputRequest) (
 	*stream.Stream[model_entities.LLMResultChunkWithStructuredOutput], error,
 ) {
-	return StreamResponse[model_entities.LLMResultChunkWithStructuredOutput](i, "POST", "/invoke/llm/structured-output", http_requests.HttpPayloadJson(payload))
+	return StreamResponse[model_entities.LLMResultChunkWithStructuredOutput](i, "POST", "/invoke/llm/structured-output",
+		http_requests.HttpPayloadJson(payload), http_requests.HttpStreamTimeouts(i.llmStreamTimeouts))
 }
 
 func (i *RealBackwardsInvocation) InvokeTextEmbedding(payload *dify_invocation.InvokeTextEmbeddingRequest) (*model_entities.TextEmbeddingResult, error) {

--- a/internal/core/dify_invocation/calldify/llm_timeouts_long_test.go
+++ b/internal/core/dify_invocation/calldify/llm_timeouts_long_test.go
@@ -1,0 +1,106 @@
+package calldify
+
+import (
+	"encoding/binary"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/langgenius/dify-plugin-daemon/internal/core/dify_invocation"
+	"github.com/langgenius/dify-plugin-daemon/pkg/entities/model_entities"
+	"github.com/langgenius/dify-plugin-daemon/pkg/utils/routine"
+	"github.com/langgenius/dify-plugin-daemon/pkg/utils/stream"
+	"github.com/stretchr/testify/require"
+)
+
+// Opt-in wall-clock regression against deployment budgets without provider
+// credentials or external model calls. The two paths run concurrently.
+func TestBackwardsLLMLongStream(t *testing.T) {
+	secondsText := os.Getenv("DIFY_TEST_BACKWARDS_LLM_STREAM_SECONDS")
+	if secondsText == "" {
+		t.Skip("set DIFY_TEST_BACKWARDS_LLM_STREAM_SECONDS to exercise deployment budgets")
+	}
+	seconds, err := strconv.Atoi(secondsText)
+	require.NoError(t, err)
+	require.Greater(t, seconds, 0)
+	require.LessOrEqual(t, seconds, 1200)
+	readMS := func(key string, fallback int64) int64 {
+		if value := os.Getenv(key); value != "" {
+			parsed, err := strconv.ParseInt(value, 10, 64)
+			require.NoError(t, err)
+			return parsed
+		}
+		return fallback
+	}
+	payload := NewDifyInvocationDaemonPayload{
+		ReadTimeout:             readMS("DIFY_BACKWARDS_INVOCATION_READ_TIMEOUT", 240000),
+		LLMFirstResponseTimeout: readMS("DIFY_BACKWARDS_INVOCATION_LLM_FIRST_RESPONSE_TIMEOUT", 0),
+		LLMIdleTimeout:          readMS("DIFY_BACKWARDS_INVOCATION_LLM_IDLE_TIMEOUT", 0),
+		LLMTotalTimeout:         readMS("DIFY_BACKWARDS_INVOCATION_LLM_TOTAL_TIMEOUT", 0),
+		ResponseMaxBufferSize:   1024 * 1024,
+	}
+	require.Greater(t, int64(seconds)*1000, payload.ReadTimeout, "stream must outlive the legacy body deadline")
+	routine.InitPool(16)
+	for _, legacy := range []bool{false, true} {
+		name := "llm_policy"
+		if legacy {
+			name = "legacy_control"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				w.(http.Flusher).Flush()
+				body := []byte(`{"data":{"model":"fixture","delta":{"index":0,"message":{"role":"assistant","content":"progress"}}}}`)
+				header := make([]byte, 14)
+				header[0] = 0x0f
+				binary.LittleEndian.PutUint16(header[2:4], 10)
+				binary.LittleEndian.PutUint32(header[4:8], uint32(len(body)))
+				frame := append(header, body...)
+				ticker := time.NewTicker(time.Second)
+				defer ticker.Stop()
+				for range seconds {
+					select {
+					case <-r.Context().Done():
+						return
+					case <-ticker.C:
+					}
+					_, _ = w.Write(frame)
+					w.(http.Flusher).Flush()
+				}
+			}))
+			defer server.Close()
+			config := payload
+			config.BaseUrl = server.URL
+			invocation, err := NewDifyInvocationDaemon(config)
+			require.NoError(t, err)
+			started := time.Now()
+			var response *stream.Stream[model_entities.LLMResultChunk]
+			if legacy {
+				response, err = StreamResponse[model_entities.LLMResultChunk](invocation.(*RealBackwardsInvocation), http.MethodPost, "invoke/llm")
+			} else {
+				response, err = invocation.InvokeLLM(&dify_invocation.InvokeLLMRequest{InvokeLLMSchema: dify_invocation.InvokeLLMSchema{Stream: true}})
+			}
+			require.NoError(t, err)
+			defer response.Close()
+			count := 0
+			for response.Next() {
+				_, err = response.Read()
+				if err != nil {
+					break
+				}
+				count++
+			}
+			t.Logf("frames=%d elapsed=%s error=%v", count, time.Since(started), err)
+			if legacy {
+				require.ErrorContains(t, err, "failed to read system header")
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, seconds, count)
+			}
+		})
+	}
+}

--- a/internal/core/dify_invocation/calldify/llm_timeouts_long_test.go
+++ b/internal/core/dify_invocation/calldify/llm_timeouts_long_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/langgenius/dify-plugin-daemon/internal/core/dify_invocation"
 	"github.com/langgenius/dify-plugin-daemon/pkg/entities/model_entities"
+	"github.com/langgenius/dify-plugin-daemon/pkg/utils/http_requests"
 	"github.com/langgenius/dify-plugin-daemon/pkg/utils/routine"
 	"github.com/langgenius/dify-plugin-daemon/pkg/utils/stream"
 	"github.com/stretchr/testify/require"
@@ -63,13 +64,13 @@ func TestBackwardsLLMLongStream(t *testing.T) {
 				ticker := time.NewTicker(time.Second)
 				defer ticker.Stop()
 				for range seconds {
+					_, _ = w.Write(frame)
+					w.(http.Flusher).Flush()
 					select {
 					case <-r.Context().Done():
 						return
 					case <-ticker.C:
 					}
-					_, _ = w.Write(frame)
-					w.(http.Flusher).Flush()
 				}
 			}))
 			defer server.Close()
@@ -94,9 +95,18 @@ func TestBackwardsLLMLongStream(t *testing.T) {
 				}
 				count++
 			}
-			t.Logf("frames=%d elapsed=%s error=%v", count, time.Since(started), err)
+			elapsed := time.Since(started)
+			t.Logf("frames=%d elapsed=%s error=%v", count, elapsed, err)
 			if legacy {
-				require.ErrorContains(t, err, "failed to read system header")
+				// The timer may interrupt the frame prefix, header, or payload.
+				// Assert the fixed cutoff rather than one platform-specific read error.
+				require.Error(t, err)
+				var timeout *http_requests.StreamTimeoutError
+				require.NotErrorAs(t, err, &timeout)
+				require.Greater(t, count, 0)
+				require.Less(t, count, seconds)
+				require.GreaterOrEqual(t, elapsed, time.Duration(config.ReadTimeout)*time.Millisecond)
+				require.Less(t, elapsed, time.Duration(config.ReadTimeout)*time.Millisecond+5*time.Second)
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, seconds, count)

--- a/internal/core/dify_invocation/calldify/llm_timeouts_test.go
+++ b/internal/core/dify_invocation/calldify/llm_timeouts_test.go
@@ -1,0 +1,117 @@
+package calldify
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/langgenius/dify-plugin-daemon/internal/core/dify_invocation"
+	"github.com/langgenius/dify-plugin-daemon/pkg/utils/http_requests"
+	"github.com/langgenius/dify-plugin-daemon/pkg/utils/routine"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBackwardsLLMTimeoutInheritance(t *testing.T) {
+	for _, tc := range []struct {
+		name               string
+		first, idle, total int64
+		want               http_requests.StreamTimeouts
+	}{
+		{"legacy_defaults_remain_bounded", 0, 0, 0, http_requests.StreamTimeouts{FirstResponse: 240 * time.Second, ReadIdle: 240 * time.Second, Total: 240 * time.Second}},
+		{"total_override_also_extends_first_response", 0, 0, 600000, http_requests.StreamTimeouts{FirstResponse: 600 * time.Second, ReadIdle: 240 * time.Second, Total: 600 * time.Second}},
+		{"independent_budgets", 300000, 120000, 600000, http_requests.StreamTimeouts{FirstResponse: 300 * time.Second, ReadIdle: 120 * time.Second, Total: 600 * time.Second}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			invocation, err := NewDifyInvocationDaemon(NewDifyInvocationDaemonPayload{
+				BaseUrl: "http://localhost", ReadTimeout: 240000,
+				LLMFirstResponseTimeout: tc.first, LLMIdleTimeout: tc.idle, LLMTotalTimeout: tc.total,
+			})
+			require.NoError(t, err)
+			require.Equal(t, tc.want, invocation.(*RealBackwardsInvocation).llmStreamTimeouts)
+		})
+	}
+}
+
+func TestBackwardsLLMEndpointsUseNewBudgets(t *testing.T) {
+	routine.InitPool(16)
+	for _, structured := range []bool{false, true} {
+		for _, streaming := range []bool{false, true} {
+			t.Run(fmt.Sprintf("structured=%v/stream=%v", structured, streaming), func(t *testing.T) {
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					require.Equal(t, "test-key", r.Header.Get("X-Inner-Api-Key"))
+					path := "/inner/api/invoke/llm"
+					if structured {
+						path += "/structured-output"
+					}
+					require.Equal(t, path, r.URL.Path)
+					w.WriteHeader(http.StatusOK)
+					w.(http.Flusher).Flush()
+					select {
+					case <-r.Context().Done():
+						return
+					case <-time.After(140 * time.Millisecond):
+					}
+					body := []byte(`{"data":{"model":"fixture","delta":{"index":0,"message":{"role":"assistant","content":"ok"}},"structured_output":{"answer":"ok"}}}`)
+					header := make([]byte, 14)
+					header[0] = 0x0f
+					binary.LittleEndian.PutUint16(header[2:4], 10)
+					binary.LittleEndian.PutUint32(header[4:8], uint32(len(body)))
+					_, _ = w.Write(append(header, body...))
+				}))
+				defer server.Close()
+				invocation, err := NewDifyInvocationDaemon(NewDifyInvocationDaemonPayload{
+					BaseUrl: server.URL, CallingKey: "test-key", ReadTimeout: 40, ResponseMaxBufferSize: 1024 * 1024,
+					LLMTotalTimeout: 1000, LLMIdleTimeout: 60,
+				})
+				require.NoError(t, err)
+				schema := dify_invocation.InvokeLLMSchema{Stream: streaming}
+				if structured {
+					response, err := invocation.InvokeLLMWithStructuredOutput(&dify_invocation.InvokeLLMWithStructuredOutputRequest{InvokeLLMSchema: schema})
+					require.NoError(t, err)
+					defer response.Close()
+					require.True(t, response.Next())
+					chunk, err := response.Read()
+					require.NoError(t, err)
+					require.Equal(t, "ok", chunk.Delta.Message.Content)
+					require.Equal(t, "ok", chunk.StructuredOutput["answer"])
+					require.False(t, response.Next())
+				} else {
+					response, err := invocation.InvokeLLM(&dify_invocation.InvokeLLMRequest{InvokeLLMSchema: schema})
+					require.NoError(t, err)
+					defer response.Close()
+					require.True(t, response.Next())
+					chunk, err := response.Read()
+					require.NoError(t, err)
+					require.Equal(t, "ok", chunk.Delta.Message.Content)
+					require.False(t, response.Next())
+				}
+			})
+		}
+	}
+}
+
+func TestBackwardsToolRetainsLegacyTimeout(t *testing.T) {
+	routine.InitPool(16)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+	invocation, err := NewDifyInvocationDaemon(NewDifyInvocationDaemonPayload{
+		BaseUrl: server.URL, ReadTimeout: 60, ResponseMaxBufferSize: 1024,
+		LLMTotalTimeout: 1000,
+	})
+	require.NoError(t, err)
+	response, err := invocation.InvokeTool(&dify_invocation.InvokeToolRequest{})
+	require.NoError(t, err)
+	defer response.Close()
+	require.True(t, response.Next())
+	_, err = response.Read()
+	require.ErrorContains(t, err, "failed to read system header")
+	var timeout *http_requests.StreamTimeoutError
+	require.NotErrorAs(t, err, &timeout)
+}

--- a/internal/core/dify_invocation/calldify/types.go
+++ b/internal/core/dify_invocation/calldify/types.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 
 	"github.com/langgenius/dify-plugin-daemon/internal/core/dify_invocation"
+	"github.com/langgenius/dify-plugin-daemon/pkg/utils/http_requests"
 )
 
 type RealBackwardsInvocation struct {
@@ -14,6 +15,7 @@ type RealBackwardsInvocation struct {
 	client                *http.Client
 	writeTimeout          int64
 	readTimeout           int64
+	llmStreamTimeouts     http_requests.StreamTimeouts
 	responseMaxBufferSize int64
 	traceCtx              context.Context
 }

--- a/internal/core/plugin_manager/manager.go
+++ b/internal/core/plugin_manager/manager.go
@@ -177,11 +177,14 @@ func (p *PluginManager) Launch(configuration *app.Config) {
 
 	invocation, err := calldify.NewDifyInvocationDaemon(
 		calldify.NewDifyInvocationDaemonPayload{
-			BaseUrl:               configuration.DifyInnerApiURL,
-			CallingKey:            configuration.DifyInnerApiKey,
-			WriteTimeout:          configuration.DifyInvocationWriteTimeout,
-			ReadTimeout:           configuration.DifyInvocationReadTimeout,
-			ResponseMaxBufferSize: configuration.ResponseMaxBufferSize,
+			BaseUrl:                 configuration.DifyInnerApiURL,
+			CallingKey:              configuration.DifyInnerApiKey,
+			WriteTimeout:            configuration.DifyInvocationWriteTimeout,
+			ReadTimeout:             configuration.DifyInvocationReadTimeout,
+			LLMFirstResponseTimeout: configuration.DifyInvocationLLMFirstResponseTimeout,
+			LLMIdleTimeout:          configuration.DifyInvocationLLMIdleTimeout,
+			LLMTotalTimeout:         configuration.DifyInvocationLLMTotalTimeout,
+			ResponseMaxBufferSize:   configuration.ResponseMaxBufferSize,
 		},
 	)
 	if err != nil {

--- a/internal/types/app/config.go
+++ b/internal/types/app/config.go
@@ -277,6 +277,11 @@ type Config struct {
 	DifyInvocationWriteTimeout int64 `envconfig:"DIFY_BACKWARDS_INVOCATION_WRITE_TIMEOUT" default:"5000"`
 	// dify invocation read timeout in milliseconds
 	DifyInvocationReadTimeout int64 `envconfig:"DIFY_BACKWARDS_INVOCATION_READ_TIMEOUT" default:"240000"`
+	// LLM-only budgets in milliseconds. Zero inherits the existing read budget,
+	// except the first-response budget, which inherits the effective LLM total.
+	DifyInvocationLLMFirstResponseTimeout int64 `envconfig:"DIFY_BACKWARDS_INVOCATION_LLM_FIRST_RESPONSE_TIMEOUT" default:"0" validate:"gte=0"`
+	DifyInvocationLLMIdleTimeout          int64 `envconfig:"DIFY_BACKWARDS_INVOCATION_LLM_IDLE_TIMEOUT" default:"0" validate:"gte=0"`
+	DifyInvocationLLMTotalTimeout         int64 `envconfig:"DIFY_BACKWARDS_INVOCATION_LLM_TOTAL_TIMEOUT" default:"0" validate:"gte=0"`
 
 	ResponseMaxBufferSize int64 `envconfig:"RESPONSE_MAX_BUFFER_SIZE" default:"31457280"`
 }

--- a/internal/types/app/config_test.go
+++ b/internal/types/app/config_test.go
@@ -31,6 +31,33 @@ func newValidConfigForValidation() *Config {
 	return config
 }
 
+func TestBackwardsLLMTimeoutConfig(t *testing.T) {
+	t.Setenv("DIFY_BACKWARDS_INVOCATION_LLM_FIRST_RESPONSE_TIMEOUT", "300000")
+	t.Setenv("DIFY_BACKWARDS_INVOCATION_LLM_IDLE_TIMEOUT", "120000")
+	t.Setenv("DIFY_BACKWARDS_INVOCATION_LLM_TOTAL_TIMEOUT", "600000")
+	var parsed Config
+	require.NoError(t, envconfig.Process("", &parsed))
+	require.EqualValues(t, 300000, parsed.DifyInvocationLLMFirstResponseTimeout)
+	require.EqualValues(t, 120000, parsed.DifyInvocationLLMIdleTimeout)
+	require.EqualValues(t, 600000, parsed.DifyInvocationLLMTotalTimeout)
+
+	for _, field := range []string{"first_response", "idle", "total"} {
+		t.Run(field, func(t *testing.T) {
+			config := newValidConfigForValidation()
+			require.NoError(t, config.Validate())
+			switch field {
+			case "first_response":
+				config.DifyInvocationLLMFirstResponseTimeout = -1
+			case "idle":
+				config.DifyInvocationLLMIdleTimeout = -1
+			case "total":
+				config.DifyInvocationLLMTotalTimeout = -1
+			}
+			require.Error(t, config.Validate())
+		})
+	}
+}
+
 func TestValidateLogLevel(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/pkg/utils/http_requests/http_options.go
+++ b/pkg/utils/http_requests/http_options.go
@@ -25,6 +25,7 @@ const (
 	HttpOptionTypeUsingLengthPrefixed              = "usingLengthPrefixed"
 	HttpOptionTypeContext                          = "context"
 	HttpOptionTypeMaxChunkSize                     = "maxChunkSize"
+	HttpOptionTypeStreamTimeouts                   = "streamTimeouts"
 )
 
 // milliseconds
@@ -35,6 +36,11 @@ func HttpWriteTimeout(timeout int64) HttpOptions {
 // milliseconds
 func HttpReadTimeout(timeout int64) HttpOptions {
 	return HttpOptions{HttpOptionTypeReadTimeout, timeout}
+}
+
+// HttpStreamTimeouts replaces the legacy fixed body-read timer for this request only.
+func HttpStreamTimeouts(timeouts StreamTimeouts) HttpOptions {
+	return HttpOptions{HttpOptionTypeStreamTimeouts, timeouts}
 }
 
 func HttpHeader(header map[string]string) HttpOptions {

--- a/pkg/utils/http_requests/http_warpper.go
+++ b/pkg/utils/http_requests/http_warpper.go
@@ -2,6 +2,7 @@ package http_requests
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -76,13 +77,42 @@ func PatchAndParse[T any](client *http.Client, url string, options ...HttpOption
 }
 
 func RequestAndParseStream[T any](client *http.Client, url string, method string, options ...HttpOptions) (*stream.Stream[T], error) {
+	var watchdog *streamWatchdog
+	var limits *StreamTimeouts
+	ctx := context.Background()
+	for _, option := range options {
+		if option.Type == HttpOptionTypeContext {
+			if value, ok := option.Value.(context.Context); ok {
+				ctx = value
+			}
+		} else if option.Type == HttpOptionTypeStreamTimeouts {
+			value := option.Value.(StreamTimeouts)
+			limits = &value
+		}
+	}
+	if limits != nil {
+		var err error
+		watchdog, err = newStreamWatchdog(ctx, *limits)
+		if err != nil {
+			return nil, err
+		}
+		options = append(options, HttpContext(watchdog.ctx))
+	}
 	resp, err := Request(client, url, method, options...)
 	if err != nil {
+		if watchdog != nil {
+			if cause := watchdog.stop(); cause != nil {
+				err = cause
+			}
+		}
 		return nil, err
 	}
 
 	if resp.StatusCode != http.StatusOK {
 		defer resp.Body.Close()
+		if watchdog != nil {
+			defer watchdog.stop()
+		}
 		errorText, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("request failed with status code: %d and respond with: %s", resp.StatusCode, errorText)
 	}
@@ -105,8 +135,19 @@ func RequestAndParseStream[T any](client *http.Client, url string, method string
 			maxChunkSize = option.Value.(int64)
 		}
 	}
-	time.AfterFunc(time.Millisecond*time.Duration(readTimeout), func() {
-		// close the response body if timeout
+	var legacyTimer *time.Timer
+	if watchdog == nil {
+		legacyTimer = time.AfterFunc(time.Millisecond*time.Duration(readTimeout), func() {
+			resp.Body.Close()
+		})
+	}
+	ch.OnClose(func() {
+		if watchdog != nil {
+			watchdog.stop()
+		}
+		if legacyTimer != nil {
+			legacyTimer.Stop()
+		}
 		resp.Body.Close()
 	})
 
@@ -123,6 +164,11 @@ func RequestAndParseStream[T any](client *http.Client, url string, method string
 			}
 		}
 
+		if watchdog != nil {
+			if err := watchdog.progress(true); err != nil {
+				return err
+			}
+		}
 		ch.Write(t)
 		return nil
 	}
@@ -131,13 +177,17 @@ func RequestAndParseStream[T any](client *http.Client, url string, method string
 		routinepkg.RoutineLabelKeyModule: "http_requests",
 		routinepkg.RoutineLabelKeyMethod: "RequestAndParseStream",
 	}, func() {
-		defer resp.Body.Close()
+		defer ch.Close()
+		var reader io.Reader = resp.Body
+		if watchdog != nil {
+			reader = &streamActivityReader{Reader: reader, watchdog: watchdog}
+		}
 
 		var err error
 		if usingLengthPrefixed {
-			err = parser.LengthPrefixedChunking(resp.Body, 0x0f, uint32(maxChunkSize), processData)
+			err = parser.LengthPrefixedChunking(reader, 0x0f, uint32(maxChunkSize), processData)
 		} else {
-			err = parser.LineBasedChunking(resp.Body, int(maxChunkSize), func(data []byte) error {
+			err = parser.LineBasedChunking(reader, int(maxChunkSize), func(data []byte) error {
 				if len(data) == 0 {
 					return nil
 				}
@@ -159,11 +209,14 @@ func RequestAndParseStream[T any](client *http.Client, url string, method string
 			})
 		}
 
+		if watchdog != nil {
+			if cause := watchdog.stop(); cause != nil {
+				err = cause
+			}
+		}
 		if err != nil {
 			ch.WriteError(err)
 		}
-
-		ch.Close()
 	})
 
 	return ch, nil

--- a/pkg/utils/http_requests/stream_timeouts.go
+++ b/pkg/utils/http_requests/stream_timeouts.go
@@ -1,0 +1,159 @@
+package http_requests
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+)
+
+// StreamTimeouts separates transport progress from the total request budget.
+// FirstResponse ends at the first decoded response frame, not the first LLM token.
+type StreamTimeouts struct {
+	FirstResponse time.Duration
+	ReadIdle      time.Duration
+	Total         time.Duration
+}
+
+type StreamTimeoutPhase string
+
+const (
+	StreamTimeoutFirstResponse StreamTimeoutPhase = "first_response"
+	StreamTimeoutReadIdle      StreamTimeoutPhase = "read_idle"
+	StreamTimeoutTotal         StreamTimeoutPhase = "total"
+)
+
+type StreamTimeoutError struct {
+	Phase    StreamTimeoutPhase
+	Duration time.Duration
+}
+
+func (e *StreamTimeoutError) Error() string {
+	return fmt.Sprintf("stream invocation timed out (phase=%s, timeout_ms=%d)", e.Phase, e.Duration.Milliseconds())
+}
+
+func (e *StreamTimeoutError) Unwrap() error { return context.DeadlineExceeded }
+func (e *StreamTimeoutError) Timeout() bool { return true }
+
+type streamWatchdog struct {
+	ctx    context.Context
+	cancel context.CancelCauseFunc
+	limits StreamTimeouts
+	start  time.Time
+
+	mu        sync.Mutex
+	timer     *time.Timer
+	responded bool
+	lastRead  time.Time
+	stopped   bool
+	cause     error
+}
+
+func newStreamWatchdog(parent context.Context, limits StreamTimeouts) (*streamWatchdog, error) {
+	if limits.FirstResponse <= 0 || limits.ReadIdle <= 0 || limits.Total <= 0 {
+		return nil, fmt.Errorf("stream first response, read idle, and total timeouts must be positive")
+	}
+	ctx, cancel := context.WithCancelCause(parent)
+	w := &streamWatchdog{ctx: ctx, cancel: cancel, limits: limits, start: time.Now()}
+	w.mu.Lock()
+	deadline, _ := w.deadlineLocked()
+	w.timer = time.AfterFunc(time.Until(deadline), w.expire)
+	w.mu.Unlock()
+	return w, nil
+}
+
+func (w *streamWatchdog) deadlineLocked() (time.Time, *StreamTimeoutError) {
+	deadline := w.start.Add(w.limits.Total)
+	err := &StreamTimeoutError{Phase: StreamTimeoutTotal, Duration: w.limits.Total}
+	phaseDeadline := w.start.Add(w.limits.FirstResponse)
+	phase, timeout := StreamTimeoutFirstResponse, w.limits.FirstResponse
+	if w.responded {
+		phaseDeadline = w.lastRead.Add(w.limits.ReadIdle)
+		phase, timeout = StreamTimeoutReadIdle, w.limits.ReadIdle
+	}
+	if phaseDeadline.Before(deadline) {
+		return phaseDeadline, &StreamTimeoutError{Phase: phase, Duration: timeout}
+	}
+	return deadline, err
+}
+
+func (w *streamWatchdog) expire() {
+	w.mu.Lock()
+	if w.stopped || w.ctx.Err() != nil {
+		w.mu.Unlock()
+		return
+	}
+	deadline, cause := w.deadlineLocked()
+	if remaining := time.Until(deadline); remaining > 0 {
+		// A previous timer callback may already be running when progress resets it.
+		w.timer.Reset(remaining)
+		w.mu.Unlock()
+		return
+	}
+	w.stopped, w.cause = true, cause
+	w.mu.Unlock()
+	w.cancel(cause)
+}
+
+func (w *streamWatchdog) progress(response bool) error {
+	w.mu.Lock()
+	if w.cause != nil {
+		cause := w.cause
+		w.mu.Unlock()
+		return cause
+	}
+	if w.stopped || w.ctx.Err() != nil {
+		cause := context.Cause(w.ctx)
+		w.mu.Unlock()
+		return cause
+	}
+	now := time.Now()
+	deadline, cause := w.deadlineLocked()
+	if !now.Before(deadline) {
+		w.stopped, w.cause = true, cause
+		w.timer.Stop()
+		w.mu.Unlock()
+		w.cancel(cause)
+		return cause
+	}
+	if response {
+		w.responded = true
+	}
+	if w.responded {
+		w.lastRead = now
+	}
+	deadline, _ = w.deadlineLocked()
+	w.timer.Reset(time.Until(deadline))
+	w.mu.Unlock()
+	return nil
+}
+
+// stop returns the real terminal cause before cancelling for resource cleanup.
+func (w *streamWatchdog) stop() error {
+	w.mu.Lock()
+	w.stopped = true
+	w.timer.Stop()
+	cause := w.cause
+	if cause == nil {
+		cause = context.Cause(w.ctx)
+	}
+	w.mu.Unlock()
+	w.cancel(nil)
+	return cause
+}
+
+type streamActivityReader struct {
+	io.Reader
+	watchdog *streamWatchdog
+}
+
+func (r *streamActivityReader) Read(p []byte) (int, error) {
+	n, err := r.Reader.Read(p)
+	if n > 0 {
+		if cause := r.watchdog.progress(false); cause != nil {
+			return n, cause
+		}
+	}
+	return n, err
+}

--- a/pkg/utils/http_requests/stream_timeouts_test.go
+++ b/pkg/utils/http_requests/stream_timeouts_test.go
@@ -1,0 +1,289 @@
+package http_requests
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/langgenius/dify-plugin-daemon/pkg/utils/routine"
+	"github.com/langgenius/dify-plugin-daemon/pkg/utils/stream"
+	"github.com/stretchr/testify/require"
+)
+
+func timeoutTestFrame(body string) []byte {
+	header := make([]byte, 14)
+	header[0] = 0x0f
+	binary.LittleEndian.PutUint16(header[2:4], 10)
+	binary.LittleEndian.PutUint32(header[4:8], uint32(len(body)))
+	return append(header, body...)
+}
+
+func readTimeoutTestStream(response *stream.Stream[map[string]int]) (int, error) {
+	defer response.Close()
+	count := 0
+	for response.Next() {
+		if _, err := response.Read(); err != nil {
+			return count, err
+		}
+		count++
+	}
+	return count, nil
+}
+
+func requireTimeoutPhase(t *testing.T, err error, phase StreamTimeoutPhase) {
+	t.Helper()
+	var timeout *StreamTimeoutError
+	require.ErrorAs(t, err, &timeout)
+	require.Equal(t, phase, timeout.Phase)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.True(t, timeout.Timeout())
+	require.Contains(t, err.Error(), "phase="+string(phase))
+	require.NotContains(t, err.Error(), "use of closed network connection")
+}
+
+func TestStreamTimeoutsContinuousProgressOutlivesLegacyBudget(t *testing.T) {
+	routine.InitPool(16)
+	for _, framed := range []bool{true, false} {
+		t.Run(fmt.Sprintf("length_prefixed=%v", framed), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				w.(http.Flusher).Flush()
+				for i := 0; i < 12; i++ {
+					select {
+					case <-r.Context().Done():
+						return
+					case <-time.After(20 * time.Millisecond):
+					}
+					body := fmt.Sprintf(`{"chunk":%d}`, i)
+					if framed {
+						_, _ = w.Write(timeoutTestFrame(body))
+					} else {
+						_, _ = fmt.Fprintf(w, "data: %s\n\n", body)
+					}
+					w.(http.Flusher).Flush()
+				}
+			}))
+			defer server.Close()
+			response, err := RequestAndParseStream[map[string]int](server.Client(), server.URL, http.MethodGet,
+				HttpReadTimeout(50), HttpUsingLengthPrefixed(framed),
+				HttpStreamTimeouts(StreamTimeouts{FirstResponse: time.Second, ReadIdle: 150 * time.Millisecond, Total: 2 * time.Second}))
+			require.NoError(t, err)
+			count, err := readTimeoutTestStream(response)
+			require.NoError(t, err)
+			require.Equal(t, 12, count)
+		})
+	}
+}
+
+func TestStreamTimeoutsClassifyAndCancelBlockedRequests(t *testing.T) {
+	routine.InitPool(16)
+	for _, tc := range []struct {
+		name    string
+		headers bool
+		first   bool
+		active  bool
+		limits  StreamTimeouts
+		phase   StreamTimeoutPhase
+	}{
+		{"before_headers", false, false, false, StreamTimeouts{80 * time.Millisecond, time.Second, 2 * time.Second}, StreamTimeoutFirstResponse},
+		{"first_frame", true, false, false, StreamTimeouts{80 * time.Millisecond, time.Second, 2 * time.Second}, StreamTimeoutFirstResponse},
+		{"read_idle", true, true, false, StreamTimeouts{time.Second, 80 * time.Millisecond, 2 * time.Second}, StreamTimeoutReadIdle},
+		{"total_with_progress", true, true, true, StreamTimeouts{time.Second, time.Second, 160 * time.Millisecond}, StreamTimeoutTotal},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cancelled := make(chan struct{})
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				defer close(cancelled)
+				if tc.headers {
+					w.WriteHeader(http.StatusOK)
+					w.(http.Flusher).Flush()
+				}
+				if tc.first {
+					_, _ = w.Write(timeoutTestFrame(`{"chunk":1}`))
+					w.(http.Flusher).Flush()
+				}
+				if tc.active {
+					for {
+						select {
+						case <-r.Context().Done():
+							return
+						case <-time.After(15 * time.Millisecond):
+							_, _ = w.Write(timeoutTestFrame(`{"chunk":2}`))
+							w.(http.Flusher).Flush()
+						}
+					}
+				}
+				<-r.Context().Done()
+			}))
+			defer server.Close()
+			response, err := RequestAndParseStream[map[string]int](server.Client(), server.URL, http.MethodGet,
+				HttpUsingLengthPrefixed(true), HttpStreamTimeouts(tc.limits))
+			if tc.headers {
+				require.NoError(t, err)
+				_, err = readTimeoutTestStream(response)
+			}
+			requireTimeoutPhase(t, err, tc.phase)
+			select {
+			case <-cancelled:
+			case <-time.After(time.Second):
+				t.Fatal("upstream request was not cancelled")
+			}
+		})
+	}
+}
+
+func TestStreamTimeoutsBlockingResponseDoesNotUseIdleBudget(t *testing.T) {
+	routine.InitPool(16)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		select {
+		case <-time.After(180 * time.Millisecond):
+			_, _ = w.Write(timeoutTestFrame(`{"chunk":1}`))
+		case <-r.Context().Done():
+		}
+	}))
+	defer server.Close()
+	response, err := RequestAndParseStream[map[string]int](server.Client(), server.URL, http.MethodPost,
+		HttpUsingLengthPrefixed(true), HttpStreamTimeouts(StreamTimeouts{time.Second, 50 * time.Millisecond, 2 * time.Second}))
+	require.NoError(t, err)
+	count, err := readTimeoutTestStream(response)
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+}
+
+func TestStreamTimeoutsPartialFrameBytesResetIdle(t *testing.T) {
+	routine.InitPool(16)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(timeoutTestFrame(`{"chunk":1}`))
+		w.(http.Flusher).Flush()
+		for _, b := range timeoutTestFrame(`{"chunk":2}`) {
+			select {
+			case <-r.Context().Done():
+				return
+			case <-time.After(10 * time.Millisecond):
+			}
+			_, _ = w.Write([]byte{b})
+			w.(http.Flusher).Flush()
+		}
+	}))
+	defer server.Close()
+	response, err := RequestAndParseStream[map[string]int](server.Client(), server.URL, http.MethodGet,
+		HttpUsingLengthPrefixed(true), HttpStreamTimeouts(StreamTimeouts{time.Second, 100 * time.Millisecond, 2 * time.Second}))
+	require.NoError(t, err)
+	count, err := readTimeoutTestStream(response)
+	require.NoError(t, err)
+	require.Equal(t, 2, count)
+}
+
+func TestStreamTimeoutsParentCancellationAndConsumerClose(t *testing.T) {
+	routine.InitPool(16)
+	for _, consumerClose := range []bool{false, true} {
+		t.Run(fmt.Sprintf("consumer_close=%v", consumerClose), func(t *testing.T) {
+			cancelled := make(chan struct{})
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write(timeoutTestFrame(`{"chunk":1}`))
+				w.(http.Flusher).Flush()
+				<-r.Context().Done()
+				close(cancelled)
+			}))
+			defer server.Close()
+			ctx, cancel := context.WithCancelCause(context.Background())
+			defer cancel(nil)
+			response, err := RequestAndParseStream[map[string]int](server.Client(), server.URL, http.MethodGet,
+				HttpContext(ctx), HttpUsingLengthPrefixed(true), HttpStreamTimeouts(StreamTimeouts{time.Second, time.Second, 2 * time.Second}))
+			require.NoError(t, err)
+			require.True(t, response.Next())
+			_, err = response.Read()
+			require.NoError(t, err)
+			if consumerClose {
+				response.Close()
+			} else {
+				cause := errors.New("workflow cancelled")
+				cancel(cause)
+				_, err = readTimeoutTestStream(response)
+				require.ErrorIs(t, err, cause)
+				var timeout *StreamTimeoutError
+				require.False(t, errors.As(err, &timeout))
+			}
+			select {
+			case <-cancelled:
+			case <-time.After(time.Second):
+				t.Fatal("upstream request was not cancelled")
+			}
+		})
+	}
+}
+
+func TestStreamTimeoutsPreserveUpstreamAndFramingErrors(t *testing.T) {
+	routine.InitPool(16)
+	for _, status := range []int{http.StatusBadRequest, http.StatusOK} {
+		t.Run(fmt.Sprintf("status=%d", status), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(status)
+				_, _ = w.Write([]byte("invalid provider request"))
+			}))
+			defer server.Close()
+			response, err := RequestAndParseStream[map[string]int](server.Client(), server.URL, http.MethodGet,
+				HttpUsingLengthPrefixed(true), HttpStreamTimeouts(StreamTimeouts{time.Second, time.Second, 2 * time.Second}))
+			if status == http.StatusOK {
+				require.NoError(t, err)
+				_, err = readTimeoutTestStream(response)
+				require.Contains(t, err.Error(), "magic number mismatch")
+			} else {
+				require.Contains(t, err.Error(), "status code: 400")
+				require.Contains(t, err.Error(), "invalid provider request")
+			}
+			var timeout *StreamTimeoutError
+			require.False(t, errors.As(err, &timeout))
+		})
+	}
+}
+
+func TestLegacyStreamKeepsFixedBodyDeadline(t *testing.T) {
+	routine.InitPool(16)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+	response, err := RequestAndParseStream[map[string]int](server.Client(), server.URL, http.MethodGet,
+		HttpUsingLengthPrefixed(true), HttpReadTimeout(80))
+	require.NoError(t, err)
+	_, err = readTimeoutTestStream(response)
+	require.Error(t, err)
+	var timeout *StreamTimeoutError
+	require.False(t, errors.As(err, &timeout))
+	require.Contains(t, err.Error(), "failed to read system header")
+}
+
+func TestStreamWatchdogStopAndConcurrentProgress(t *testing.T) {
+	w, err := newStreamWatchdog(context.Background(), StreamTimeouts{time.Second, time.Second, 2 * time.Second})
+	require.NoError(t, err)
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Go(func() {
+			for j := 0; j < 100; j++ {
+				_ = w.progress(true)
+			}
+		})
+	}
+	wg.Wait()
+	require.NoError(t, w.stop())
+	w.expire()
+	require.Nil(t, w.cause)
+	require.ErrorIs(t, context.Cause(w.ctx), context.Canceled)
+	for _, limits := range []StreamTimeouts{{}, {-time.Second, time.Second, time.Second}, {time.Second, 0, time.Second}} {
+		_, err := newStreamWatchdog(context.Background(), limits)
+		require.Error(t, err)
+		require.True(t, strings.Contains(err.Error(), "must be positive"))
+	}
+}


### PR DESCRIPTION
## Description

Fixes the reverse LLM stream cutoff reported in [DIFY-2972](https://linear.app/dify/issue/DIFY-2972/saas-prod-用户反馈-agent-问题).

The reverse HTTP stream previously closed its response body after a fixed read budget (240 seconds by default), even while model data kept arriving. A slow Agent LLM call consequently surfaced a low-level closed-connection/framing error rather than an actionable timeout.

This change adds an opt-in HTTP stream timeout policy and applies it to reverse LLM and structured-output LLM calls:

- Separate first-response, read-idle, and total budgets. The total includes connection/headers/body; idle accounting starts after the first decoded frame and resets on incoming bytes or frames.
- Caller cancellation and earlier parent deadlines remain effective. Completion and consumer closure cancel the reverse request and release timers/body resources.
- Timeout errors carry their phase and duration through the existing reverse-call error message; no SDK wire-protocol change or automatic retry is introduced.
- Other reverse calls keep the legacy fixed read budget. Existing configuration remains bounded: zero for a new setting means inherit, not unlimited.

New settings are `DIFY_BACKWARDS_INVOCATION_LLM_FIRST_RESPONSE_TIMEOUT`, `DIFY_BACKWARDS_INVOCATION_LLM_IDLE_TIMEOUT`, and `DIFY_BACKWARDS_INVOCATION_LLM_TOTAL_TIMEOUT`, all in milliseconds. The total/idle budgets inherit the existing read budget; first-response inherits the effective LLM total.

**Deployment must set the intended larger LLM budget explicitly.** Upgrading the image alone intentionally does not increase the inherited 240-second limit. The operator guide documents example values and enclosing execution/SDK/serverless limits.

This is independent of #814: it governs the reverse HTTP transport, not a caller's first-output-token SLA. A decoded empty model delta can count as a response frame; blocking calls wait under first-response/total limits rather than the post-response idle budget.

## Type of Change

- [x] Bug fix

## Testing

- `go test -race ./pkg/utils/http_requests ./internal/core/dify_invocation/calldify ./internal/types/app -count=1 -timeout=90s`
- Repeated the focused stream/LLM race tests eight times.
- `go vet` passed for the changed HTTP, reverse invocation, configuration, and plugin manager packages.
- PR CI passed: unit tests, database integration, plugin integration, and both local/serverless Docker builds.
- Tests cover continuous progress past the legacy cutoff, delayed headers/first frame, idle and total expiry, blocking and structured responses, partial-frame reads, cancellation/consumer close, configuration inheritance/validation, and preservation of upstream errors and non-LLM timeout behavior.

## Remote Dev Verification

Runtime code was built from `b91401c329787a627a02a78e9557fd21e9078edc` via the existing `build/*` workflow before opening this PR. [Build run](https://github.com/langgenius/dify-plugin-daemon/actions/runs/34560368328) produced local/serverless images for amd64 and arm64.

Dev ran the immutable `b91401c329787a627a02a78e9557fd21e9078edc-local` image with first-response/total budgets of 600000ms and idle of 240000ms. The legacy read budget remained 240000ms; enclosing daemon execution and API/worker read budgets were set to 900 seconds. API/worker image IDs and persistent volumes were unchanged.

- Real console API configuration and execution of the production Agent strategy version (`langgenius/agent:0.0.47`) with GPT-5.5 succeeded.
- A real Agent workflow performed `current_time` through the reverse tool path and then a second LLM call successfully.
- A normal forward LLM workflow succeeded. Temporary workflow apps were cleaned up.
- The Linux HTTP and reverse-invocation regression binaries passed inside the updated dev container, including error/cancellation and blocking/structured-output cases.
- A 260-second framed HTTP producer exercised the real reverse-client code, with a legacy control in parallel. The new policy completed all frames, while the legacy control terminated at 240 seconds. This long-stream test uses a local producer, not a paid model; it is checked in as an opt-in deployment regression.

The final follow-up commit only makes the long test accept a cutoff in any frame-read stage, since the platform may interrupt a prefix, header, or payload. It does not change the deployed runtime code.

Production has not been changed; it requires the new image and coordinated timeout settings. Actual provider-side cancellation still depends on downstream API/runtime/SDK behavior.

From Codex
